### PR TITLE
feat: MCPサーバーに独自ドメインを設定する

### DIFF
--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import os
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Annotated
@@ -19,6 +20,8 @@ from app.models.mcp import (
 from app.models.mcp_token import MCPToken
 
 logger = logging.getLogger(__name__)
+
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "")
 
 router = APIRouter(prefix="/api/mcp", tags=["mcp"])
 
@@ -276,7 +279,7 @@ async def get_mcp_settings(
     logger.info(f"Fetching MCP settings for user {user_id}")
 
     return MCPSettingsResponse(
-        server_url="https://5gcqmlela7.execute-api.ap-northeast-1.amazonaws.com/",
+        server_url=MCP_SERVER_URL,
         token_expires_in=3600,
         token_expiration_options=[30, 60, 90, 365]
     )

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -20,6 +20,7 @@ resource "aws_lambda_function" "api" {
       CORS_ORIGINS           = jsonencode(["https://${local.current_env.domain_name}"])
       ENVIRONMENT            = terraform.workspace
       CACHE_BUCKET_NAME      = aws_s3_bucket.cache.bucket
+      MCP_SERVER_URL         = "https://${local.current_env.mcp_domain_name}"
     }
   }
 

--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -128,3 +128,62 @@ resource "aws_lambda_permission" "mcp_server_api_gateway" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.mcp_server.execution_arn}/*"
 }
+
+# ACM 証明書（API Gateway は ap-northeast-1 に作成）
+resource "aws_acm_certificate" "mcp_server" {
+  domain_name       = local.current_env.mcp_domain_name
+  validation_method = "DNS"
+  lifecycle { create_before_destroy = true }
+}
+
+# ACM DNS 検証レコード
+resource "aws_route53_record" "mcp_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.mcp_server.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.main.zone_id
+}
+
+# ACM 証明書の検証完了を待機
+resource "aws_acm_certificate_validation" "mcp_server" {
+  certificate_arn         = aws_acm_certificate.mcp_server.arn
+  validation_record_fqdns = [for record in aws_route53_record.mcp_cert_validation : record.fqdn]
+}
+
+# API Gateway v2 カスタムドメイン名
+resource "aws_apigatewayv2_domain_name" "mcp_server" {
+  domain_name = local.current_env.mcp_domain_name
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate_validation.mcp_server.certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+# API マッピング（カスタムドメインを API Gateway ステージに紐付け）
+resource "aws_apigatewayv2_api_mapping" "mcp_server" {
+  api_id      = aws_apigatewayv2_api.mcp_server.id
+  domain_name = aws_apigatewayv2_domain_name.mcp_server.id
+  stage       = aws_apigatewayv2_stage.mcp_server.id
+}
+
+# Route53 A レコード（カスタムドメイン → API Gateway ドメイン）
+resource "aws_route53_record" "mcp_server" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = local.current_env.mcp_domain_name
+  type    = "A"
+  alias {
+    name                   = aws_apigatewayv2_domain_name.mcp_server.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.mcp_server.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -55,8 +55,8 @@ output "backend_role_arn" {
 
 # MCP Server API Gateway outputs
 output "mcp_server_api_url" {
-  description = "HTTP API Gateway URL for MCP Server"
-  value       = aws_apigatewayv2_api.mcp_server.api_endpoint
+  description = "MCP Server URL (custom domain)"
+  value       = "https://${local.current_env.mcp_domain_name}"
 }
 
 # Environment info

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,11 +17,13 @@ locals {
       domain_name      = "notes.dev.devtools.site"
       hosted_zone_name = "dev.devtools.site"
       enable_noindex   = true
+      mcp_domain_name  = "mcp.notes.dev.devtools.site"
     }
     prd = {
       domain_name      = "notes.devtools.site"
       hosted_zone_name = "devtools.site"
       enable_noindex   = false
+      mcp_domain_name  = "mcp.notes.devtools.site"
     }
   }
 


### PR DESCRIPTION
## 概要

MCPサーバーの URL を API Gateway デフォルトエンドポイントから独自ドメインに変更します。
これにより URL が安定し、ハードコードを排除して環境変数で動的管理できるようになります。

## 変更内容

- `terraform/variables.tf`: `env_config` に `mcp_domain_name` を追加（dev/prd 各環境）
- `terraform/mcp.tf`: ACM 証明書・DNS 検証・API Gateway カスタムドメイン・Route53 A レコードを追加
- `terraform/outputs.tf`: `mcp_server_api_url` 出力をカスタムドメイン URL に変更
- `terraform/lambda.tf`: バックエンド API Lambda に `MCP_SERVER_URL` 環境変数を追加
- `backend/app/routers/mcp.py`: ハードコードされた URL を `os.environ.get("MCP_SERVER_URL", "")` に変更

**ドメイン:**
- dev: `mcp.notes.dev.devtools.site`
- prd: `mcp.notes.devtools.site`

## テスト方法

- [ ] `make tf-validate ENV=dev` で Terraform 構文確認
- [ ] `make tf-plan ENV=dev` で差分確認
- [ ] `make tf-apply ENV=dev` 適用後、`curl https://mcp.notes.dev.devtools.site/health` で疎通確認
- [ ] フロントエンドの設定ダイアログに正しい MCP URL が表示されることを確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）