### PR TITLE
perf: エディタの大量テキスト入力時の遅延を改善

### DIFF
--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -1,8 +1,9 @@
 
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EditorPanel } from './EditorPanel'
 import type { Note } from '@/types'
+import { calculateHash } from '@/lib/utils'
 
 // Mock react-markdown
 vi.mock('react-markdown', () => ({
@@ -31,6 +32,12 @@ vi.mock('@/hooks/useApi', () => ({
 // Mock Clock to avoid interval timers
 vi.mock('@/components/Clock', () => ({
   Clock: () => <div data-testid="clock">Clock</div>,
+}))
+
+// Mock calculateHash to control timing in debounce tests
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: string[]) => args.filter(Boolean).join(' '),
+  calculateHash: vi.fn().mockResolvedValue('mockhash'),
 }))
 
 describe('EditorPanel', () => {
@@ -109,13 +116,182 @@ describe('EditorPanel', () => {
     // Verify preview toggle works correctly
     // The actual useDeferredValue optimization is tested via code review
     render(<EditorPanel {...defaultProps} />)
-    
+
     // Click preview toggle
     const previewButton = screen.getByTestId('editor-preview-toggle')
     fireEvent.click(previewButton)
-    
+
     // Preview should be visible with the content
     expect(screen.getByTestId('markdown-preview')).toBeInTheDocument()
+  })
+
+  describe('Performance optimizations', () => {
+    const mockCalculateHash = vi.mocked(calculateHash)
+
+    beforeEach(() => {
+      mockCalculateHash.mockClear()
+    })
+
+    describe('Hash calculation debounce (500ms)', () => {
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('does not calculate hash before 500ms have elapsed', () => {
+        vi.useFakeTimers()
+        render(<EditorPanel {...defaultProps} />)
+        mockCalculateHash.mockClear() // clear the initial mount call
+
+        const textarea = screen.getByRole('textbox', { name: /content/i })
+        fireEvent.change(textarea, { target: { value: 'New content' } })
+
+        vi.advanceTimersByTime(499)
+        expect(mockCalculateHash).not.toHaveBeenCalled()
+      })
+
+      it('calculates hash after 500ms have elapsed', () => {
+        vi.useFakeTimers()
+        render(<EditorPanel {...defaultProps} />)
+        mockCalculateHash.mockClear()
+
+        const textarea = screen.getByRole('textbox', { name: /content/i })
+        fireEvent.change(textarea, { target: { value: 'New content' } })
+
+        vi.advanceTimersByTime(500)
+        expect(mockCalculateHash).toHaveBeenCalledWith('New content')
+      })
+
+      it('resets debounce timer on rapid typing (only calculates once)', () => {
+        vi.useFakeTimers()
+        render(<EditorPanel {...defaultProps} />)
+        mockCalculateHash.mockClear()
+
+        const textarea = screen.getByRole('textbox', { name: /content/i })
+
+        // Simulate rapid typing: 3 keystrokes within 500ms
+        fireEvent.change(textarea, { target: { value: 'a' } })
+        vi.advanceTimersByTime(200)
+        fireEvent.change(textarea, { target: { value: 'ab' } })
+        vi.advanceTimersByTime(200)
+        fireEvent.change(textarea, { target: { value: 'abc' } })
+
+        // 400ms elapsed since last change — not yet triggered
+        vi.advanceTimersByTime(499)
+        expect(mockCalculateHash).not.toHaveBeenCalled()
+
+        // 500ms after last change — triggered once with final value
+        vi.advanceTimersByTime(1)
+        expect(mockCalculateHash).toHaveBeenCalledTimes(1)
+        expect(mockCalculateHash).toHaveBeenCalledWith('abc')
+      })
+    })
+
+    describe('Scroll RAF throttling', () => {
+      let originalRaf: typeof requestAnimationFrame
+      let originalCaf: typeof cancelAnimationFrame
+
+      beforeEach(() => {
+        originalRaf = window.requestAnimationFrame
+        originalCaf = window.cancelAnimationFrame
+      })
+
+      afterEach(() => {
+        window.requestAnimationFrame = originalRaf
+        window.cancelAnimationFrame = originalCaf
+      })
+
+      it('throttles rapid editor scroll events to one RAF per frame', () => {
+        const mockRaf = vi.fn().mockReturnValue(1)
+        window.requestAnimationFrame = mockRaf
+
+        render(<EditorPanel {...defaultProps} />)
+
+        // Open preview to enable scroll sync
+        const previewButton = screen.getByTestId('editor-preview-toggle')
+        fireEvent.click(previewButton)
+
+        const textarea = screen.getByRole('textbox', { name: /content/i })
+
+        // Fire multiple scroll events in the same frame
+        fireEvent.scroll(textarea)
+        fireEvent.scroll(textarea)
+        fireEvent.scroll(textarea)
+
+        // Only one RAF should be scheduled (subsequent events are blocked by the ref guard)
+        expect(mockRaf).toHaveBeenCalledTimes(1)
+      })
+
+      it('allows a new RAF after previous frame completes', () => {
+        vi.useFakeTimers()
+
+        let rafCallback: FrameRequestCallback | null = null
+        const mockRaf = vi.fn().mockImplementation((cb: FrameRequestCallback) => {
+          rafCallback = cb
+          return 1
+        })
+        window.requestAnimationFrame = mockRaf
+
+        render(<EditorPanel {...defaultProps} />)
+
+        const previewButton = screen.getByTestId('editor-preview-toggle')
+        fireEvent.click(previewButton)
+
+        const textarea = screen.getByRole('textbox', { name: /content/i })
+
+        // First scroll — schedules RAF
+        fireEvent.scroll(textarea)
+        expect(mockRaf).toHaveBeenCalledTimes(1)
+
+        // Execute the RAF callback — clears scrollRafRef.current and sets isScrollingRef.current = true
+        act(() => {
+          rafCallback?.(0)
+        })
+
+        // Advance past the 50ms timeout inside the RAF callback that resets isScrollingRef
+        vi.advanceTimersByTime(50)
+
+        // Second scroll after frame + cooldown — should schedule a new RAF
+        fireEvent.scroll(textarea)
+        expect(mockRaf).toHaveBeenCalledTimes(2)
+
+        vi.useRealTimers()
+      })
+
+      it('cancels pending RAF on unmount to prevent stale callbacks', () => {
+        const pendingRafId = 42
+        const mockRaf = vi.fn().mockReturnValue(pendingRafId)
+        const mockCaf = vi.fn()
+        window.requestAnimationFrame = mockRaf
+        window.cancelAnimationFrame = mockCaf
+
+        const { unmount } = render(<EditorPanel {...defaultProps} />)
+
+        // Open preview and trigger a scroll to schedule a RAF
+        const previewButton = screen.getByTestId('editor-preview-toggle')
+        fireEvent.click(previewButton)
+
+        const textarea = screen.getByRole('textbox', { name: /content/i })
+        fireEvent.scroll(textarea)
+
+        // RAF is pending (callback not yet executed)
+        expect(mockRaf).toHaveBeenCalled()
+
+        // Unmount should cancel the pending RAF
+        unmount()
+        expect(mockCaf).toHaveBeenCalledWith(pendingRafId)
+      })
+
+      it('does not cancel RAF on unmount when no scroll was pending', () => {
+        const mockCaf = vi.fn()
+        window.cancelAnimationFrame = mockCaf
+
+        const { unmount } = render(<EditorPanel {...defaultProps} />)
+
+        // Unmount without triggering any scroll
+        unmount()
+        expect(mockCaf).not.toHaveBeenCalled()
+      })
+    })
   })
 })
 

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -73,17 +73,28 @@ export function EditorPanel({
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const isScrollingRef = useRef(false);
+  const contentLinesRef = useRef(1);
+  const scrollRafRef = useRef<number | null>(null);
+
+  // Cache line count whenever content changes (cheap ref update, avoids O(n) split in scroll handlers)
+  useEffect(() => {
+    let count = 1;
+    for (let i = 0; i < content.length; i++) {
+      if (content.charCodeAt(i) === 10) count++;
+    }
+    contentLinesRef.current = count;
+  }, [content]);
 
   // Hash-based Verification Logic
   const [currentHash, setCurrentHash] = useState("");
 
-  // Calculate hash of current content whenever it changes (debounced slightly to avoid freezing typing)
+  // Calculate hash of current content whenever it changes (debounced to avoid blocking typing)
   useEffect(() => {
     const calculate = async () => {
       const hash = await calculateHash(content);
       setCurrentHash(hash);
     };
-    const timer = setTimeout(calculate, 200);
+    const timer = setTimeout(calculate, 500);
     return () => clearTimeout(timer);
   }, [content]);
 
@@ -113,6 +124,15 @@ export function EditorPanel({
   useEffect(() => {
     noteIdRef.current = note?.id;
   }, [note?.id]);
+
+  // Clean up pending RAF on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollRafRef.current !== null) {
+        cancelAnimationFrame(scrollRafRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -428,77 +448,82 @@ export function EditorPanel({
 
 
 
-  // Scroll Sync Handlers
-  // Scroll Sync Handlers
+  // Scroll Sync Handlers (throttled with requestAnimationFrame, no content dependency)
   const handleEditorScroll = useCallback(() => {
     if (isScrollingRef.current || !isPreviewOpen || !textareaRef.current || !previewContainerRef.current) return;
+    if (scrollRafRef.current !== null) return;
 
-    isScrollingRef.current = true;
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      if (!textareaRef.current || !previewContainerRef.current) return;
 
-    const editor = textareaRef.current;
-    const preview = previewContainerRef.current;
+      isScrollingRef.current = true;
 
-    // Calculate target line number based on scroll percentage of source
-    // This assumes roughly uniform line height in the source which is true for monospaced textarea
-    const contentLines = content.split("\n").length;
-    const scrollPercentage = editor.scrollTop / (editor.scrollHeight - editor.clientHeight || 1);
-    const targetLine = Math.floor(contentLines * scrollPercentage);
+      const editor = textareaRef.current;
+      const preview = previewContainerRef.current;
 
-    // Find the element in preview that corresponds to this line or the next closest one
-    const elements = Array.from(preview.querySelectorAll("[data-source-line]")) as HTMLElement[];
-    let targetElement = null;
+      const contentLines = contentLinesRef.current;
+      const scrollPercentage = editor.scrollTop / (editor.scrollHeight - editor.clientHeight || 1);
+      const targetLine = Math.floor(contentLines * scrollPercentage);
 
-    for (const el of elements) {
-      const line = parseInt(el.getAttribute("data-source-line") || "0", 10);
-      if (line >= targetLine) {
-        targetElement = el;
-        break;
+      const elements = Array.from(preview.querySelectorAll("[data-source-line]")) as HTMLElement[];
+      let targetElement = null;
+
+      for (const el of elements) {
+        const line = parseInt(el.getAttribute("data-source-line") || "0", 10);
+        if (line >= targetLine) {
+          targetElement = el;
+          break;
+        }
       }
-    }
 
-    if (targetElement) {
-      // Adjust for the element's position relative to the container
-      preview.scrollTop = targetElement.offsetTop - preview.offsetTop;
-    } else if (scrollPercentage > 0.99) {
-      // If roughly at the end, sync to bottom
-      preview.scrollTop = preview.scrollHeight;
-    }
+      if (targetElement) {
+        preview.scrollTop = targetElement.offsetTop - preview.offsetTop;
+      } else if (scrollPercentage > 0.99) {
+        preview.scrollTop = preview.scrollHeight;
+      }
 
-    setTimeout(() => {
-      isScrollingRef.current = false;
-    }, 50);
-  }, [content, isPreviewOpen]);
+      setTimeout(() => {
+        isScrollingRef.current = false;
+      }, 50);
+    });
+  }, [isPreviewOpen]);
 
   const handlePreviewScroll = useCallback(() => {
     if (isScrollingRef.current || !textareaRef.current || !previewContainerRef.current) return;
+    if (scrollRafRef.current !== null) return;
 
-    isScrollingRef.current = true;
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      if (!textareaRef.current || !previewContainerRef.current) return;
 
-    const editor = textareaRef.current;
-    const preview = previewContainerRef.current;
-    const contentLines = content.split("\n").length;
+      isScrollingRef.current = true;
 
-    // Find the first visible element in the preview
-    const elements = Array.from(preview.querySelectorAll("[data-source-line]")) as HTMLElement[];
-    let visibleElement: HTMLElement | null = null;
+      const editor = textareaRef.current;
+      const preview = previewContainerRef.current;
+      const contentLines = contentLinesRef.current;
 
-    for (const el of elements) {
-      if (el.offsetTop - preview.offsetTop >= preview.scrollTop) {
-        visibleElement = el;
-        break;
+      const elements = Array.from(preview.querySelectorAll("[data-source-line]")) as HTMLElement[];
+      let visibleElement: HTMLElement | null = null;
+
+      for (const el of elements) {
+        if (el.offsetTop - preview.offsetTop >= preview.scrollTop) {
+          visibleElement = el;
+          break;
+        }
       }
-    }
 
-    if (visibleElement) {
-      const line = parseInt(visibleElement.getAttribute("data-source-line") || "0", 10);
-      const targetScrollTop = (line / contentLines) * (editor.scrollHeight - editor.clientHeight);
-      editor.scrollTop = targetScrollTop;
-    }
+      if (visibleElement) {
+        const line = parseInt(visibleElement.getAttribute("data-source-line") || "0", 10);
+        const targetScrollTop = (line / contentLines) * (editor.scrollHeight - editor.clientHeight);
+        editor.scrollTop = targetScrollTop;
+      }
 
-    setTimeout(() => {
-      isScrollingRef.current = false;
-    }, 50);
-  }, [content]);
+      setTimeout(() => {
+        isScrollingRef.current = false;
+      }, 50);
+    });
+  }, []);
 
   // JSON export handlers
   const downloadFile = (content: string, filename: string, mimeType: string) => {


### PR DESCRIPTION
## 概要

1万字付近でのタイピング・IME変換がもたつく問題を修正した。
キーストロークごとに発生していた連鎖的な重い処理を最適化し、スクロール同期とハッシュ計算のコストを削減する。

## 変更内容

- **`EditorPanel.tsx`**: スクロール同期ハンドラのパフォーマンス改善
  - `contentLinesRef` を追加し、行数を `charCodeAt` ループでキャッシュ（`content.split('\n')` による O(n) 処理とキーストロークごとの関数再生成を廃止）
  - スクロールイベントを `requestAnimationFrame` でスロットリング（同一フレーム内の重複イベントを `scrollRafRef` ガードで排除）
  - アンマウント時に `cancelAnimationFrame` で未実行の RAF をクリーンアップ
  - ハッシュ計算のデバウンスを 200ms → 500ms に延長（高速タイピング中の SHA-256 計算頻度を削減）

- **`EditorPanel.test.tsx`**: 上記の最適化を検証するユニットテストを追加
  - ハッシュ計算デバウンスのタイミング検証（499ms 未達で未実行 / 500ms で実行 / 連続タイピングでリセット）
  - RAF スロットリング検証（同一フレーム内は 1 回のみ / フレーム完了後は再スケジュール可能）
  - アンマウント時の RAF キャンセル検証

## テスト方法

- [ ] 1万字以上のテキストをエディタに貼り付け、追加入力・IME変換がスムーズか確認
- [ ] プレビュー表示中にスクロールしてエディタ↔プレビュー同期が正常か確認
- [ ] `make test-frontend` を実行して全 51 テストが通ることを確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）—— 変更なし