### PR TITLE
fix: スクロールバーをテーマカラーに合わせる

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -118,6 +118,24 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-width: thin;
+    scrollbar-color: var(--muted-foreground) transparent;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: var(--muted-foreground);
+    border-radius: 4px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--foreground);
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
## 概要

ダークモード時にエディタのスクロールバーが白く表示される問題を修正。CSS 変数を使ったスクロールバースタイルを追加し、ライト/ダーク両モードで自動的にテーマに馴染む色になるようにした。

## 変更内容

- `frontend/src/app/globals.css` にスクロールバースタイルを追加
  - `scrollbar-width: thin` / `scrollbar-color` で Firefox 対応
  - `::-webkit-scrollbar*` 擬似要素で Chrome/Safari 対応
  - サム色に `var(--muted-foreground)`、ホバー時に `var(--foreground)` を使用し、テーマ変数に連動

## テスト方法

- [ ] ダークモードでエディタを開き、スクロールバーが暗いグレー系で表示されることを確認
- [ ] ライトモードでも同様にスクロールバーが適切な色で表示されることを確認
- [ ] プレビューペインのスクロールバーも同様に表示されることを確認

## チェックリスト

- [ ] テストを追加・更新した
- [x] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）