### PR TITLE
refactor: フルスクリーンをネイティブFullscreen APIに移行

### DIFF
--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -127,107 +127,92 @@ describe('EditorPanel', () => {
   })
 
   describe('Fullscreen mode', () => {
+    let requestFullscreenMock: ReturnType<typeof vi.fn>
+    let exitFullscreenMock: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      requestFullscreenMock = vi.fn().mockImplementation(() => {
+        Object.defineProperty(document, 'fullscreenElement', { value: document.body, configurable: true })
+        document.dispatchEvent(new Event('fullscreenchange'))
+        return Promise.resolve()
+      })
+      exitFullscreenMock = vi.fn().mockImplementation(() => {
+        Object.defineProperty(document, 'fullscreenElement', { value: null, configurable: true })
+        document.dispatchEvent(new Event('fullscreenchange'))
+        return Promise.resolve()
+      })
+      HTMLElement.prototype.requestFullscreen = requestFullscreenMock
+      document.exitFullscreen = exitFullscreenMock
+      Object.defineProperty(document, 'fullscreenElement', { value: null, configurable: true })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(document, 'fullscreenElement', { value: null, configurable: true })
+    })
+
     it('renders fullscreen toggle button', () => {
       render(<EditorPanel {...defaultProps} />)
       expect(screen.getByTestId('editor-fullscreen-button')).toBeInTheDocument()
     })
 
-    it('enters fullscreen when toggle button is clicked', () => {
+    it('calls requestFullscreen when toggle button is clicked', async () => {
       render(<EditorPanel {...defaultProps} />)
       const button = screen.getByTestId('editor-fullscreen-button')
-      fireEvent.click(button)
-      // In fullscreen mode, the outer container has fixed positioning
-      const container = button.closest('[class*="fixed"]')
-      expect(container).toBeInTheDocument()
+      await act(async () => { fireEvent.click(button) })
+      expect(requestFullscreenMock).toHaveBeenCalled()
     })
 
-    it('exits fullscreen when toggle button is clicked again', () => {
+    it('calls exitFullscreen when button is clicked while in fullscreen', async () => {
       render(<EditorPanel {...defaultProps} />)
       const button = screen.getByTestId('editor-fullscreen-button')
 
       // Enter fullscreen
-      fireEvent.click(button)
-      expect(button.closest('[class*="fixed"]')).toBeInTheDocument()
+      await act(async () => { fireEvent.click(button) })
+      expect(requestFullscreenMock).toHaveBeenCalled()
 
       // Exit fullscreen
-      fireEvent.click(button)
-      expect(button.closest('[class*="fixed"]')).not.toBeInTheDocument()
+      await act(async () => { fireEvent.click(button) })
+      expect(exitFullscreenMock).toHaveBeenCalled()
     })
 
-    it('shows exit fullscreen aria-label when in fullscreen', () => {
+    it('shows exit fullscreen aria-label when in fullscreen', async () => {
       render(<EditorPanel {...defaultProps} />)
       const button = screen.getByTestId('editor-fullscreen-button')
       expect(button).toHaveAttribute('aria-label', 'editor.fullscreen')
 
-      fireEvent.click(button)
+      await act(async () => { fireEvent.click(button) })
       expect(button).toHaveAttribute('aria-label', 'editor.exitFullscreen')
     })
 
-    it('exits fullscreen when Escape key is pressed', () => {
+    it('syncs state when fullscreenchange event fires (e.g. ESC key)', async () => {
       render(<EditorPanel {...defaultProps} />)
       const button = screen.getByTestId('editor-fullscreen-button')
 
-      // Enter fullscreen first
-      fireEvent.click(button)
-      expect(button.closest('[class*="fixed"]')).toBeInTheDocument()
+      // Enter fullscreen
+      await act(async () => { fireEvent.click(button) })
+      expect(button).toHaveAttribute('aria-label', 'editor.exitFullscreen')
 
-      // Press Escape to exit
-      fireEvent.keyDown(document, { key: 'Escape' })
-      expect(button.closest('[class*="fixed"]')).not.toBeInTheDocument()
+      // Simulate browser ESC by dispatching fullscreenchange with no fullscreenElement
+      await act(async () => {
+        Object.defineProperty(document, 'fullscreenElement', { value: null, configurable: true })
+        document.dispatchEvent(new Event('fullscreenchange'))
+      })
+      expect(button).toHaveAttribute('aria-label', 'editor.fullscreen')
     })
 
-    it('Escape key has no effect when not in fullscreen', () => {
-      render(<EditorPanel {...defaultProps} />)
-      const button = screen.getByTestId('editor-fullscreen-button')
-
-      // Ensure we are not in fullscreen
-      expect(button.closest('[class*="fixed"]')).not.toBeInTheDocument()
-
-      // Pressing Escape should not change anything
-      fireEvent.keyDown(document, { key: 'Escape' })
-      expect(button.closest('[class*="fixed"]')).not.toBeInTheDocument()
-    })
-
-    it('toggles fullscreen with Ctrl+Shift+F', () => {
+    it('toggles fullscreen with Ctrl+Shift+F', async () => {
       render(<EditorPanel {...defaultProps} />)
       const button = screen.getByTestId('editor-fullscreen-button')
 
       // Toggle on
-      fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true })
-      expect(button.closest('[class*="fixed"]')).toBeInTheDocument()
+      await act(async () => { fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true }) })
+      expect(requestFullscreenMock).toHaveBeenCalled()
+      expect(button).toHaveAttribute('aria-label', 'editor.exitFullscreen')
 
       // Toggle off
-      fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true })
-      expect(button.closest('[class*="fixed"]')).not.toBeInTheDocument()
-    })
-
-    it('sets body overflow to hidden when fullscreen is active', () => {
-      render(<EditorPanel {...defaultProps} />)
-      expect(document.body.style.overflow).toBe('')
-
-      fireEvent.click(screen.getByTestId('editor-fullscreen-button'))
-      expect(document.body.style.overflow).toBe('hidden')
-    })
-
-    it('restores body overflow when exiting fullscreen', () => {
-      render(<EditorPanel {...defaultProps} />)
-      const button = screen.getByTestId('editor-fullscreen-button')
-
-      fireEvent.click(button)
-      expect(document.body.style.overflow).toBe('hidden')
-
-      fireEvent.click(button)
-      expect(document.body.style.overflow).toBe('')
-    })
-
-    it('restores body overflow on unmount', () => {
-      const { unmount } = render(<EditorPanel {...defaultProps} />)
-
-      fireEvent.click(screen.getByTestId('editor-fullscreen-button'))
-      expect(document.body.style.overflow).toBe('hidden')
-
-      unmount()
-      expect(document.body.style.overflow).toBe('')
+      await act(async () => { fireEvent.keyDown(document, { key: 'F', ctrlKey: true, shiftKey: true }) })
+      expect(exitFullscreenMock).toHaveBeenCalled()
+      expect(button).toHaveAttribute('aria-label', 'editor.fullscreen')
     })
   })
 

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -9,7 +9,7 @@ import type { Note, Folder, TokenUsageRead } from "@/types";
 import { useApi, useTranslation } from "@/hooks";
 import { TokenUsageIndicator } from "@/components/TokenUsageIndicator";
 import { SparklesIcon, TrashIcon, MessageSquareIcon, FolderIcon, ChevronDownIcon, Loader2Icon, CheckIcon, DownloadIcon, EyeIcon, EyeOffIcon, HashIcon, Share2Icon, Maximize2Icon, Minimize2Icon } from "lucide-react";
-import { useEffect, useState, useRef, useCallback, KeyboardEvent, useDeferredValue, useLayoutEffect } from "react";
+import { useEffect, useState, useRef, useCallback, KeyboardEvent, useDeferredValue } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { SyncStatus } from "@/hooks/useNotes";
@@ -63,6 +63,7 @@ export function EditorPanel({
   const [isExportDropdownOpen, setIsExportDropdownOpen] = useState(false);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const fullscreenContainerRef = useRef<HTMLDivElement>(null);
 
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [imageUploadError, setImageUploadError] = useState<string | null>(null);
@@ -457,31 +458,35 @@ export function EditorPanel({
 
 
 
-  // Fullscreen keyboard shortcuts
+  // Fullscreen API toggle
+  const toggleFullscreen = useCallback(async () => {
+    if (!document.fullscreenElement) {
+      await fullscreenContainerRef.current?.requestFullscreen();
+    } else {
+      await document.exitFullscreen();
+    }
+  }, []);
+
+  // Sync React state with Fullscreen API (handles ESC key from browser)
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  // Fullscreen keyboard shortcut (Ctrl/Cmd+Shift+F)
   useEffect(() => {
     const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
-      if (e.key === "Escape" && isFullscreen) {
-        setIsFullscreen(false);
-      } else if (e.key === "F" && (e.ctrlKey || e.metaKey) && e.shiftKey) {
+      if (e.key === "F" && (e.ctrlKey || e.metaKey) && e.shiftKey) {
         e.preventDefault();
-        setIsFullscreen((prev) => !prev);
+        toggleFullscreen();
       }
     };
     document.addEventListener("keydown", handleGlobalKeyDown);
     return () => document.removeEventListener("keydown", handleGlobalKeyDown);
-  }, [isFullscreen]);
-
-  // Prevent body scroll when fullscreen
-  useLayoutEffect(() => {
-    if (isFullscreen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isFullscreen]);
+  }, [toggleFullscreen]);
 
   // Scroll Sync Handlers (throttled with requestAnimationFrame, no content dependency)
   const handleEditorScroll = useCallback(() => {
@@ -651,7 +656,7 @@ export function EditorPanel({
   // --- SAVE STATUS LOGIC END ---
 
   return (
-    <div className={isFullscreen ? "fixed inset-0 z-50 flex flex-col bg-background overflow-hidden" : "flex-1 flex flex-col overflow-hidden"}>
+    <div ref={fullscreenContainerRef} className={isFullscreen ? "flex flex-col bg-background overflow-hidden w-full h-full" : "flex-1 flex flex-col overflow-hidden"}>
       {/* Toolbar */}
       <div className="flex items-center justify-between p-4 md:p-4 p-2 border-b border-border/50">
         <div className="flex items-center gap-1 md:gap-2 flex-wrap">
@@ -807,7 +812,7 @@ export function EditorPanel({
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => setIsFullscreen(!isFullscreen)}
+            onClick={toggleFullscreen}
             aria-label={isFullscreen ? t("editor.exitFullscreen") : t("editor.fullscreen")}
             data-testid="editor-fullscreen-button"
             title={isFullscreen ? t("editor.exitFullscreen") : t("editor.fullscreen")}


### PR DESCRIPTION
## 概要

CSS固定配置（`fixed inset-0`）によるカスタムフルスクリーン実装を、ブラウザ標準の Fullscreen API（`requestFullscreen` / `exitFullscreen`）に移行しました。これにより、ブラウザネイティブのフルスクリーン動作（ESCキーによる終了など）と正しく連携できるようになります。

## 変更内容

- `EditorPanel.tsx`: `toggleFullscreen` を `useCallback` でラップし、Fullscreen API を呼び出すよう変更
- `EditorPanel.tsx`: `fullscreenchange` イベントリスナーで React 状態をブラウザの状態に同期（ESCキー対応）
- `EditorPanel.tsx`: `useLayoutEffect` による `body.style.overflow` 管理を削除（Fullscreen APIが自動処理）
- `EditorPanel.tsx`: コンテナに `fullscreenContainerRef` を付与し `requestFullscreen` の対象要素として設定
- `EditorPanel.tsx`: `useLayoutEffect` インポートを削除
- `EditorPanel.test.tsx`: テストを Fullscreen API モック（`requestFullscreen`/`exitFullscreen`/`fullscreenchange`）を使う形に全面更新

## テスト方法

- [ ] フルスクリーンボタンをクリックしてフルスクリーンに入れること
- [ ] フルスクリーン中にボタンを再クリックで解除できること
- [ ] フルスクリーン中に ESC キーで解除できること（ブラウザネイティブ）
- [ ] Ctrl+Shift+F でフルスクリーントグルが動作すること
- [ ] ユニットテスト全通過：`npm run test -- --run`

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）