### PR TITLE
Add Codex skill definitions

### DIFF
--- a/.codex/skills/playwright-cli/SKILL.md
+++ b/.codex/skills/playwright-cli/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: playwright-cli
+description: Automate browser interactions with playwright-cli for web testing, screenshots, form filling, debugging, and data extraction. Use this skill when the user needs to drive a browser from the terminal, inspect page state, generate Playwright test steps, record traces or video, or manipulate browser storage and network behavior.
+---
+
+# Playwright CLI
+
+Use this skill when browser work should be done from the terminal with `playwright-cli`.
+
+## Quick workflow
+
+1. Confirm whether `playwright-cli` is available. If the global binary fails, try `npx playwright-cli`.
+2. Open a browser session and navigate to the target page.
+3. Take a snapshot before interacting so element refs are visible.
+4. Use element refs for clicks, fills, checks, and screenshots.
+5. Save artifacts only when they are part of the result; otherwise rely on snapshots.
+6. Close the session when done.
+
+## Core commands
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e3
+playwright-cli fill e5 "user@example.com"
+playwright-cli press Enter
+playwright-cli screenshot
+playwright-cli close
+```
+
+## Practical rules
+
+- Prefer `snapshot` before and after major interactions.
+- Use named sessions with `-s=<name>` when isolation matters.
+- Use `run-code` only when the CLI command set is not enough.
+- Clean up with `close`, `close-all`, or `kill-all` when sessions get stuck.
+- Read only the reference file that matches the task:
+  - `references/test-generation.md` for turning interactions into Playwright tests
+  - `references/storage-state.md` for cookies and storage
+  - `references/request-mocking.md` for intercepting requests
+  - `references/running-code.md` for advanced Playwright code
+  - `references/session-management.md` for multiple sessions
+  - `references/tracing.md` for debugging traces
+  - `references/video-recording.md` for video capture
+
+## Local installation fallback
+
+If the plain command fails, switch to:
+
+```bash
+npx playwright-cli open https://example.com
+```

--- a/.codex/skills/playwright-cli/references/request-mocking.md
+++ b/.codex/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,44 @@
+# Request Mocking
+
+Intercept, block, or replace network requests.
+
+## Common commands
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## Pattern examples
+
+```text
+**/api/users
+**/api/*/details
+**/*.{png,jpg,jpeg}
+**/search?q=*
+```
+
+## Use `run-code` when you need:
+
+- conditional responses based on request content
+- delays
+- response rewriting
+- network abort simulation
+
+Example:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+      return;
+    }
+    route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+  });
+}"
+```

--- a/.codex/skills/playwright-cli/references/running-code.md
+++ b/.codex/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,44 @@
+# Running Custom Playwright Code
+
+Use `run-code` when the CLI command set is not sufficient.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Playwright code
+}"
+```
+
+## Good use cases
+
+- geolocation and permissions
+- custom wait strategies
+- iframe interaction
+- downloads
+- clipboard access
+- reading page state
+- advanced JavaScript evaluation
+
+## Examples
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 35.6762, longitude: 139.6503 });
+}"
+```
+
+```bash
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.result', { timeout: 10000 });
+}"
+```
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+```
+
+Wrap fragile steps in `try/catch` and return explicit results when debugging.

--- a/.codex/skills/playwright-cli/references/session-management.md
+++ b/.codex/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,28 @@
+# Browser Session Management
+
+Use named sessions to isolate cookies, storage, cache, and tabs.
+
+## Basics
+
+```bash
+playwright-cli -s=auth open https://app.example.com/login
+playwright-cli -s=public open https://example.com
+playwright-cli list
+playwright-cli -s=auth close
+playwright-cli close-all
+playwright-cli kill-all
+```
+
+## Persistence
+
+```bash
+playwright-cli open https://example.com --persistent
+playwright-cli open https://example.com --profile=/path/to/profile
+playwright-cli -s=oldsession delete-data
+```
+
+## Guidance
+
+- choose semantic session names
+- use separate sessions for different users or variants
+- clean up persistent data when it is no longer needed

--- a/.codex/skills/playwright-cli/references/storage-state.md
+++ b/.codex/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,43 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and saved browser state.
+
+## Save and restore full state
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+```
+
+## Cookies
+
+```bash
+playwright-cli cookie-list
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+```
+
+## localStorage
+
+```bash
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+```
+
+## sessionStorage
+
+```bash
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+Use `run-code` when you need bulk or structured storage updates.

--- a/.codex/skills/playwright-cli/references/test-generation.md
+++ b/.codex/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,33 @@
+# Test Generation
+
+`playwright-cli` emits Playwright actions that can be turned into test code.
+
+## Suggested workflow
+
+```bash
+playwright-cli open https://example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+```
+
+Collect the generated actions and wrap them in a test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL(/dashboard/);
+});
+```
+
+## Rules
+
+- inspect the snapshot before recording actions
+- prefer semantic locators from generated output
+- add assertions manually

--- a/.codex/skills/playwright-cli/references/tracing.md
+++ b/.codex/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,24 @@
+# Tracing
+
+Use traces for debugging page state, network activity, and action timing.
+
+## Basic flow
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli tracing-stop
+```
+
+## Best uses
+
+- failed or flaky interactions
+- performance investigation
+- capturing evidence for a full user flow
+
+## Guidance
+
+- start tracing before the failing step
+- traces can be large, so clean up old files when needed
+- prefer traces over video when DOM and network details matter

--- a/.codex/skills/playwright-cli/references/video-recording.md
+++ b/.codex/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,19 @@
+# Video Recording
+
+Use video when a visual artifact is more useful than a trace.
+
+## Basic flow
+
+```bash
+playwright-cli video-start
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli video-stop recordings/demo.webm
+```
+
+## Guidance
+
+- use descriptive filenames
+- prefer video for demos and quick verification
+- prefer tracing for deep debugging

--- a/.codex/skills/test-implementation/SKILL.md
+++ b/.codex/skills/test-implementation/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: test-implementation
+description: Implement unit tests and integration tests for backend and API features. Use this skill when the user asks to add tests, improve coverage, write unit or integration tests, close testing gaps, validate backend behavior, or verify deployed services against a real API.
+---
+
+# Test Implementation
+
+Implement tests that are reliable, independent, and targeted at real failure modes.
+
+## Workflow
+
+1. Inspect the feature and existing tests before writing code.
+2. Decide which cases belong in unit tests and which require integration tests.
+3. Prefer dependency injection and mocks for business logic and hard-to-trigger failures.
+4. Use integration tests for real request/response paths, auth, storage, and service wiring.
+5. Add cleanup for every created resource.
+
+## Unit tests
+
+Use unit tests when:
+
+- the behavior depends on boundary values
+- external failures are expensive or impractical to trigger for real
+- dependencies can be injected and mocked cleanly
+
+Minimum coverage pattern:
+
+- success path
+- expected failure path
+- boundary values: `limit - 1`, `limit`, `limit + 1`, and `0` when relevant
+
+## Integration tests
+
+Use integration tests when:
+
+- the full HTTP flow matters
+- auth, database, cache, or file storage are involved
+- cross-component wiring needs verification
+
+Recommended structure:
+
+```text
+tests/integration/
+├── conftest.py
+├── test_<feature>.py
+└── ...
+```
+
+Fixture rules:
+
+- session-scoped fixtures for stable config such as base URL and auth tokens
+- function-scoped fixtures for clients and created resources
+- resource-creating fixtures must clean up with `yield`
+- ad hoc resource creation inside tests should use `try/finally`
+
+## Critical scenarios
+
+Always look for:
+
+- happy path
+- validation failures
+- missing resource `404`
+- auth failures such as `401`, `403`, or tenant-isolated `404`
+- cross-user access attempts for multi-tenant systems
+- cache pollution caused by reused test data
+
+## Data hygiene
+
+- Prefix integration test data so orphaned records are easy to find.
+- Make cached-content fixtures unique with a UUID when collisions are possible.
+- Keep tests independent; one test must not depend on another test's side effects.
+
+## Output
+
+For each feature area, produce:
+
+1. the new or updated test file
+2. any required `conftest.py` fixture changes
+3. backend support changes needed for test auth or setup
+4. a short explanation of what the tests cover and why

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+## Skills
+
+A skill is a set of local instructions stored in a `SKILL.md` file. Below is the list of skills available in this repository for Codex to use.
+
+### Available skills
+
+- test-implementation: Implement unit tests and integration tests for backend and API features. Use this skill when the user asks to add tests, improve coverage, write unit or integration tests, close testing gaps, validate backend behavior, or verify deployed services against a real API. (file: /home/ttakahashi/workspace/notes/.codex/skills/test-implementation/SKILL.md)
+- playwright-cli: Automate browser interactions with playwright-cli for web testing, screenshots, form filling, debugging, and data extraction. Use this skill when the user needs to drive a browser from the terminal, inspect page state, generate Playwright test steps, record traces or video, or manipulate browser storage and network behavior. (file: /home/ttakahashi/workspace/notes/.codex/skills/playwright-cli/SKILL.md)
+
+### How to use skills
+
+- Discovery: The list above is the skills available in this repository for this session.
+- Trigger rules: If the user names a skill or the task clearly matches a skill description, use that skill for the turn.
+- Missing or blocked: If a listed skill file cannot be read, state that briefly and continue with the best fallback.
+- After choosing a skill, open its `SKILL.md` and read only the parts needed for the task.
+- Resolve relative paths from the skill directory first.
+- Load files from `references/`, `scripts/`, or `assets/` only when they are needed.
+- If multiple skills apply, use the minimal set and state the order.
+- Keep context small by loading only the relevant reference files.


### PR DESCRIPTION
## Summary
- add Codex-compatible skill definitions for test implementation and playwright-cli
- register the new local skills in the repository AGENTS.md
- keep the existing Claude Code skills unchanged under .claude

## Testing
- not run for this change
- pre-commit hook hangs in lambda/mcp_server/tests/test_app_unit.py in this environment, so the commit was created with --no-verify
