### PR TITLE
fix: stabilize mobile Playwright E2E cases

### DIFF
--- a/frontend/tests/share.spec.ts
+++ b/frontend/tests/share.spec.ts
@@ -35,16 +35,27 @@ test.describe('Sharing Functionality', () => {
 
     const noteList = isMobile ? page.getByTestId('mobile-layout-notes') : page.getByTestId('desktop-layout');
     await noteList.getByTestId('note-list-add-note-button').click();
-    await createPromise;
+    const createdNote = await createPromise.then(resp => resp.json() as Promise<{ id: string }>);
     console.log('[Share E2E] Note created');
 
-    // Wait for editor
-    await page.waitForTimeout(500);
-
-    // Enter note content
+    // Wait for editor. On mobile, note creation can leave the view on the list,
+    // so open the created note explicitly if the editor is not visible yet.
     const layout = isMobile ? page.getByTestId('mobile-layout-editor') : page.getByTestId('desktop-layout');
-    const titleInput = layout.getByLabel(/title/i);
-    const contentTextarea = layout.getByRole('textbox', { name: /content/i });
+    const titleInput = layout.getByTestId('editor-title-input');
+    const contentTextarea = layout.getByTestId('editor-content-input');
+
+    if (isMobile) {
+      try {
+        await expect(titleInput).toBeVisible({ timeout: 5000 });
+      } catch {
+        const createdNoteItem = noteList.getByTestId(`note-list-item-${createdNote.id}`);
+        await expect(createdNoteItem).toBeVisible({ timeout: 15000 });
+        await createdNoteItem.click();
+        await expect(titleInput).toBeVisible({ timeout: 20000 });
+      }
+    } else {
+      await expect(titleInput).toBeVisible({ timeout: 20000 });
+    }
 
     const noteTitle = `Shared Note ${Date.now()}`;
     const noteContent = '# Hello World\n\nThis is a shared note for E2E testing.\n\n- Item 1\n- Item 2';

--- a/frontend/tests/ui.spec.ts
+++ b/frontend/tests/ui.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test.describe('UI Loading States', () => {
 
-  test('should show loading state when creating a folder', async ({ page }) => {
-    // Only test on desktop as mobile layout logic differs significantly
+  test('should show loading state when creating a folder', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Desktop only');
     await page.goto('/');
     const desktopLayout = page.getByTestId('desktop-layout');
     const createFolderPromise = page.waitForResponse(


### PR DESCRIPTION
## 概要

モバイル向けの Playwright E2E で CI だけ落ちていた 2 ケースを安定化します。`share.spec.ts` のモバイル遷移待ちを補強し、`ui.spec.ts` の desktop 前提テストをモバイルから外します。

## 変更内容

- `share.spec.ts` で、モバイルの note 作成後に editor が見えない場合は作成ノートを `id` ベースで明示的に開くよう変更
- `share.spec.ts` の入力対象を `editor-title-input` / `editor-content-input` に統一
- `ui.spec.ts` の folder loading test を desktop-only にして、モバイルレイアウトでの不正な assertion を回避

## テスト方法

- [x] `E2E_TARGET=dev npx playwright test tests/share.spec.ts --project="Mobile Chrome"`
- [x] `E2E_TARGET=dev npx playwright test tests/ui.spec.ts --project="Mobile Chrome"`
- [x] `docker run --rm --ipc=host -u "$(id -u):$(id -g)" -e HOME=/tmp -v /home/ttakahashi/workspace/notes:/work -w /work/frontend mcr.microsoft.com/playwright:v1.57.0-noble bash -lc 'E2E_TARGET=dev npx playwright test tests/share.spec.ts --project="Mobile Safari"'`
- [x] `docker run --rm --ipc=host -u "$(id -u):$(id -g)" -e HOME=/tmp -v /home/ttakahashi/workspace/notes:/work -w /work/frontend mcr.microsoft.com/playwright:v1.57.0-noble bash -lc 'E2E_TARGET=dev npx playwright test tests/ui.spec.ts --project="Mobile Safari"'`
- [x] `make test-backend`
- [x] `make test-frontend`
- [x] `cd lambda/mcp_server && uv run --extra dev pytest tests/test_app_unit.py -q --tb=short`

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）
