### PR TITLE
chore: ignore root Playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,12 @@ Thumbs.db
 test-payload.json
 
 # Playwright
+test-results/
+playwright-report/
 frontend/test-results/
 frontend/playwright-report/
 frontend/playwright/.auth/
+after-login.png
 
 # Playwright CLI
 .playwright-cli/


### PR DESCRIPTION
## 概要

ローカルの Playwright 実行で root 配下に生成される成果物が未追跡として溜まっていたため、root の `.gitignore` を調整しました。通常の開発・E2E 実行で不要な差分が増えないようにしています。

## 変更内容

- root の `test-results/` を ignore 対象に追加
- root の `playwright-report/` を ignore 対象に追加
- 単発のデバッグ画像 `after-login.png` を ignore 対象に追加
- 既存の `frontend/` 配下の Playwright ignore ルールはそのまま維持

## テスト方法

- [x] `git status --short --branch` で `after-login.png` と `test-results/` が未追跡に出ないことを確認
- [x] pre-commit hook
- [x] pre-push hook

## チェックリスト

- [ ] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）