### PR TITLE
chore: add Claude Code post-tool hook

### DIFF
--- a/.claude/hooks/post-tool-use-format-and-lint.sh
+++ b/.claude/hooks/post-tool-use-format-and-lint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+make_bin="${CLAUDE_HOOK_MAKE_BIN:-make}"
+
+payload="$(cat)"
+if [ -z "$payload" ]; then
+  exit 0
+fi
+
+file_path="$(
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+tool_input = data.get("tool_input") or {}
+file_path = tool_input.get("file_path") or ""
+sys.stdout.write(file_path)
+'
+)"
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+case "$file_path" in
+  "$project_dir"/*)
+    rel_path="${file_path#"$project_dir"/}"
+    ;;
+  *)
+    rel_path="$file_path"
+    ;;
+esac
+
+if [ -z "$rel_path" ]; then
+  exit 0
+fi
+
+case "$rel_path" in
+  ../*|*/../*|..)
+    exit 0
+    ;;
+esac
+
+"$make_bin" -C "$project_dir" --no-print-directory claude-post-tool-use FILE_PATH="$rel_path" >/dev/null 2>&1 || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-use-format-and-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -287,13 +287,64 @@ test-integration: tf-switch ## Run integration tests against the deployed enviro
 .PHONY: test-lint
 test-lint: lint-backend lint-frontend ## Run all linters
 
+.PHONY: test-claude-hooks
+test-claude-hooks: ## Verify Claude Code PostToolUse hook routing
+	./scripts/test_claude_post_tool_use_hook.sh
+
+BACKEND_PATH ?= .
+FRONTEND_PATH ?= .
+TERRAFORM_PATH ?= .
+
+.PHONY: format
+format: format-backend format-frontend format-terraform ## Run project auto-formatters
+
+.PHONY: lint-backend-fix
+lint-backend-fix: ## Run backend linter with auto-fixes (ruff --fix)
+	cd backend && uv run ruff check --fix $(BACKEND_PATH)
+
+.PHONY: format-backend
+format-backend: ## Run backend formatter (ruff format)
+	cd backend && uv run ruff format $(BACKEND_PATH)
+
 .PHONY: lint-backend
 lint-backend: ## Run backend linter (ruff)
-	cd backend && uv run ruff check .
+	cd backend && uv run ruff check $(BACKEND_PATH)
+
+.PHONY: format-frontend
+format-frontend: ## Run frontend auto-fixes (eslint --fix)
+	cd frontend && npm run lint -- --fix $(FRONTEND_PATH)
 
 .PHONY: lint-frontend
 lint-frontend: ## Run frontend linter (eslint)
-	cd frontend && npm run lint
+	cd frontend && npm run lint -- $(FRONTEND_PATH)
+
+.PHONY: format-terraform
+format-terraform: ## Run Terraform formatter
+	cd terraform && terraform fmt $(TERRAFORM_PATH)
+
+.PHONY: claude-post-tool-use
+claude-post-tool-use: ## Run hook-safe format/lint steps for a single edited file (FILE_PATH=...)
+	@if [ -z "$(FILE_PATH)" ]; then \
+		echo "FILE_PATH is required"; \
+		exit 1; \
+	fi
+	@file_path="$(FILE_PATH)"; \
+	case "$$file_path" in \
+		backend/*.py) \
+			rel_path="$${file_path#backend/}"; \
+			$(MAKE) --no-print-directory lint-backend-fix BACKEND_PATH="$$rel_path" && \
+			$(MAKE) --no-print-directory format-backend BACKEND_PATH="$$rel_path" && \
+			$(MAKE) --no-print-directory lint-backend BACKEND_PATH="$$rel_path" ;; \
+		frontend/*.js|frontend/*.jsx|frontend/*.ts|frontend/*.tsx|frontend/*.mjs|frontend/*.cjs) \
+			rel_path="$${file_path#frontend/}"; \
+			$(MAKE) --no-print-directory format-frontend FRONTEND_PATH="$$rel_path" && \
+			$(MAKE) --no-print-directory lint-frontend FRONTEND_PATH="$$rel_path" ;; \
+		terraform/*.tf|terraform/*.tfvars) \
+			rel_path="$${file_path#terraform/}"; \
+			$(MAKE) --no-print-directory format-terraform TERRAFORM_PATH="$$rel_path" ;; \
+		*) \
+			true ;; \
+	esac
 
 PLAYWRIGHT_DOCKER_IMAGE ?= mcr.microsoft.com/playwright:v1.57.0-noble
 PLAYWRIGHT_DOCKER_RUN = docker run --rm --ipc=host -u "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/work" -w /work/frontend $(PLAYWRIGHT_DOCKER_IMAGE) bash -lc

--- a/scripts/test_claude_post_tool_use_hook.sh
+++ b/scripts/test_claude_post_tool_use_hook.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hook_script="$project_dir/.claude/hooks/post-tool-use-format-and-lint.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+log_file="$tmp_dir/make.log"
+mock_make="$tmp_dir/mock-make.sh"
+
+cat >"$mock_make" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CLAUDE_HOOK_TEST_LOG"
+EOF
+
+chmod +x "$mock_make"
+
+run_hook() {
+  local payload="$1"
+  printf '%s' "$payload" | \
+    CLAUDE_PROJECT_DIR="$project_dir" \
+    CLAUDE_HOOK_MAKE_BIN="$mock_make" \
+    CLAUDE_HOOK_TEST_LOG="$log_file" \
+    "$hook_script"
+}
+
+run_make_target() {
+  local file_path="$1"
+  CLAUDE_HOOK_TEST_LOG="$log_file" \
+    make -C "$project_dir" --no-print-directory claude-post-tool-use FILE_PATH="$file_path" MAKE="$mock_make"
+}
+
+assert_contains() {
+  local pattern="$1"
+  if ! grep -F "$pattern" "$log_file" >/dev/null 2>&1; then
+    echo "expected log to contain: $pattern" >&2
+    echo "actual log:" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+}
+
+assert_log_lines() {
+  local expected="$1"
+  local actual
+  actual="$(wc -l <"$log_file" | tr -d ' ')"
+  if [ "$actual" != "$expected" ]; then
+    echo "expected $expected log lines, got $actual" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+}
+
+: >"$log_file"
+run_hook '{"tool_input":{"file_path":"'"$project_dir"'/backend/app/main.py"}}'
+assert_log_lines 1
+assert_contains 'claude-post-tool-use FILE_PATH=backend/app/main.py'
+
+: >"$log_file"
+run_make_target 'backend/app/main.py'
+assert_log_lines 3
+assert_contains 'lint-backend-fix BACKEND_PATH=app/main.py'
+assert_contains 'format-backend BACKEND_PATH=app/main.py'
+assert_contains 'lint-backend BACKEND_PATH=app/main.py'
+
+: >"$log_file"
+run_hook '{"tool_input":{"file_path":"frontend/src/app/page.tsx"}}'
+assert_log_lines 1
+assert_contains 'claude-post-tool-use FILE_PATH=frontend/src/app/page.tsx'
+
+: >"$log_file"
+run_make_target 'frontend/src/app/page.tsx'
+assert_log_lines 2
+assert_contains 'format-frontend FRONTEND_PATH=src/app/page.tsx'
+assert_contains 'lint-frontend FRONTEND_PATH=src/app/page.tsx'
+
+: >"$log_file"
+run_hook '{"tool_input":{"file_path":"README.md"}}'
+assert_log_lines 1
+assert_contains 'claude-post-tool-use FILE_PATH=README.md'
+
+: >"$log_file"
+run_make_target 'terraform/main.tf'
+assert_log_lines 1
+assert_contains 'format-terraform TERRAFORM_PATH=main.tf'
+
+: >"$log_file"
+run_hook '{"tool_input":{"note":"missing path"}}'
+assert_log_lines 0


### PR DESCRIPTION
## 概要

Claude Code の `PostToolUse` hook を project 設定として追加し、`Edit` / `MultiEdit` / `Write` の後に対象ファイルだけへ formatter と linter を走らせる仕組みを導入しました。

## 変更内容

- `.claude/settings.json` に `PostToolUse` hook を追加
- `.claude/hooks/post-tool-use-format-and-lint.sh` を追加し、hook payload から編集ファイルを抽出して `make claude-post-tool-use` に委譲
- `Makefile` に backend / frontend / terraform 向けの file-aware な format / lint ターゲットと hook 用ターゲットを追加
- `scripts/test_claude_post_tool_use_hook.sh` を追加し、hook のルーティングと `make` ターゲット呼び出しを検証可能にした

## テスト方法

- [x] `make test-claude-hooks`
- [x] `make lint-backend BACKEND_PATH=app/main.py`
- [x] `make lint-frontend FRONTEND_PATH=eslint.config.mjs`
- [x] pre-push hook
  - `make test-backend`
  - `make test-frontend`
  - `make test-mcp-lambda-unit`

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）
