### PR TITLE
chore: expand test workflow targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,23 +264,46 @@ clean: ## Clean build artifacts
 # Testing
 # =============================================================================
 
+# Test command guide:
+# - `make test` is the fastest day-to-day check: backend + frontend unit tests + lint.
+# - `make test-unit` adds the MCP Lambda unit tests to the fast local suite.
+# - `make test-all ENV=dev` runs the full validation suite: lint + unit + integration + E2E.
+# - `make test-integration ENV=dev` hits the deployed backend in the selected environment.
+# - `make test-e2e-host ENV=dev` runs browsers that work well on the host (Chromium family).
+# - `make test-e2e-all ENV=dev` mirrors CI locally: host Chromium + Docker WebKit/Safari.
+#
+# Common overrides:
+# - `ENV=dev|prd` selects the deployed environment for integration/E2E tests.
+# - `TEST_ARGS='tests/auth.spec.ts'` or `TEST_ARGS='-g "full cycle"'` narrows Playwright runs.
+# - `PROJECT=webkit` is required only for the generic Docker Playwright target.
+
 .PHONY: test
-test: test-backend test-frontend test-lint ## Run all tests
+test: test-backend test-frontend test-lint ## Run the default fast suite: backend + frontend unit tests + lint
+
+.PHONY: test-unit
+test-unit: test-backend test-frontend test-mcp-lambda-unit ## Run all unit tests across backend, frontend, and MCP Lambda
+
+.PHONY: test-all
+test-all: test-unit test-lint test-integration test-mcp-lambda-integration test-e2e-all ## Run the full suite: lint + unit + integration + E2E
 
 .PHONY: test-mcp-lambda-unit
 test-mcp-lambda-unit: ## Run MCP Lambda unit tests
 	cd lambda/mcp_server && uv run --extra dev pytest tests/test_app_unit.py -q --tb=short
 
+.PHONY: test-mcp-lambda-integration
+test-mcp-lambda-integration: ## Run MCP Lambda integration tests (requires AWS/Cognito env vars)
+	cd lambda/mcp_server && uv run --extra dev pytest tests/test_mcp_integration.py -v
+
 .PHONY: test-backend
-test-backend: ## Run backend tests
+test-backend: ## Run backend unit/integration-free tests locally
 	cd backend && uv run --extra dev python -m pytest -v
 
 .PHONY: test-frontend
-test-frontend: ## Run frontend unit tests
+test-frontend: ## Run frontend Vitest unit tests
 	cd frontend && npm run test -- --run
 
 .PHONY: test-integration
-test-integration: tf-switch ## Run integration tests against the deployed environment
+test-integration: tf-switch ## Run backend integration tests against the deployed environment selected by ENV
 	$(eval API_URL := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw api_url))
 	cd backend && API_URL=$(API_URL) uv run --extra dev python -m pytest tests/integration -v
 
@@ -290,6 +313,13 @@ test-lint: lint-backend lint-frontend ## Run all linters
 .PHONY: test-claude-hooks
 test-claude-hooks: ## Verify Claude Code PostToolUse hook routing
 	./scripts/test_claude_post_tool_use_hook.sh
+
+# Playwright browser split:
+# - `chromium` and `Mobile Chrome` run directly on the host.
+# - `webkit` and `Mobile Safari` run in Docker because Linux host WebKit/WPE is less stable
+#   and can crash with messages like `WPEWebProcess quit unexpectedly`.
+PLAYWRIGHT_DOCKER_IMAGE ?= mcr.microsoft.com/playwright:v1.57.0-noble
+PLAYWRIGHT_DOCKER_RUN = docker run --rm --ipc=host -u "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/work" -w /work/frontend $(PLAYWRIGHT_DOCKER_IMAGE) bash -lc
 
 BACKEND_PATH ?= .
 FRONTEND_PATH ?= .
@@ -346,11 +376,8 @@ claude-post-tool-use: ## Run hook-safe format/lint steps for a single edited fil
 			true ;; \
 	esac
 
-PLAYWRIGHT_DOCKER_IMAGE ?= mcr.microsoft.com/playwright:v1.57.0-noble
-PLAYWRIGHT_DOCKER_RUN = docker run --rm --ipc=host -u "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/work" -w /work/frontend $(PLAYWRIGHT_DOCKER_IMAGE) bash -lc
-
 .PHONY: test-e2e
-test-e2e: ## Run E2E tests against dev or prd (E2E_TARGET=dev|prd)
+test-e2e: ## Run all Playwright projects on the host (use only if your host can run every browser)
 	cd frontend && E2E_TARGET=$(ENV) npx playwright test $(TEST_ARGS)
 
 .PHONY: test-e2e-dev
@@ -360,6 +387,11 @@ test-e2e-dev: ## Run E2E tests against dev environment
 .PHONY: test-e2e-prd
 test-e2e-prd: ## Run E2E tests against prd environment
 	cd frontend && E2E_TARGET=prd npx playwright test $(TEST_ARGS)
+
+.PHONY: test-e2e-host
+test-e2e-host: ## Run the host-supported Playwright projects: chromium + Mobile Chrome
+	cd frontend && E2E_TARGET=$(ENV) npx playwright test --project=chromium $(TEST_ARGS)
+	cd frontend && E2E_TARGET=$(ENV) npx playwright test --project="Mobile Chrome" $(TEST_ARGS)
 
 .PHONY: test-e2e-docker
 test-e2e-docker: ## Run E2E tests in Docker (PROJECT required, ENV=dev|prd)
@@ -374,8 +406,14 @@ test-e2e-webkit-docker: ## Run WebKit E2E tests in Docker
 test-e2e-mobile-safari-docker: ## Run Mobile Safari E2E tests in Docker
 	$(PLAYWRIGHT_DOCKER_RUN) 'E2E_TARGET=$(ENV) npx playwright test --project="Mobile Safari" $(TEST_ARGS)'
 
+.PHONY: test-e2e-all
+test-e2e-all: ## Run the CI-style Playwright split locally: host Chromium + Docker WebKit/Safari
+	@$(MAKE) --no-print-directory test-e2e-host ENV=$(ENV) TEST_ARGS='$(TEST_ARGS)'
+	@$(MAKE) --no-print-directory test-e2e-webkit-docker ENV=$(ENV) TEST_ARGS='$(TEST_ARGS)'
+	@$(MAKE) --no-print-directory test-e2e-mobile-safari-docker ENV=$(ENV) TEST_ARGS='$(TEST_ARGS)'
+
 .PHONY: install-playwright-deps
-install-playwright-deps: ## Install Playwright browser dependencies (dnf)
+install-playwright-deps: ## Install host-side Playwright dependencies for Chromium (WebKit still uses Docker here)
 	dnf install -y libicu libjpeg-turbo gstreamer1-plugins-base
 
 .PHONY: install-hooks

--- a/README.md
+++ b/README.md
@@ -195,18 +195,60 @@ make deploy ENV=prd
 
 ## Testing
 
-### Backend Unit Tests
+Makefile is the primary entry point for tests. `make help` shows the full list, and the targets below are the normal day-to-day commands.
+
+### Quick Start
 
 ```bash
-cd backend
-uv run pytest
+# Fast local check used most often
+make test
+
+# All unit tests, including the MCP Lambda package
+make test-unit
+
+# Backend integration tests against the deployed dev environment
+make test-integration ENV=dev
+
+# Full E2E split that matches CI
+make test-e2e-all ENV=dev
+
+# Everything: lint + unit + integration + E2E
+make test-all ENV=dev
 ```
 
-### Frontend E2E Tests (Playwright)
+### What Each Target Runs
 
-E2E tests use Playwright to test the application across multiple browsers.
+```bash
+# Default fast suite: backend + frontend unit tests + lint
+make test
 
-#### Setup
+# Unit tests only
+make test-backend
+make test-frontend
+make test-mcp-lambda-unit
+make test-unit
+
+# Deployed-environment tests
+make test-integration ENV=dev
+make test-mcp-lambda-integration
+
+# E2E on browsers that run well on the host
+make test-e2e-host ENV=dev
+
+# E2E for each Safari/WebKit project in Docker
+make test-e2e-webkit-docker ENV=dev
+make test-e2e-mobile-safari-docker ENV=dev
+
+# CI-style full E2E run
+make test-e2e-all ENV=dev
+
+# Full validation before a larger merge or release
+make test-all ENV=dev
+```
+
+### E2E Setup
+
+E2E tests use Playwright across Chromium and Safari-family projects.
 
 1. Create `frontend/.env.local` with test credentials:
    ```env
@@ -214,54 +256,41 @@ E2E tests use Playwright to test the application across multiple browsers.
    E2E_TEST_USER_PASSWORD=YourTestPassword123!
    ```
 
-2. Install Playwright browsers:
+2. Install Playwright browsers for host-side projects:
    ```bash
    cd frontend
    npx playwright install
    ```
 
-#### Running Tests
+3. Use Docker for `webkit` and `Mobile Safari`.
+   On Linux hosts we have seen WebKit/WPE crashes such as `WPEWebProcess quit unexpectedly`, so the supported local path is:
+   - Host execution: `chromium`, `Mobile Chrome`
+   - Docker execution: `webkit`, `Mobile Safari`
+
+### E2E Examples
 
 ```bash
-# Local development (starts dev server automatically)
-npx playwright test
+# Narrow to a specific file
+make test-e2e-host ENV=dev TEST_ARGS='tests/auth.spec.ts'
 
-# Against dev environment
-E2E_TARGET=dev npx playwright test
+# Narrow by grep
+make test-e2e-host ENV=dev TEST_ARGS='-g "full cycle"'
 
-# Against production
-E2E_TARGET=prd npx playwright test
-
-# Run specific test file
-E2E_TARGET=dev npx playwright test tests/auth.spec.ts
-
-# Run with UI mode (interactive)
-npx playwright test --ui
-
-# View HTML report
-npx playwright show-report
-```
-
-#### Make Targets
-
-```bash
-# Host execution
-make test-e2e-dev
-make test-e2e-prd
-
-# Pass through specific files or grep filters
-make test-e2e-dev TEST_ARGS='tests/auth.spec.ts'
-make test-e2e-dev TEST_ARGS='-g "full cycle"'
-
-# Docker execution for WebKit/Safari on hosts with incompatible system libraries
-make test-e2e-webkit-docker ENV=dev
-make test-e2e-mobile-safari-docker ENV=dev
-
-# Generic Docker target
+# Run a single Docker-backed browser
 make test-e2e-docker ENV=dev PROJECT=webkit TEST_ARGS='tests/auth.spec.ts'
+
+# If your host can run every Playwright project directly, this remains available
+make test-e2e ENV=dev
 ```
 
-GitHub Actions also uses the same split: `chromium` and `Mobile Chrome` run on the standard Ubuntu runner, while `webkit` and `Mobile Safari` run inside the Playwright Docker image. Configure `E2E_TEST_USER_EMAIL` and `E2E_TEST_USER_PASSWORD` as repository secrets before enabling the workflow.
+GitHub Actions uses the same split as `make test-e2e-all`: `chromium` and `Mobile Chrome` run on the standard Ubuntu runner, while `webkit` and `Mobile Safari` run inside the Playwright Docker image. Configure `E2E_TEST_USER_EMAIL` and `E2E_TEST_USER_PASSWORD` as repository secrets before enabling the workflow.
+
+### Notes
+
+- `ENV=dev|prd` selects the deployed environment for integration and E2E tests.
+- `TEST_ARGS='...'` is passed through to Playwright, so file paths and `-g` filters work as-is.
+- `test-mcp-lambda-integration` requires the AWS/Cognito-related environment variables expected by [`lambda/mcp_server/tests/test_mcp_integration.py`](lambda/mcp_server/tests/test_mcp_integration.py).
+- `test-all` includes `test-integration`, `test-mcp-lambda-integration`, and `test-e2e-all`, so it assumes the deployed environment, Docker, and E2E credentials are all available.
 
 > [!TIP]
 > For detailed credential management and CI/CD setup, see [frontend/docs/E2E_CREDENTIALS.md](frontend/docs/E2E_CREDENTIALS.md).


### PR DESCRIPTION
## 概要

テスト実行用の `make` ターゲットを整理し、日常利用向けの高速チェックと、統合・E2E を含むフル検証の導線を分かりやすくしました。あわせて README のテスト手順を現在の Makefile 運用に合わせて更新しています。

## 変更内容

- `make test-unit` / `make test-all` / `make test-mcp-lambda-integration` / `make test-e2e-host` / `make test-e2e-all` を追加
- 各テストターゲットの説明を具体化し、Playwright の host 実行と Docker 実行の役割分担を Makefile コメントに明記
- README の Testing セクションを Makefile 中心のガイドに再構成し、主要コマンドと E2E 実行例を更新

## テスト方法

- [x] `make help`
- [x] `make lint-backend`
- [x] `make lint-frontend` 
- [x] `make test-backend`
- [x] `make test-frontend`
- [x] `make test-mcp-lambda-unit`

## チェックリスト

- [ ] テストを追加・更新した
- [x] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）

## Notes

- `make lint-frontend` は既存の未使用変数警告 3 件を出しますが、失敗はしていません。
- `make test-frontend` は既存の `EditorPanel.test.tsx` の `act(...)` 警告を出しますが、78 件すべて通過しています。