### PR TITLE
chore: add stop hook unit test automation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/agent_stop_hook_unit_tests.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|MultiEdit|Write",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[features]
+codex_hooks = true
+
+suppress_unstable_features_warning = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/agent_stop_hook_unit_tests.sh",
+            "timeout": 1800,
+            "statusMessage": "Running unit tests before stopping"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,10 @@ test: test-backend test-frontend test-lint ## Run the default fast suite: backen
 .PHONY: test-unit
 test-unit: test-backend test-frontend test-mcp-lambda-unit ## Run all unit tests across backend, frontend, and MCP Lambda
 
+.PHONY: stop-hook-unit-tests
+stop-hook-unit-tests: ## Run unit tests from Claude/Codex Stop hooks
+	@$(MAKE) --no-print-directory test-unit
+
 .PHONY: test-all
 test-all: test-unit test-lint test-integration test-mcp-lambda-integration test-e2e-all ## Run the full suite: lint + unit + integration + E2E
 
@@ -311,8 +315,20 @@ test-integration: tf-switch ## Run backend integration tests against the deploye
 test-lint: lint-backend lint-frontend ## Run all linters
 
 .PHONY: test-claude-hooks
-test-claude-hooks: ## Verify Claude Code PostToolUse hook routing
+test-claude-hooks: ## Verify Claude Code hook routing
 	./scripts/test_claude_post_tool_use_hook.sh
+	./scripts/test_agent_hook_configs.sh --claude
+
+.PHONY: test-stop-hooks
+test-stop-hooks: ## Verify shared Stop hook behavior
+	./scripts/test_agent_stop_hook.sh
+
+.PHONY: test-codex-hooks
+test-codex-hooks: ## Verify Codex hook routing
+	./scripts/test_agent_hook_configs.sh --codex
+
+.PHONY: test-agent-hooks
+test-agent-hooks: test-claude-hooks test-stop-hooks test-codex-hooks ## Verify Claude Code and Codex hook routing
 
 # Playwright browser split:
 # - `chromium` and `Mobile Chrome` run directly on the host.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Once set up, the correct versions of `node`, `python`, and `go` will be automati
 
 Git hooks are managed with `lefthook`. The configured hooks run fast lint checks on `pre-commit`, and heavier test suites on `pre-push`.
 
+Agent hook settings are checked into the repo for both Claude Code and Codex. Their Stop hooks run `make stop-hook-unit-tests`, and you can verify the wiring with `make test-agent-hooks`.
+
 ### Quick Start
 
 1. Open the project in VS Code

--- a/scripts/agent_stop_hook_unit_tests.sh
+++ b/scripts/agent_stop_hook_unit_tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+make_bin="${AGENT_STOP_HOOK_MAKE_BIN:-make}"
+make_target="${AGENT_STOP_HOOK_TARGET:-stop-hook-unit-tests}"
+max_lines="${AGENT_STOP_HOOK_MAX_LINES:-200}"
+
+if output="$("$make_bin" -C "$project_dir" --no-print-directory "$make_target" 2>&1)"; then
+  exit 0
+fi
+
+printf 'Unit tests failed while running `%s`.\n' "$make_target" >&2
+printf 'Fix the failing tests before stopping.\n' >&2
+
+trimmed_output="$(printf '%s\n' "$output" | tail -n "$max_lines")"
+if [ -n "$trimmed_output" ]; then
+  printf '\n%s\n' "$trimmed_output" >&2
+fi
+
+exit 2

--- a/scripts/test_agent_hook_configs.sh
+++ b/scripts/test_agent_hook_configs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mode="${1:-}"
+
+if [ "$mode" != "--claude" ] && [ "$mode" != "--codex" ]; then
+  echo "usage: $0 --claude|--codex" >&2
+  exit 1
+fi
+
+if [ "$mode" = "--claude" ]; then
+  jq -e '
+    .hooks.Stop[0].hooks[0].type == "command" and
+    .hooks.Stop[0].hooks[0].command == "$CLAUDE_PROJECT_DIR/scripts/agent_stop_hook_unit_tests.sh"
+  ' "$project_dir/.claude/settings.json" >/dev/null
+  exit 0
+fi
+
+jq -e '
+  .hooks.Stop[0].hooks[0].type == "command" and
+  .hooks.Stop[0].hooks[0].command == "./scripts/agent_stop_hook_unit_tests.sh" and
+  .hooks.Stop[0].hooks[0].timeout == 1800 and
+  .hooks.Stop[0].hooks[0].statusMessage == "Running unit tests before stopping"
+' "$project_dir/.codex/hooks.json" >/dev/null
+
+grep -Fx '[features]' "$project_dir/.codex/config.toml" >/dev/null
+grep -Fx 'codex_hooks = true' "$project_dir/.codex/config.toml" >/dev/null
+grep -Fx 'suppress_unstable_features_warning = true' "$project_dir/.codex/config.toml" >/dev/null

--- a/scripts/test_agent_stop_hook.sh
+++ b/scripts/test_agent_stop_hook.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hook_script="$project_dir/scripts/agent_stop_hook_unit_tests.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+log_file="$tmp_dir/make.log"
+stderr_file="$tmp_dir/stderr.log"
+stdout_file="$tmp_dir/stdout.log"
+mock_make="$tmp_dir/mock-make.sh"
+
+cat >"$mock_make" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$AGENT_STOP_HOOK_TEST_LOG"
+if [ "${AGENT_STOP_HOOK_TEST_EXIT_CODE:-0}" -eq 0 ]; then
+  exit 0
+fi
+printf '%s\n' "${AGENT_STOP_HOOK_TEST_FAILURE_OUTPUT:-simulated failure}" >&2
+exit "${AGENT_STOP_HOOK_TEST_EXIT_CODE}"
+EOF
+
+chmod +x "$mock_make"
+
+assert_contains() {
+  local file_path="$1"
+  local pattern="$2"
+  if ! grep -F -- "$pattern" "$file_path" >/dev/null 2>&1; then
+    echo "expected $file_path to contain: $pattern" >&2
+    echo "actual contents:" >&2
+    cat "$file_path" >&2
+    exit 1
+  fi
+}
+
+: >"$log_file"
+AGENT_STOP_HOOK_TEST_LOG="$log_file" \
+AGENT_STOP_HOOK_MAKE_BIN="$mock_make" \
+"$hook_script" >"$stdout_file" 2>"$stderr_file"
+assert_contains "$log_file" "-C $project_dir --no-print-directory stop-hook-unit-tests"
+if [ -s "$stderr_file" ]; then
+  echo "expected no stderr on success" >&2
+  cat "$stderr_file" >&2
+  exit 1
+fi
+
+: >"$log_file"
+set +e
+AGENT_STOP_HOOK_TEST_LOG="$log_file" \
+AGENT_STOP_HOOK_TEST_EXIT_CODE=1 \
+AGENT_STOP_HOOK_TEST_FAILURE_OUTPUT='backend tests failed' \
+AGENT_STOP_HOOK_MAKE_BIN="$mock_make" \
+"$hook_script" >"$stdout_file" 2>"$stderr_file"
+status=$?
+set -e
+if [ "$status" -ne 2 ]; then
+  echo "expected exit code 2 on failure, got $status" >&2
+  exit 1
+fi
+assert_contains "$log_file" "-C $project_dir --no-print-directory stop-hook-unit-tests"
+assert_contains "$stderr_file" 'Unit tests failed while running `stop-hook-unit-tests`.'
+assert_contains "$stderr_file" 'Fix the failing tests before stopping.'
+assert_contains "$stderr_file" 'backend tests failed'


### PR DESCRIPTION
## 概要

Claude Code と Codex の Stop Hook からリポジトリの unit test を共通実行できるようにし、hook 設定と動作確認のテストを追加しました。

## 変更内容

- Claude Code の `Stop` hook を追加し、共通スクリプト `scripts/agent_stop_hook_unit_tests.sh` で `make stop-hook-unit-tests` を実行するように変更
- Codex 向けに `.codex/hooks.json` と `.codex/config.toml` を追加し、`codex_hooks` を有効化したうえで同じ Stop Hook を実行するように設定
- `Makefile` に Stop Hook 用ターゲットと hook 検証ターゲットを追加し、shell ベースの検証スクリプトで Claude/Codex 両方の設定をテスト
- README に agent hook の運用方法を追記

## テスト方法

- [x] `make test-agent-hooks`
- [x] `make stop-hook-unit-tests`
- [x] `git push -u origin chore/agent-stop-hooks` 実行時の pre-push hook

## チェックリスト

- [x] テストを追加・更新した
- [x] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）