### PR TITLE
chore: block destructive bash commands in Claude hook

### DIFF
--- a/.claude/hooks/pre-tool-use-block-destructive-commands.sh
+++ b/.claude/hooks/pre-tool-use-block-destructive-commands.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+make_bin="${CLAUDE_HOOK_MAKE_BIN:-make}"
+
+payload="$(cat)"
+if [ -z "$payload" ]; then
+  exit 0
+fi
+
+command="$(
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+tool_input = data.get("tool_input") or {}
+command = tool_input.get("command") or ""
+sys.stdout.write(command)
+'
+)"
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+CLAUDE_HOOK_COMMAND="$command" \
+  "$make_bin" -C "$project_dir" --no-print-directory claude-pre-tool-use

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use-block-destructive-commands.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|MultiEdit|Write",

--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,7 @@ test-lint: lint-backend lint-frontend ## Run all linters
 
 .PHONY: test-claude-hooks
 test-claude-hooks: ## Verify Claude Code hook routing
+	./scripts/test_claude_pre_tool_use_hook.sh
 	./scripts/test_claude_post_tool_use_hook.sh
 	./scripts/test_agent_hook_configs.sh --claude
 
@@ -391,6 +392,10 @@ claude-post-tool-use: ## Run hook-safe format/lint steps for a single edited fil
 		*) \
 			true ;; \
 	esac
+
+.PHONY: claude-pre-tool-use
+claude-pre-tool-use: ## Block destructive Claude Bash commands based on CLAUDE_HOOK_COMMAND
+	@python3 scripts/claude_pre_tool_use_guard.py
 
 .PHONY: test-e2e
 test-e2e: ## Run all Playwright projects on the host (use only if your host can run every browser)

--- a/scripts/claude_pre_tool_use_guard.py
+++ b/scripts/claude_pre_tool_use_guard.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import shlex
+import sys
+
+
+SHELL_WRAPPERS = {"bash", "sh", "zsh"}
+SHELL_EXEC_FLAGS = {"-c", "-lc", "-ic", "-ec", "-lec", "-xc", "-exc"}
+PREFIX_WRAPPERS = {"command", "builtin", "nohup"}
+
+
+def is_env_assignment(token: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token))
+
+
+def parse_command(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return []
+
+
+def strip_wrappers(tokens: list[str]) -> list[str]:
+    current = tokens
+    while current:
+        while current and is_env_assignment(current[0]):
+            current = current[1:]
+
+        if not current:
+            return current
+
+        head = current[0]
+        if head == "sudo":
+            index = 1
+            while index < len(current) and current[index].startswith("-"):
+                index += 1
+            current = current[index:]
+            continue
+
+        if head == "env":
+            index = 1
+            while index < len(current) and (
+                current[index].startswith("-") or is_env_assignment(current[index])
+            ):
+                index += 1
+            current = current[index:]
+            continue
+
+        if head in PREFIX_WRAPPERS:
+            current = current[1:]
+            continue
+
+        if head in SHELL_WRAPPERS and len(current) >= 3 and current[1] in SHELL_EXEC_FLAGS:
+            current = parse_command(current[2])
+            continue
+
+        return current
+
+    return current
+
+
+def has_short_flag(option: str, flag: str) -> bool:
+    if not option.startswith("-") or option.startswith("--"):
+        return False
+    return flag in option[1:]
+
+
+def rm_is_recursive_force(tokens: list[str]) -> bool:
+    recursive = False
+    force = False
+
+    for token in tokens[1:]:
+        if token == "--":
+            break
+        if not token.startswith("-"):
+            break
+        if token == "--recursive":
+            recursive = True
+            continue
+        if token == "--force":
+            force = True
+            continue
+        if has_short_flag(token, "r") or has_short_flag(token, "R"):
+            recursive = True
+        if has_short_flag(token, "f"):
+            force = True
+
+    return recursive and force
+
+
+def git_clean_is_forceful(tokens: list[str]) -> bool:
+    force = False
+    dirs = False
+
+    for token in tokens[2:]:
+        if token == "--":
+            break
+        if not token.startswith("-"):
+            break
+        if has_short_flag(token, "f"):
+            force = True
+        if has_short_flag(token, "d"):
+            dirs = True
+
+    return force and dirs
+
+
+def find_delete(tokens: list[str]) -> bool:
+    return any(token == "-delete" for token in tokens[1:])
+
+
+def blocked_reason(command: str) -> str | None:
+    tokens = strip_wrappers(parse_command(command))
+    if not tokens:
+        return None
+
+    if tokens[0] == "rm" and rm_is_recursive_force(tokens):
+        return "Blocked destructive command pattern `rm -rf`."
+
+    if len(tokens) >= 2 and tokens[0] == "terraform" and tokens[1] == "destroy":
+        return "Blocked destructive command pattern `terraform destroy`."
+
+    if len(tokens) >= 3 and tokens[0] == "git" and tokens[1] == "reset" and "--hard" in tokens[2:]:
+        return "Blocked destructive command pattern `git reset --hard`."
+
+    if len(tokens) >= 2 and tokens[0] == "git" and tokens[1] == "clean" and git_clean_is_forceful(tokens):
+        return "Blocked destructive command pattern `git clean -fd`."
+
+    if tokens[0] == "find" and find_delete(tokens):
+        return "Blocked destructive command pattern `find ... -delete`."
+
+    return None
+
+
+def main() -> int:
+    command = os.environ.get("CLAUDE_HOOK_COMMAND", "")
+    reason = blocked_reason(command)
+    if not reason:
+        return 0
+
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"{reason} Run it manually outside Claude Code if you really intend to delete state."
+                ),
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_agent_hook_configs.sh
+++ b/scripts/test_agent_hook_configs.sh
@@ -12,8 +12,12 @@ fi
 
 if [ "$mode" = "--claude" ]; then
   jq -e '
+    .hooks.PreToolUse[0].matcher == "Bash" and
+    .hooks.PreToolUse[0].hooks[0].type == "command" and
+    .hooks.PreToolUse[0].hooks[0].command == "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-use-block-destructive-commands.sh" and
     .hooks.Stop[0].hooks[0].type == "command" and
-    .hooks.Stop[0].hooks[0].command == "$CLAUDE_PROJECT_DIR/scripts/agent_stop_hook_unit_tests.sh"
+    .hooks.Stop[0].hooks[0].command == "$CLAUDE_PROJECT_DIR/scripts/agent_stop_hook_unit_tests.sh" and
+    .hooks.PostToolUse[0].matcher == "Edit|MultiEdit|Write"
   ' "$project_dir/.claude/settings.json" >/dev/null
   exit 0
 fi

--- a/scripts/test_claude_pre_tool_use_hook.sh
+++ b/scripts/test_claude_pre_tool_use_hook.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hook_script="$project_dir/.claude/hooks/pre-tool-use-block-destructive-commands.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+log_file="$tmp_dir/make.log"
+stdout_file="$tmp_dir/stdout.log"
+mock_make="$tmp_dir/mock-make.sh"
+
+cat >"$mock_make" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CLAUDE_HOOK_TEST_LOG"
+EOF
+
+chmod +x "$mock_make"
+
+run_hook() {
+  local payload="$1"
+  printf '%s' "$payload" | \
+    CLAUDE_PROJECT_DIR="$project_dir" \
+    CLAUDE_HOOK_MAKE_BIN="$mock_make" \
+    CLAUDE_HOOK_TEST_LOG="$log_file" \
+    "$hook_script" >"$stdout_file"
+}
+
+run_make_target() {
+  local command="$1"
+  CLAUDE_HOOK_COMMAND="$command" \
+    make -C "$project_dir" --no-print-directory claude-pre-tool-use >"$stdout_file"
+}
+
+assert_contains() {
+  local file_path="$1"
+  local pattern="$2"
+  if ! grep -F -- "$pattern" "$file_path" >/dev/null 2>&1; then
+    echo "expected $file_path to contain: $pattern" >&2
+    echo "actual contents:" >&2
+    cat "$file_path" >&2
+    exit 1
+  fi
+}
+
+assert_empty() {
+  local file_path="$1"
+  if [ -s "$file_path" ]; then
+    echo "expected $file_path to be empty" >&2
+    cat "$file_path" >&2
+    exit 1
+  fi
+}
+
+assert_denied() {
+  local pattern="$1"
+  jq -e --arg pattern "$pattern" '
+    .hookSpecificOutput.hookEventName == "PreToolUse" and
+    .hookSpecificOutput.permissionDecision == "deny" and
+    (.hookSpecificOutput.permissionDecisionReason | contains($pattern))
+  ' "$stdout_file" >/dev/null
+}
+
+: >"$log_file"
+run_hook '{"tool_input":{"command":"rm -rf frontend/.next"}}'
+assert_contains "$log_file" '-C '"$project_dir"' --no-print-directory claude-pre-tool-use'
+assert_empty "$stdout_file"
+
+run_make_target 'rm -rf frontend/.next'
+assert_denied 'rm -rf'
+
+run_make_target 'sudo rm -fr /tmp/notes'
+assert_denied 'rm -rf'
+
+run_make_target 'terraform destroy -auto-approve'
+assert_denied 'terraform destroy'
+
+run_make_target 'bash -lc '"'"'rm -rf terraform/.terraform'"'"''
+assert_denied 'rm -rf'
+
+run_make_target 'git reset --hard HEAD~1'
+assert_denied 'git reset --hard'
+
+run_make_target 'rm README.md'
+assert_empty "$stdout_file"
+
+run_make_target 'terraform plan'
+assert_empty "$stdout_file"
+
+CLAUDE_HOOK_COMMAND='' \
+  make -C "$project_dir" --no-print-directory claude-pre-tool-use >"$stdout_file"
+assert_empty "$stdout_file"


### PR DESCRIPTION
## Summary

Add a Claude Code PreToolUse hook for Bash commands so known destructive commands are denied before they run.
This keeps risky operations like `rm -rf` and `terraform destroy` out of the Claude execution path while preserving the existing hook workflow.

## Changes

- add a Claude `PreToolUse` Bash hook and wrapper script in `.claude/settings.json`
- add a guard that detects destructive command patterns including `rm -rf`, `terraform destroy`, `git reset --hard`, `git clean -fd`, and `find ... -delete`
- add Claude hook tests and config assertions, and wire the new test into `make test-claude-hooks`

## Testing

- `make test-claude-hooks`
- `pre-push` hook: backend tests, frontend tests, mcp lambda unit tests

## Notes

- existing frontend lint/test warnings in unrelated files still appear during hooks, but the suite passes