### PR TITLE
fix: allow frontend deploys without sentry dsn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ ECR_REPO = $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/notes-app-api-$
 MCP_SERVER_REPO = $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/notes-app-mcp-server-$(ENV)
 SENTRY_DSN_PARAMETER_NAME_FRONTEND ?= /notes-app/$(ENV)/sentry-dsn-frontend
 SENTRY_DSN_PARAMETER_NAME_BACKEND ?= /notes-app/$(ENV)/sentry-dsn-backend
+OPTIONAL_SSM_PARAMETER_SCRIPT := ./scripts/get_optional_ssm_parameter.sh
 
 .PHONY: help
 help: ## Show this help
@@ -128,7 +129,7 @@ build-frontend: tf-switch ## Build frontend for production
 	$(eval API_URL := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw api_url))
 	$(eval COGNITO_USER_POOL_ID := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw cognito_user_pool_id))
 	$(eval COGNITO_CLIENT_ID := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw cognito_user_pool_client_id))
-	SENTRY_DSN=$$(aws ssm get-parameter --name "$(SENTRY_DSN_PARAMETER_NAME_FRONTEND)" --with-decryption --region $(AWS_REGION) --profile $(AWS_PROFILE) --query 'Parameter.Value' --output text) && \
+	SENTRY_DSN=$$($(OPTIONAL_SSM_PARAMETER_SCRIPT) "$(SENTRY_DSN_PARAMETER_NAME_FRONTEND)" "$(AWS_REGION)" "$(AWS_PROFILE)") && \
 	cd frontend && NEXT_PUBLIC_API_URL=$(API_URL) NEXT_PUBLIC_ENVIRONMENT=$(ENV) NEXT_PUBLIC_COGNITO_USER_POOL_ID=$(COGNITO_USER_POOL_ID) NEXT_PUBLIC_COGNITO_CLIENT_ID=$(COGNITO_CLIENT_ID) NEXT_PUBLIC_SENTRY_DSN="$$SENTRY_DSN" npm run build
 
 .PHONY: build-frontend-local
@@ -191,7 +192,7 @@ _deploy-frontend: ## Build and deploy frontend to S3 (optimized)
 	$(eval BUCKET := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw frontend_bucket_name))
 	$(eval CF_DIST := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw cloudfront_distribution_id))
 	@echo "Building frontend..."
-	@SENTRY_DSN=$$(aws ssm get-parameter --name "$(SENTRY_DSN_PARAMETER_NAME_FRONTEND)" --with-decryption --region $(AWS_REGION) --profile $(AWS_PROFILE) --query 'Parameter.Value' --output text) && \
+	@SENTRY_DSN=$$($(OPTIONAL_SSM_PARAMETER_SCRIPT) "$(SENTRY_DSN_PARAMETER_NAME_FRONTEND)" "$(AWS_REGION)" "$(AWS_PROFILE)") && \
 	cd frontend && NEXT_PUBLIC_API_URL=$(API_URL) NEXT_PUBLIC_ENVIRONMENT=$(ENV) NEXT_PUBLIC_COGNITO_USER_POOL_ID=$(COGNITO_USER_POOL_ID) NEXT_PUBLIC_COGNITO_CLIENT_ID=$(COGNITO_CLIENT_ID) NEXT_PUBLIC_SENTRY_DSN="$$SENTRY_DSN" npm run build
 	@echo "Syncing frontend files to S3..."
 	aws s3 sync frontend/out/ s3://$(BUCKET) --delete --profile $(AWS_PROFILE)
@@ -377,6 +378,10 @@ test-codex-hooks: ## Verify Codex hook routing
 .PHONY: test-git-hook-helpers
 test-git-hook-helpers: ## Verify helper scripts used by git hooks
 	./scripts/test_changed_unit_test_targets.sh
+
+.PHONY: test-ssm-parameter-helper
+test-ssm-parameter-helper: ## Verify the optional SSM parameter lookup helper
+	./scripts/test_get_optional_ssm_parameter.sh
 
 .PHONY: test-agent-hooks
 test-agent-hooks: test-claude-hooks test-stop-hooks test-codex-hooks ## Verify Claude Code and Codex hook routing

--- a/frontend/src/lib/sentry.test.ts
+++ b/frontend/src/lib/sentry.test.ts
@@ -52,4 +52,13 @@ describe("Sentry browser config", () => {
     expect(config.replaysSessionSampleRate).toBe(0.1);
     expect(config.replaysOnErrorSampleRate).toBe(1);
   });
+
+  it("disables Sentry when the browser DSN is not configured", () => {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+    const config = getSentryBrowserConfig();
+
+    expect(config.enabled).toBe(false);
+    expect(config.dsn).toBeUndefined();
+  });
 });

--- a/scripts/get_optional_ssm_parameter.sh
+++ b/scripts/get_optional_ssm_parameter.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+parameter_name="${1:?parameter name is required}"
+aws_region="${2:?aws region is required}"
+aws_profile="${3:?aws profile is required}"
+
+if response="$(
+  aws ssm get-parameter \
+    --name "$parameter_name" \
+    --with-decryption \
+    --region "$aws_region" \
+    --profile "$aws_profile" \
+    --query 'Parameter.Value' \
+    --output text 2>&1
+)"; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+if printf '%s' "$response" | grep -q "ParameterNotFound"; then
+  exit 0
+fi
+
+printf '%s\n' "$response" >&2
+exit 1

--- a/scripts/test_get_optional_ssm_parameter.sh
+++ b/scripts/test_get_optional_ssm_parameter.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="$project_dir/scripts/get_optional_ssm_parameter.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_aws="$tmpdir/aws"
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "unexpected output" >&2
+    echo "expected: $expected" >&2
+    echo "actual: $actual" >&2
+    exit 1
+  fi
+}
+
+assert_success_with_value() {
+  local output
+
+  output="$(
+    PATH="$tmpdir:$PATH" \
+      AWS_STUB_MODE=success \
+      "$script_path" "/notes-app/prd/sentry-dsn-frontend" "ap-northeast-1" "prd"
+  )"
+
+  assert_eq "$output" "https://public@example.ingest.sentry.io/123"
+}
+
+assert_missing_parameter_returns_empty() {
+  local output
+
+  output="$(
+    PATH="$tmpdir:$PATH" \
+      AWS_STUB_MODE=missing \
+      "$script_path" "/notes-app/prd/sentry-dsn-frontend" "ap-northeast-1" "prd"
+  )"
+
+  assert_eq "$output" ""
+}
+
+assert_other_aws_errors_fail() {
+  if PATH="$tmpdir:$PATH" AWS_STUB_MODE=access-denied "$script_path" "/notes-app/prd/sentry-dsn-frontend" "ap-northeast-1" "prd" >/dev/null 2>&1; then
+    echo "expected helper to fail on non-ParameterNotFound aws errors" >&2
+    exit 1
+  fi
+}
+
+printf '%s\n' '#!/usr/bin/env bash' > "$fake_aws"
+printf '%s\n' 'set -euo pipefail' >> "$fake_aws"
+printf '%s\n' 'case "${AWS_STUB_MODE:-}" in' >> "$fake_aws"
+printf '%s\n' '  success)' >> "$fake_aws"
+printf '%s\n' "    printf '%s\\n' 'https://public@example.ingest.sentry.io/123'" >> "$fake_aws"
+printf '%s\n' '    ;;' >> "$fake_aws"
+printf '%s\n' '  missing)' >> "$fake_aws"
+printf '%s\n' "    printf '%s\\n' 'An error occurred (ParameterNotFound) when calling the GetParameter operation:' >&2" >> "$fake_aws"
+printf '%s\n' '    exit 254' >> "$fake_aws"
+printf '%s\n' '    ;;' >> "$fake_aws"
+printf '%s\n' '  access-denied)' >> "$fake_aws"
+printf '%s\n' "    printf '%s\\n' 'An error occurred (AccessDeniedException) when calling the GetParameter operation:' >&2" >> "$fake_aws"
+printf '%s\n' '    exit 254' >> "$fake_aws"
+printf '%s\n' '    ;;' >> "$fake_aws"
+printf '%s\n' '  *)' >> "$fake_aws"
+printf '%s\n' "    printf '%s\\n' 'unexpected AWS_STUB_MODE' >&2" >> "$fake_aws"
+printf '%s\n' '    exit 1' >> "$fake_aws"
+printf '%s\n' '    ;;' >> "$fake_aws"
+printf '%s\n' 'esac' >> "$fake_aws"
+chmod +x "$fake_aws"
+
+assert_success_with_value
+assert_missing_parameter_returns_empty
+assert_other_aws_errors_fail


### PR DESCRIPTION
## 概要

本番 frontend デプロイが Sentry DSN の SSM パラメータ未登録時に `ParameterNotFound` で失敗していたため、DSN を任意扱いにしてデプロイを継続できるようにしました。

## 変更内容

- frontend build と `_deploy-frontend` が、SSM パラメータ未登録時に空文字を返す helper script を使うよう変更
- `ParameterNotFound` のみ握りつぶし、それ以外の AWS エラーは従来どおり失敗させる shell helper とテストを追加
- browser DSN 未設定時に Sentry が無効化される frontend テストを追加

## テスト方法

- [x] `make test-ssm-parameter-helper`
- [x] `make test-frontend`
- [x] pre-commit hooks
- [x] pre-push hooks
- [x] `make deploy ENV=prd`

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）