### PR TITLE
fix: avoid bootstrap fetch errors in prd

### DIFF
--- a/frontend/src/contexts/LanguageContext.test.tsx
+++ b/frontend/src/contexts/LanguageContext.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getApiMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useApi: () => ({
+    getApi: getApiMock,
+  }),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+import { LanguageProvider, useLanguage } from "./LanguageContext";
+
+function LanguageConsumer() {
+  const { isLoading, language } = useLanguage();
+
+  return (
+    <>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="language">{language}</span>
+    </>
+  );
+}
+
+describe("LanguageProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips loading settings while unauthenticated", async () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+
+    render(
+      <LanguageProvider>
+        <LanguageConsumer />
+      </LanguageProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("language")).toHaveTextContent("auto");
+    expect(getApiMock).not.toHaveBeenCalled();
+  });
+
+  it("loads the persisted language after authentication is ready", async () => {
+    const getSettingsMock = vi.fn().mockResolvedValue({
+      settings: {
+        language: "ja",
+      },
+    });
+
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    getApiMock.mockResolvedValue({
+      getSettings: getSettingsMock,
+    });
+
+    render(
+      <LanguageProvider>
+        <LanguageConsumer />
+      </LanguageProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("language")).toHaveTextContent("ja");
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(getApiMock).toHaveBeenCalledTimes(1);
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from "react";
 import { ja, en, type TranslationKeys, type Language } from "@/locales";
 import { useApi } from "@/hooks";
+import { useAuth } from "@/lib/auth-context";
 
 interface LanguageContextType {
   language: Language;
@@ -26,27 +27,58 @@ function getTranslations(effectiveLanguage: "ja" | "en"): TranslationKeys {
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const { getApi } = useApi();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const [language, setLanguageState] = useState<Language>("auto");
   const [isLoading, setIsLoading] = useState(true);
 
   // Load language setting from backend on mount
   useEffect(() => {
+    let isActive = true;
+
     async function loadLanguage() {
+      if (authLoading) {
+        return;
+      }
+
+      if (!isAuthenticated) {
+        if (!isActive) {
+          return;
+        }
+
+        setLanguageState("auto");
+        setIsLoading(false);
+        return;
+      }
+
       try {
         const apiClient = await getApi();
         const response = await apiClient.getSettings();
+        if (!isActive) {
+          return;
+        }
+
         setLanguageState(response.settings.language as Language);
       } catch (error) {
+        if (!isActive) {
+          return;
+        }
+
         console.error("Failed to load language settings:", error);
         // Fall back to auto
         setLanguageState("auto");
       } finally {
-        setIsLoading(false);
+        if (isActive) {
+          setIsLoading(false);
+        }
       }
     }
 
-    loadLanguage();
-  }, [getApi]);
+    void loadLanguage();
+
+    return () => {
+      isActive = false;
+    };
+  }, [authLoading, getApi, isAuthenticated]);
 
   const setLanguage = useCallback((newLanguage: Language) => {
     setLanguageState(newLanguage);

--- a/frontend/src/hooks/useHomeData.test.ts
+++ b/frontend/src/hooks/useHomeData.test.ts
@@ -119,4 +119,35 @@ describe("useHomeData", () => {
     expect(notesDB.getAllFolders).not.toHaveBeenCalled();
     expect(notesDB.getAllNotes).not.toHaveBeenCalled();
   });
+
+  it("does not log snapshot failures after the hook unmounts", async () => {
+    const getWorkspaceSnapshotMock = vi.fn();
+    let rejectSnapshot: (error: unknown) => void = () => undefined;
+
+    vi.mocked(notesDB.getAllFolders).mockResolvedValue([]);
+    vi.mocked(notesDB.getAllNotes).mockResolvedValue([]);
+    getWorkspaceSnapshotMock.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectSnapshot = reject;
+      })
+    );
+    getApiMock.mockResolvedValue({
+      getWorkspaceSnapshot: getWorkspaceSnapshotMock,
+    });
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { unmount } = renderHook(() => useHomeData(true));
+
+    await waitFor(() => {
+      expect(getWorkspaceSnapshotMock).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    rejectSnapshot(new TypeError("Failed to fetch"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/frontend/src/hooks/useTokenUsage.test.ts
+++ b/frontend/src/hooks/useTokenUsage.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getApiMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock("./useApi", () => ({
+  useApi: () => ({
+    getApi: getApiMock,
+  }),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+import { useTokenUsage } from "./useTokenUsage";
+
+describe("useTokenUsage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("waits for auth to finish before requesting settings", () => {
+    useAuthMock.mockReturnValue({ isLoading: true });
+
+    renderHook(() => useTokenUsage(true));
+
+    expect(getApiMock).not.toHaveBeenCalled();
+  });
+
+  it("loads token usage once the user is authenticated", async () => {
+    const getSettingsMock = vi.fn().mockResolvedValue({
+      token_usage: {
+        tokens_used: 12,
+        monthly_limit: 1000,
+      },
+    });
+
+    useAuthMock.mockReturnValue({ isLoading: false });
+    getApiMock.mockResolvedValue({
+      getSettings: getSettingsMock,
+    });
+
+    const { result } = renderHook(() => useTokenUsage(true));
+
+    await waitFor(() => {
+      expect(result.current.tokenUsage).toEqual({
+        tokens_used: 12,
+        monthly_limit: 1000,
+      });
+    });
+
+    expect(getApiMock).toHaveBeenCalledTimes(1);
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useTokenUsage.ts
+++ b/frontend/src/hooks/useTokenUsage.ts
@@ -3,13 +3,15 @@
 import { useState, useCallback, useEffect } from "react";
 import { useApi } from "./useApi";
 import type { TokenUsageRead } from "@/types";
+import { useAuth } from "@/lib/auth-context";
 
 export function useTokenUsage(isAuthenticated: boolean) {
     const { getApi } = useApi();
+    const { isLoading: authLoading } = useAuth();
     const [tokenUsage, setTokenUsage] = useState<TokenUsageRead | null>(null);
 
     const fetchTokenUsage = useCallback(async () => {
-        if (!isAuthenticated) return;
+        if (authLoading || !isAuthenticated) return;
         try {
             const apiClient = await getApi();
             const response = await apiClient.getSettings();
@@ -19,12 +21,11 @@ export function useTokenUsage(isAuthenticated: boolean) {
         } catch (error) {
             console.error("Failed to fetch token usage:", error);
         }
-    }, [isAuthenticated, getApi]);
+    }, [authLoading, isAuthenticated, getApi]);
 
     useEffect(() => {
-        fetchTokenUsage();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isAuthenticated, getApi]);
+        void fetchTokenUsage();
+    }, [fetchTokenUsage]);
 
     const recordUsage = useCallback((tokens: number) => {
         setTokenUsage((prev) =>

--- a/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
@@ -28,9 +28,13 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
   }, []);
 
   useEffect(() => {
+    let isActive = true;
+
     async function loadData() {
       if (!isAuthenticated) {
-        setIsLoading(false);
+        if (isActive) {
+          setIsLoading(false);
+        }
         return;
       }
 
@@ -46,6 +50,10 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
         ]);
 
         if (localFolders.length > 0 || localNotes.length > 0) {
+          if (!isActive) {
+            return;
+          }
+
           setFolders(localFolders);
           setNotes(localNotes);
           setIsLoading(false);
@@ -54,6 +62,10 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
         if (navigator.onLine) {
           const apiClient = await getApi();
           const snapshot = await apiClient.getWorkspaceSnapshot();
+          if (!isActive) {
+            return;
+          }
+
           const serverFolders = getActiveFolders(snapshot);
           const serverNotes = getActiveNotes(snapshot);
 
@@ -63,15 +75,23 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
           await persistWorkspaceSnapshot(snapshot);
         }
       } catch (error) {
-        console.error("Failed to load data:", error);
+        if (isActive) {
+          console.error("Failed to load data:", error);
+        }
       } finally {
-        setIsLoading(false);
+        if (isActive) {
+          setIsLoading(false);
+        }
       }
     }
 
     if (!authLoading) {
       void loadData();
     }
+
+    return () => {
+      isActive = false;
+    };
   }, [authLoading, getApi, isAuthenticated]);
 
   useEffect(() => {


### PR DESCRIPTION
## 概要

prd 環境の初期表示時に、認証確立前の設定取得やアンロード後の snapshot 取得が走り、`401` や `Failed to fetch` が console に出る問題を抑制します。

## 変更内容

- `LanguageContext` と `useTokenUsage` で、認証状態の確定前は `/api/settings` を呼ばないように修正
- `useWorkspaceSnapshotState` で、unmount 後の snapshot 取得失敗を無視して不要な console error を出さないように修正
- 上記の回帰を防ぐ frontend テストを追加

## テスト方法

- [x] `cd frontend && npm run test -- --run src/contexts/LanguageContext.test.tsx src/hooks/useTokenUsage.test.ts src/hooks/useHomeData.test.ts`
- [x] pre-push hook により `backend` unit/integration、`frontend` unit、`lambda` unit を実行
- [x] `make deploy-frontend ENV=prd` 実施後、`notes.devtools.site` でログイン直後の console error が出ないことを確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）