### PR TITLE
feature: exponential backoff retry for editor save failures

### DIFF
--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -665,7 +665,7 @@ export function EditorPanel({
   let statusColorClass = "";
 
   // Destructure syncStatus
-  const { remote: remoteStatus, lastError, isSaving } = syncStatus;
+  const { remote: remoteStatus, lastError, isSaving, retryCountdown } = syncStatus;
 
   // Hash-based Verification Logic
   // If no savedHash is available yet (initial load), fall back to remoteStatus checks temporarily
@@ -684,6 +684,9 @@ export function EditorPanel({
     // Remote Failed
     statusIcon = <CheckIcon className="h-3 w-3" />;
     statusText = t("sync.failedSavedLocally");
+    if (retryCountdown !== undefined) {
+      statusText += " " + t("sync.retryingIn").replace("{{seconds}}", String(retryCountdown));
+    }
     statusTooltip = t("sync.remoteSaveFailed");
     statusColorClass = "text-orange-500";
   } else if (isStrictlyMismatch || isLooselyMismatch) {

--- a/frontend/src/lib/sync/syncConfig.ts
+++ b/frontend/src/lib/sync/syncConfig.ts
@@ -1,0 +1,5 @@
+export const SYNC_RETRY_CONFIG = {
+  maxRetryAttempts: 3,
+  retryBaseDelayMs: 2000,
+  retryMaxDelayMs: 30000,
+} as const;

--- a/frontend/src/lib/sync/types.ts
+++ b/frontend/src/lib/sync/types.ts
@@ -6,4 +6,5 @@ export interface SyncStatus {
   remote: RemoteSyncStatus;
   lastError?: string;
   isSaving: boolean;
+  retryCountdown?: number; // seconds until next retry; undefined = not retrying
 }

--- a/frontend/src/lib/sync/useNoteSyncEngine.test.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.test.ts
@@ -18,6 +18,7 @@ const translationMap = {
   "sync.offlineSyncUnavailable": "Cannot sync while offline",
   "sync.localSaveFailed": "Failed to save locally",
   "sync.conflictReloaded": "Conflict reloaded",
+  "sync.retryingIn": "Retrying in {{seconds}}s...",
 } as const;
 const refreshWorkspaceSnapshotMock = vi.fn();
 const onSnapshotSyncedMock = vi.fn();
@@ -91,6 +92,7 @@ function useNoteSyncEngineHarness(
   return {
     notes,
     selectedNoteId,
+    setSelectedNoteId,
     ...useNoteSyncEngine({
       setNotes,
       selectedFolderId,
@@ -309,5 +311,280 @@ describe("useNoteSyncEngine", () => {
     expect(syncQueue.addChange).not.toHaveBeenCalled();
     expect(result.current.syncStatus.remote).toBe("failed");
     expect(result.current.syncStatus.lastError).toBe("Conflict reloaded");
+  });
+
+  describe("retry behavior", () => {
+    it("fires a first retry after 2s on server failure, then succeeds", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const updatedServerNote = buildNote({ content: "Synced", version: 2 });
+      const snapshot = {
+        folders: [],
+        notes: [updatedServerNote],
+        cursor: "cursor-2",
+        server_time: "2024-01-02T00:00:00.000Z",
+      };
+      const applyWorkspaceChanges = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockResolvedValueOnce({
+          applied: [{ entity: "note", operation: "update", entity_id: initialNote.id, client_mutation_id: null, folder: null, note: updatedServerNote }],
+          snapshot,
+        });
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "New content" });
+      });
+
+      // Advance past debounce (5s) to trigger first sync attempt
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+
+      // After failure, retryCountdown should be set to 2
+      expect(result.current.syncStatus.remote).toBe("failed");
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+
+      // Advance 1s — countdown ticks to 1
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(result.current.syncStatus.retryCountdown).toBe(1);
+
+      // Advance another 1s — retry fires, countdown clears
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(result.current.syncStatus.remote).toBe("synced");
+      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("countdown decrements each second after failure", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const applyWorkspaceChanges = vi.fn().mockRejectedValue(new Error("Server error"));
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(1);
+
+      // At 2s: retry fires, fails, sets countdown for next attempt (4s)
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(4);
+
+      vi.useRealTimers();
+    });
+
+    it("uses exponential backoff delays: 2s, 4s, 8s", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const applyWorkspaceChanges = vi.fn().mockRejectedValue(new Error("Server error"));
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
+      });
+
+      // First call via debounce
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(1);
+
+      // Retry attempt 0 → fires after 2s, next delay 4s
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(4);
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(2);
+
+      // Retry attempt 1 → fires after 4s, next delay 8s
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(8);
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(3);
+
+      vi.useRealTimers();
+    });
+
+    it("exhausts after maxRetryAttempts and stays failed with no countdown", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const applyWorkspaceChanges = vi.fn().mockRejectedValue(new Error("Server error"));
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
+      });
+
+      // Initial call
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+
+      // Attempt 0 (2s delay)
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(4);
+
+      // Attempt 1 (4s delay)
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(8);
+
+      // Attempt 2 (8s delay) — last attempt (maxRetryAttempts = 3)
+      await act(async () => { await vi.advanceTimersByTimeAsync(8000); });
+      expect(result.current.syncStatus.remote).toBe("failed");
+      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
+
+      // 1 initial + 3 retries = 4 total calls
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(4);
+
+      vi.useRealTimers();
+    });
+
+    it("cancels pending retry when a new edit is made", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const updatedServerNote = buildNote({ content: "New edit synced", version: 2 });
+      const applyWorkspaceChanges = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockResolvedValue({
+          applied: [{ entity: "note", operation: "update", entity_id: initialNote.id, client_mutation_id: null, folder: null, note: updatedServerNote }],
+          snapshot: { folders: [], notes: [updatedServerNote], cursor: "cursor-2", server_time: "2024-01-02T00:00:00.000Z" },
+        });
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      // First edit → debounce → fail → countdown starts
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit 1" });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+
+      // New edit cancels retry
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit 2" });
+      });
+
+      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
+
+      // Advance well past the old retry delay — old retry should NOT fire
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      // Only the initial failed call; no retry from old countdown
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it("cancels pending retry on note switch", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote({ id: "note-1" });
+      const applyWorkspaceChanges = vi.fn().mockRejectedValue(new Error("Server error"));
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, "note-1")
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+
+      // Switch note — triggers useEffect([selectedNoteId]) which cancels retry
+      await act(async () => {
+        result.current.setSelectedNoteId("note-2");
+      });
+      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
+
+      // Advance past retry delay — retry should NOT fire
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it("does not retry on conflict errors (409)", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const applyWorkspaceChanges = vi
+        .fn()
+        .mockRejectedValueOnce(new ApiError(409, "Conflict", { detail: "stale version" }));
+      const apiClient = {
+        applyWorkspaceChanges,
+        getWorkspaceSnapshot: vi.fn(),
+      };
+      getApiMock.mockResolvedValue(apiClient);
+      refreshWorkspaceSnapshotMock.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+
+      expect(result.current.syncStatus.remote).toBe("failed");
+      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useTranslation } from "@/hooks/useTranslation";
 import { notesDB } from "@/lib/indexedDB";
@@ -16,6 +16,7 @@ import { useApi } from "@/hooks/useApi";
 import type { Note, WorkspaceSnapshotResponse } from "@/types";
 
 import { useDebouncedAsync } from "./useDebouncedAsync";
+import { SYNC_RETRY_CONFIG } from "./syncConfig";
 import type { LocalSyncStatus, RemoteSyncStatus, SyncStatus } from "./types";
 
 const NOOP_SNAPSHOT_SYNC: (snapshot: WorkspaceSnapshotResponse) => void = () => {};
@@ -56,7 +57,13 @@ export function useNoteSyncEngine({
   const [remoteStatus, setRemoteStatus] = useState<RemoteSyncStatus>("synced");
   const [lastError, setLastError] = useState<string | undefined>(undefined);
   const [savedHashes, setSavedHashes] = useState<Record<string, string>>({});
+  const [retryCountdown, setRetryCountdown] = useState<number | undefined>(undefined);
   const activeSavePromiseRef = useRef<Promise<void> | null>(null);
+  const retryAttemptRef = useRef<number>(0);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const retryArgsRef = useRef<{ id: string; updates: NoteSyncUpdates; expectedVersion?: number } | null>(null);
+  const syncNoteToServerRef = useRef<((id: string, updates: NoteSyncUpdates, expectedVersion?: number) => Promise<void>) | null>(null);
   const handleSnapshotSynced = onSnapshotSynced ?? NOOP_SNAPSHOT_SYNC;
 
   const syncNoteToServer = useCallback(
@@ -96,6 +103,9 @@ export function useNoteSyncEngine({
             const hash = await calculateHash(serverNote.content);
             setSavedHashes((prev) => ({ ...prev, [id]: hash }));
 
+            retryAttemptRef.current = 0;
+            retryArgsRef.current = null;
+            setRetryCountdown(undefined);
             setRemoteStatus("synced");
             setLocalStatus("saved");
           } catch (error) {
@@ -114,6 +124,43 @@ export function useNoteSyncEngine({
             });
             setRemoteStatus("failed");
             setLastError(t("sync.serverSyncFailed"));
+
+            const attempt = retryAttemptRef.current;
+            if (attempt < SYNC_RETRY_CONFIG.maxRetryAttempts) {
+              const delayMs = Math.min(
+                SYNC_RETRY_CONFIG.retryBaseDelayMs * Math.pow(2, attempt),
+                SYNC_RETRY_CONFIG.retryMaxDelayMs
+              );
+              const delaySec = Math.round(delayMs / 1000);
+              retryArgsRef.current = { id, updates, expectedVersion };
+              setRetryCountdown(delaySec);
+
+              retryIntervalRef.current = setInterval(() => {
+                setRetryCountdown((prev) => {
+                  if (prev === undefined || prev <= 1) {
+                    clearInterval(retryIntervalRef.current!);
+                    retryIntervalRef.current = null;
+                    return 0;
+                  }
+                  return prev - 1;
+                });
+              }, 1000);
+
+              retryTimeoutRef.current = setTimeout(() => {
+                retryTimeoutRef.current = null;
+                clearInterval(retryIntervalRef.current!);
+                retryIntervalRef.current = null;
+                setRetryCountdown(undefined);
+                const args = retryArgsRef.current;
+                retryArgsRef.current = null;
+                if (args && syncNoteToServerRef.current) {
+                  retryAttemptRef.current += 1;
+                  void syncNoteToServerRef.current(args.id, args.updates, args.expectedVersion);
+                }
+              }, delayMs);
+            } else {
+              setRetryCountdown(undefined); // exhausted, stay failed
+            }
           } finally {
             if (activeSavePromiseRef.current === currentPromise) {
               activeSavePromiseRef.current = null;
@@ -135,6 +182,10 @@ export function useNoteSyncEngine({
     },
     [getApi, handleSnapshotSynced, setNotes, t]
   );
+
+  useEffect(() => {
+    syncNoteToServerRef.current = syncNoteToServer;
+  }, [syncNoteToServer]);
 
   const {
     debounced: debouncedServerSync,
@@ -234,6 +285,14 @@ export function useNoteSyncEngine({
 
   const handleUpdateNote = useCallback(
     async (id: string, updates: NoteSyncUpdates) => {
+      clearTimeout(retryTimeoutRef.current ?? undefined);
+      clearInterval(retryIntervalRef.current ?? undefined);
+      retryTimeoutRef.current = null;
+      retryIntervalRef.current = null;
+      retryAttemptRef.current = 0;
+      retryArgsRef.current = null;
+      setRetryCountdown(undefined);
+
       let noteForLocalSave: Note | undefined;
       setNotes((prev) => {
         noteForLocalSave = prev.find((note) => note.id === id);
@@ -355,12 +414,32 @@ export function useNoteSyncEngine({
     [flushServerSync]
   );
 
+  // Cancel retry on note switch
+  useEffect(() => {
+    clearTimeout(retryTimeoutRef.current ?? undefined);
+    clearInterval(retryIntervalRef.current ?? undefined);
+    retryTimeoutRef.current = null;
+    retryIntervalRef.current = null;
+    retryAttemptRef.current = 0;
+    retryArgsRef.current = null;
+    setRetryCountdown(undefined);
+  }, [selectedNoteId]);
+
+  // Cancel retry on unmount
+  useEffect(() => {
+    return () => {
+      if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+      if (retryIntervalRef.current) clearInterval(retryIntervalRef.current);
+    };
+  }, []);
+
   return {
     syncStatus: {
       local: localStatus,
       remote: remoteStatus,
       lastError,
       isSaving: remoteStatus === "syncing",
+      retryCountdown,
     },
     savedHashes,
     handleCreateNote,

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -227,6 +227,7 @@ export const en = {
     offlineSyncUnavailable: "Cannot sync while offline",
     localSaveFailed: "Failed to save locally",
     conflictReloaded: "A sync conflict was detected, so the latest server state was reloaded",
+    retryingIn: "Retrying in {{seconds}}s...",
   },
 
   // Share
@@ -459,6 +460,7 @@ export type TranslationKeys = {
     offlineSyncUnavailable: string;
     localSaveFailed: string;
     conflictReloaded: string;
+    retryingIn: string;
   };
   share: {
     title: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -227,6 +227,7 @@ export const ja = {
     offlineSyncUnavailable: "オフラインのため同期できません",
     localSaveFailed: "ローカル保存に失敗しました",
     conflictReloaded: "競合を検出したため最新状態を再読み込みしました",
+    retryingIn: "{{seconds}}秒後にリトライ...",
   },
 
   // Share
@@ -456,6 +457,7 @@ export type TranslationKeys = {
     offlineSyncUnavailable: string;
     localSaveFailed: string;
     conflictReloaded: string;
+    retryingIn: string;
   };
   share: {
     title: string;


### PR DESCRIPTION
## 概要

保存がサーバーで失敗した際に、最大3回まで指数バックオフ（2s → 4s → 8s）で自動リトライするようにしました。エディターのステータスバーにカウントダウンが表示されるため、ユーザーはリトライが予定されていることを確認できます。

## 変更内容

- `frontend/src/lib/sync/syncConfig.ts` (新規) — リトライ設定定数（`maxRetryAttempts: 3`, `retryBaseDelayMs: 2000`, `retryMaxDelayMs: 30000`）
- `frontend/src/lib/sync/types.ts` — `SyncStatus` に `retryCountdown?: number` を追加
- `frontend/src/lib/sync/useNoteSyncEngine.ts` — 指数バックオフのリトライロジック実装（タイマー管理、キャンセル処理、ref による参照更新）
- `frontend/src/locales/en.ts` / `ja.ts` — `retryingIn` 翻訳キーを追加
- `frontend/src/components/layout/EditorPanel.tsx` — 失敗時のステータステキストにカウントダウンを付加（例：`"Sync failed (saved locally) Retrying in 2s..."`）
- `frontend/src/lib/sync/useNoteSyncEngine.test.ts` — リトライ挙動を網羅する7つのテストを追加

## テスト方法

- [ ] `make test-frontend` が全144テストを通過すること
- [ ] dev環境で編集中にオフライン状態を模擬し、「Retrying in 2s...」のカウントダウンが表示されること
- [ ] 3回リトライ後にカウントダウンが消えてフェイルドのまま残ること
- [ ] カウントダウン中に新しい編集をするとリトライがキャンセルされること
- [ ] コンフリクトエラー（409）ではリトライが発生しないこと

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）