### PR TITLE
fix: disable IPv6 on CloudFront to fix Mac/iPhone connection failures

### DIFF
--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -122,7 +122,7 @@ EOF
 # CloudFront Distribution
 resource "aws_cloudfront_distribution" "main" {
   enabled             = true
-  is_ipv6_enabled     = true
+  is_ipv6_enabled     = false
   default_root_object = "index.html"
   aliases             = [local.current_env.domain_name, local.current_env.admin_domain_name]
   price_class         = "PriceClass_200"
@@ -228,35 +228,10 @@ resource "aws_route53_record" "main" {
   }
 }
 
-# Route53 AAAA record for CloudFront (IPv6)
-resource "aws_route53_record" "main_ipv6" {
-  zone_id = data.aws_route53_zone.main.zone_id
-  name    = local.current_env.domain_name
-  type    = "AAAA"
-
-  alias {
-    name                   = aws_cloudfront_distribution.main.domain_name
-    zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "admin" {
   zone_id = data.aws_route53_zone.main.zone_id
   name    = local.current_env.admin_domain_name
   type    = "A"
-
-  alias {
-    name                   = aws_cloudfront_distribution.main.domain_name
-    zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "admin_ipv6" {
-  zone_id = data.aws_route53_zone.main.zone_id
-  name    = local.current_env.admin_domain_name
-  type    = "AAAA"
 
   alias {
     name                   = aws_cloudfront_distribution.main.domain_name


### PR DESCRIPTION
## 概要

Mac Chrome・iPhone Safari で `ERR_SOCKET_NOT_CONNECTED` や「サーバーが見つかりません」エラーが発生していた。原因は CloudFront の AAAA レコードへの IPv6 接続が一部の環境で失敗していたこと。`is_ipv6_enabled = false` に変更し、IPv4 のみに統一することで解消する。

## 変更内容

- `terraform/s3_cloudfront.tf`: `aws_cloudfront_distribution.main` の `is_ipv6_enabled` を `true` → `false` に変更
- `terraform/s3_cloudfront.tf`: `aws_route53_record.main_ipv6`（notes.devtools.site の AAAA レコード）を削除
- `terraform/s3_cloudfront.tf`: `aws_route53_record.admin_ipv6`（admin.notes.devtools.site の AAAA レコード）を削除

## テスト方法

- [x] dev 環境に `terraform apply` 適用済み（AAAA レコード2件削除・CloudFront IPv6無効化）
- [x] prd 環境に `terraform apply` 適用済み
- [ ] `dig notes.devtools.site AAAA` で AAAA レコードが返らないことを確認
- [ ] Mac Chrome でアクセスして接続できることを確認
- [ ] iPhone Safari でアクセスして接続できることを確認

## チェックリスト

- [x] テストを追加・更新した（Terraform のみの変更のためアプリテスト不要）
- [x] ドキュメントを更新した（該当なし）
- [x] ユーザー向けテキストの i18n 対応を行った（該当なし）