### PR TITLE
feat: add note print preview

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -274,6 +274,78 @@
   top: -1px;
 }
 
+.note-print-content {
+  display: none;
+}
+
+@media print {
+  body.printing-note-preview * {
+    visibility: hidden !important;
+  }
+
+  body.printing-note-preview .note-print-root,
+  body.printing-note-preview .note-print-root * {
+    visibility: visible !important;
+  }
+
+  body.printing-note-preview .note-print-root {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: auto;
+    overflow: visible !important;
+    background: white !important;
+    color: black !important;
+  }
+
+  body.printing-note-preview .note-print-screen {
+    display: none !important;
+  }
+
+  body.printing-note-preview .note-print-content {
+    display: block !important;
+    padding: 24px 32px 32px;
+  }
+
+  body.printing-note-preview .note-print-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 1.5rem;
+    line-height: 1.2;
+    color: black;
+  }
+
+  body.printing-note-preview .note-print-content .markdown-preview {
+    color: black;
+  }
+
+  body.printing-note-preview .note-print-content .markdown-preview table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  body.printing-note-preview .note-print-content .markdown-preview th,
+  body.printing-note-preview .note-print-content .markdown-preview td {
+    border: 1px solid black !important;
+    padding: 0.5rem;
+  }
+
+  body.printing-note-preview .note-print-content .markdown-preview th {
+    background: #f3f4f6 !important;
+    color: black;
+    font-weight: 600;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  body.printing-note-preview .note-print-content .markdown-preview pre,
+  body.printing-note-preview .note-print-content .markdown-preview blockquote,
+  body.printing-note-preview .note-print-content .markdown-preview table,
+  body.printing-note-preview .note-print-content .markdown-preview img {
+    break-inside: avoid;
+  }
+}
+
 /* Search Highlight */
 .search-highlight {
   background-color: var(--warning);
@@ -286,4 +358,3 @@
   background-color: rgba(255, 200, 0, 0.3);
   color: inherit;
 }
-

--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -1,5 +1,5 @@
 
-import { render, screen, fireEvent, act, createEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act, createEvent, within } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EditorPanel } from './EditorPanel'
 import type { Note } from '@/types'
@@ -131,6 +131,7 @@ describe('EditorPanel', () => {
   afterEach(() => {
     localStorage.clear()
     setViewportWidth(1280)
+    document.body.classList.remove('printing-note-preview')
   })
 
   it('renders with initial content', () => {
@@ -232,7 +233,65 @@ describe('EditorPanel', () => {
     fireEvent.click(previewButton)
 
     // Preview should be visible with the content
-    expect(screen.getByTestId('markdown-preview')).toBeInTheDocument()
+    expect(screen.getAllByTestId('markdown-preview')).toHaveLength(2)
+  })
+
+  it('prints the rendered preview content and cleans up print mode', async () => {
+    const printMock = vi.fn()
+    const originalPrint = window.print
+    const originalRequestAnimationFrame = window.requestAnimationFrame
+    const originalCancelAnimationFrame = window.cancelAnimationFrame
+
+    Object.defineProperty(window, 'print', {
+      value: printMock,
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      value: vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      }),
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      value: vi.fn(),
+      writable: true,
+      configurable: true,
+    })
+
+    render(<EditorPanel {...defaultProps} />)
+
+    fireEvent.change(screen.getByTestId('editor-title-input'), { target: { value: 'Printed title' } })
+    fireEvent.change(screen.getByRole('textbox', { name: /content/i }), { target: { value: '# Printed body' } })
+    fireEvent.click(screen.getByTestId('editor-print-button'))
+
+    const printPreview = screen.getByTestId('editor-print-preview')
+    expect(within(printPreview).getByText('Printed title')).toBeInTheDocument()
+    expect(within(printPreview).getByText('# Printed body')).toBeInTheDocument()
+    expect(document.body).toHaveClass('printing-note-preview')
+    expect(printMock).toHaveBeenCalledTimes(1)
+
+    fireEvent(window, new Event('afterprint'))
+
+    expect(document.body).not.toHaveClass('printing-note-preview')
+
+    Object.defineProperty(window, 'print', {
+      value: originalPrint,
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      value: originalRequestAnimationFrame,
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      value: originalCancelAnimationFrame,
+      writable: true,
+      configurable: true,
+    })
   })
 
   it('shows a resize handle for desktop preview mode', () => {

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -9,7 +9,7 @@ import type { Note, Folder, TokenUsageRead, EditProposal } from "@/types";
 import { DiffView } from "@/components/ai/DiffView";
 import { useApi, useTranslation } from "@/hooks";
 import { TokenUsageIndicator } from "@/components/TokenUsageIndicator";
-import { SparklesIcon, TrashIcon, MessageSquareIcon, FolderIcon, ChevronDownIcon, Loader2Icon, CheckIcon, DownloadIcon, EyeIcon, EyeOffIcon, HashIcon, Share2Icon, Maximize2Icon, Minimize2Icon } from "lucide-react";
+import { SparklesIcon, TrashIcon, MessageSquareIcon, FolderIcon, ChevronDownIcon, Loader2Icon, CheckIcon, DownloadIcon, EyeIcon, EyeOffIcon, HashIcon, Share2Icon, Maximize2Icon, Minimize2Icon, PrinterIcon } from "lucide-react";
 import { useEffect, useState, useRef, useCallback, useMemo, KeyboardEvent, useDeferredValue } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
@@ -33,6 +33,7 @@ const MIN_PREVIEW_WIDTH_PX = 280;
 const PREVIEW_RESIZE_HANDLE_WIDTH_PX = 8;
 const EDITOR_PREVIEW_WIDTH_STORAGE_KEY = "notes-editor-preview-width";
 const EDITOR_PREVIEW_LAST_WIDTH_STORAGE_KEY = "notes-editor-preview-last-width";
+const PRINT_MODE_BODY_CLASS = "printing-note-preview";
 
 interface EditorPanelProps {
   note: Note | null;
@@ -869,6 +870,33 @@ export function EditorPanel({
     downloadFile(text, filename, "text/plain");
   };
 
+  const handlePrintPreview = useCallback(() => {
+    if (!note) {
+      return;
+    }
+
+    let isCleanedUp = false;
+
+    const cleanupPrintMode = () => {
+      if (isCleanedUp) {
+        return;
+      }
+
+      isCleanedUp = true;
+      document.body.classList.remove(PRINT_MODE_BODY_CLASS);
+      window.removeEventListener("afterprint", cleanupPrintMode);
+    };
+
+    document.body.classList.add(PRINT_MODE_BODY_CLASS);
+    window.addEventListener("afterprint", cleanupPrintMode);
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.print();
+      });
+    });
+  }, [note]);
+
   const currentFolder = folders.find((f) => f.id === note?.folder_id);
 
   if (!note) {
@@ -935,7 +963,29 @@ export function EditorPanel({
   // --- SAVE STATUS LOGIC END ---
 
   return (
-    <div ref={fullscreenContainerRef} className={isFullscreen ? "flex flex-col bg-background overflow-hidden w-full h-full" : "flex-1 flex flex-col overflow-hidden"}>
+    <div
+      ref={fullscreenContainerRef}
+      className={cn(
+        "note-print-root",
+        isFullscreen ? "flex flex-col bg-background overflow-hidden w-full h-full" : "flex-1 flex flex-col overflow-hidden"
+      )}
+    >
+      <div
+        className="note-print-content"
+        aria-hidden="true"
+        data-testid="editor-print-preview"
+      >
+        <h1 className="note-print-title">{title || t("noteList.untitled")}</h1>
+        <div className="markdown-preview prose prose-sm max-w-none">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkSourceLine]}
+            components={markdownComponents}
+          >
+            {content || `*${t("editor.previewPlaceholder")}*`}
+          </ReactMarkdown>
+        </div>
+      </div>
+      <div className="note-print-screen flex flex-1 flex-col overflow-hidden">
       {/* Toolbar */}
       <div className="flex items-center justify-between p-4 md:p-4 p-2 border-b border-border/50">
         <div className="flex items-center gap-1 md:gap-2 flex-wrap">
@@ -1076,14 +1126,25 @@ export function EditorPanel({
               data-testid={isDesktopViewport
                 ? (isEditorCollapsed ? "editor-show-button" : "editor-hide-button")
                 : "editor-show-button"}
-            >
-              <span>
+          >
+            <span>
                 {isDesktopViewport
                   ? (isEditorCollapsed ? t("editor.showEditor") : t("editor.hideEditor"))
                   : t("editor.showEditor")}
               </span>
             </Button>
           )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handlePrintPreview}
+            className="gap-1 md:gap-2"
+            aria-label={t("editor.printPreview")}
+            data-testid="editor-print-button"
+          >
+            <PrinterIcon className="h-4 w-4" />
+            <span className="hidden md:inline">{t("editor.print")}</span>
+          </Button>
           {/* Share Button */}
           <Button
             variant="ghost"
@@ -1349,6 +1410,7 @@ export function EditorPanel({
           }
         }}
       />
+      </div>
     </div>
   );
 }

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -123,6 +123,7 @@ export const en = {
     chat: "Chat",
     export: "Export",
     preview: "Preview",
+    print: "Print",
     markdown: "Markdown (.md)",
     plainText: "Plain Text (.txt)",
     previewPlaceholder: "Start writing to see the preview...",
@@ -134,6 +135,7 @@ export const en = {
     summarizeNote: "Summarize note",
     toggleChat: "Toggle chat",
     exportNote: "Export note",
+    printPreview: "Print preview",
     share: "Share",
     shareNote: "Share note",
     uploading: "Uploading...",
@@ -371,6 +373,7 @@ export type TranslationKeys = {
     chat: string;
     export: string;
     preview: string;
+    print: string;
     markdown: string;
     plainText: string;
     previewPlaceholder: string;
@@ -382,6 +385,7 @@ export type TranslationKeys = {
     summarizeNote: string;
     toggleChat: string;
     exportNote: string;
+    printPreview: string;
     share: string;
     shareNote: string;
     uploading: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -123,6 +123,7 @@ export const ja = {
     chat: "チャット",
     export: "エクスポート",
     preview: "プレビュー",
+    print: "印刷",
     markdown: "Markdown (.md)",
     plainText: "プレーンテキスト (.txt)",
     previewPlaceholder: "プレビューを見るには書き始めてください...",
@@ -134,6 +135,7 @@ export const ja = {
     summarizeNote: "ノートを要約",
     toggleChat: "チャットを切り替え",
     exportNote: "ノートをエクスポート",
+    printPreview: "プレビューを印刷",
     share: "共有",
     shareNote: "ノートを共有",
     uploading: "アップロード中...",
@@ -370,6 +372,7 @@ export type TranslationKeys = {
     chat: string;
     export: string;
     preview: string;
+    print: string;
     markdown: string;
     plainText: string;
     previewPlaceholder: string;
@@ -381,6 +384,7 @@ export type TranslationKeys = {
     summarizeNote: string;
     toggleChat: string;
     exportNote: string;
+    printPreview: string;
     share: string;
     shareNote: string;
     uploading: string;


### PR DESCRIPTION
## 概要

ノート編集画面に印刷アクションを追加し、現在のノートを印刷向けの Markdown プレビューとして出力できるようにします。

## 変更内容

- `EditorPanel` に印刷ボタンを追加し、印刷中だけ表示するプレビュー DOM と `window.print()` の起動処理を実装
- 印刷時にエディタ UI を隠して本文・タイトル・Markdown テーブルを読みやすく出力する CSS を追加
- 印刷プレビューの表示と `afterprint` 後のクリーンアップを検証するテストを追加
- 印刷関連のラベルを英語・日本語の i18n 辞書に追加

## テスト方法

- [x] `make test-frontend`
- [x] `make lint-frontend`
- [x] `make test-unit`
- [x] `make test-integration-full ENV=dev`

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）