### PR TITLE
fix: avoid self-conflicts in note sync

### DIFF
--- a/frontend/src/lib/sync/useNoteSyncEngine.test.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.test.ts
@@ -258,6 +258,75 @@ describe("useNoteSyncEngine", () => {
     vi.useRealTimers();
   });
 
+  it("keeps the last acknowledged version across rapid debounced edits", async () => {
+    vi.useFakeTimers();
+
+    const initialNote = buildNote();
+    const serverNote = buildNote({
+      content: "second draft",
+      version: 2,
+      updated_at: "2024-01-02T00:00:00.000Z",
+    });
+    const applyWorkspaceChanges = vi.fn().mockResolvedValue({
+      applied: [
+        {
+          entity: "note",
+          operation: "update",
+          entity_id: serverNote.id,
+          client_mutation_id: null,
+          folder: null,
+          note: serverNote,
+        },
+      ],
+      snapshot: {
+        folders: [],
+        notes: [serverNote],
+        cursor: "cursor-2",
+        server_time: "2024-01-02T00:00:00.000Z",
+      },
+    });
+    getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+    const { result } = renderHook(() =>
+      useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+    );
+
+    await act(async () => {
+      await result.current.handleUpdateNote(initialNote.id, {
+        content: "first draft",
+      });
+    });
+
+    await act(async () => {
+      await result.current.handleUpdateNote(initialNote.id, {
+        content: "second draft",
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+      await result.current.triggerServerSync(initialNote.id);
+    });
+
+    expect(applyWorkspaceChanges).toHaveBeenCalledTimes(1);
+    expect(applyWorkspaceChanges).toHaveBeenCalledWith({
+      device_id: "device-1",
+      base_cursor: "cursor-1",
+      changes: [
+        {
+          entity: "note",
+          operation: "update",
+          entity_id: initialNote.id,
+          expected_version: 1,
+          payload: { content: "second draft" },
+        },
+      ],
+    });
+    expect(result.current.syncStatus.remote).toBe("synced");
+
+    vi.useRealTimers();
+  });
+
   it("surfaces translated local save failures", async () => {
     const initialNote = buildNote();
     vi.mocked(notesDB.saveNote).mockRejectedValueOnce(new Error("indexeddb unavailable"));

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -64,7 +64,47 @@ export function useNoteSyncEngine({
   const retryIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const retryArgsRef = useRef<{ id: string; updates: NoteSyncUpdates; expectedVersion?: number } | null>(null);
   const syncNoteToServerRef = useRef<((id: string, updates: NoteSyncUpdates, expectedVersion?: number) => Promise<void>) | null>(null);
+  const serverVersionByNoteIdRef = useRef<Record<string, number>>({});
   const handleSnapshotSynced = onSnapshotSynced ?? NOOP_SNAPSHOT_SYNC;
+
+  const getExpectedVersion = useCallback(
+    (noteId: string, fallbackVersion?: number) => {
+      const knownVersion = serverVersionByNoteIdRef.current[noteId];
+      if (knownVersion !== undefined) {
+        return knownVersion;
+      }
+
+      if (fallbackVersion !== undefined) {
+        serverVersionByNoteIdRef.current[noteId] = fallbackVersion;
+      }
+
+      return fallbackVersion;
+    },
+    []
+  );
+
+  const setServerVersion = useCallback((noteId: string, version: number) => {
+    serverVersionByNoteIdRef.current[noteId] = version;
+  }, []);
+
+  const syncServerVersionsFromSnapshot = useCallback(
+    (snapshot?: WorkspaceSnapshotResponse) => {
+      if (!snapshot) {
+        return;
+      }
+
+      const nextVersions = { ...serverVersionByNoteIdRef.current };
+      for (const note of snapshot.notes) {
+        if (note.deleted_at) {
+          delete nextVersions[note.id];
+          continue;
+        }
+        nextVersions[note.id] = note.version;
+      }
+      serverVersionByNoteIdRef.current = nextVersions;
+    },
+    []
+  );
 
   const syncNoteToServer = useCallback(
     async (id: string, updates: NoteSyncUpdates, expectedVersion?: number) => {
@@ -98,8 +138,10 @@ export function useNoteSyncEngine({
             );
 
             await persistWorkspaceSnapshot(response.snapshot);
+            syncServerVersionsFromSnapshot(response.snapshot);
             handleSnapshotSynced(response.snapshot);
 
+            setServerVersion(serverNote.id, serverNote.version);
             const hash = await calculateHash(serverNote.content);
             setSavedHashes((prev) => ({ ...prev, [id]: hash }));
 
@@ -111,9 +153,10 @@ export function useNoteSyncEngine({
           } catch (error) {
             if (isConflictApiError(error)) {
               const apiClient = await getApi();
-              await refreshWorkspaceSnapshot(apiClient, {
+              const snapshot = await refreshWorkspaceSnapshot(apiClient, {
                 onSnapshotSynced: handleSnapshotSynced,
               });
+              syncServerVersionsFromSnapshot(snapshot);
               setRemoteStatus("failed");
               setLastError(t("sync.conflictReloaded"));
               return;
@@ -180,7 +223,14 @@ export function useNoteSyncEngine({
       setRemoteStatus("failed");
       setLastError(t("sync.offlineSyncUnavailable"));
     },
-    [getApi, handleSnapshotSynced, setNotes, t]
+    [
+      getApi,
+      handleSnapshotSynced,
+      setNotes,
+      setServerVersion,
+      syncServerVersionsFromSnapshot,
+      t,
+    ]
   );
 
   useEffect(() => {
@@ -249,17 +299,21 @@ export function useNoteSyncEngine({
           prev.map((note) => (note.id === tempId ? serverNote : note))
         );
         setSelectedNoteId(serverNote.id);
+        setServerVersion(serverNote.id, serverNote.version);
+        delete serverVersionByNoteIdRef.current[tempId];
 
         await notesDB.deleteNote(tempId);
         await persistWorkspaceSnapshot(response.snapshot);
+        syncServerVersionsFromSnapshot(response.snapshot);
         handleSnapshotSynced(response.snapshot);
         setRemoteStatus("synced");
       } catch (error) {
         if (isConflictApiError(error)) {
           const apiClient = await getApi();
-          await refreshWorkspaceSnapshot(apiClient, {
+          const snapshot = await refreshWorkspaceSnapshot(apiClient, {
             onSnapshotSynced: handleSnapshotSynced,
           });
+          syncServerVersionsFromSnapshot(snapshot);
           setRemoteStatus("failed");
           setLastError(t("sync.conflictReloaded"));
           return;
@@ -281,7 +335,16 @@ export function useNoteSyncEngine({
       folder_id: selectedFolderId,
     });
     setRemoteStatus("failed");
-  }, [getApi, handleSnapshotSynced, selectedFolderId, setNotes, setSelectedNoteId, t]);
+  }, [
+    getApi,
+    handleSnapshotSynced,
+    selectedFolderId,
+    setNotes,
+    setSelectedNoteId,
+    setServerVersion,
+    syncServerVersionsFromSnapshot,
+    t,
+  ]);
 
   const handleUpdateNote = useCallback(
     async (id: string, updates: NoteSyncUpdates) => {
@@ -327,10 +390,11 @@ export function useNoteSyncEngine({
         setLastError(t("sync.localSaveFailed"));
       }
 
+      const expectedVersion = getExpectedVersion(id, noteForLocalSave?.version);
       setRemoteStatus("unsynced");
-      debouncedServerSync(id, updates, noteForLocalSave?.version);
+      debouncedServerSync(id, updates, expectedVersion);
     },
-    [debouncedServerSync, setNotes, t]
+    [debouncedServerSync, getExpectedVersion, setNotes, t]
   );
 
   const handleDeleteNote = useCallback(
@@ -338,6 +402,7 @@ export function useNoteSyncEngine({
       try {
         cancelServerSync();
         const noteToDelete = await notesDB.getNote(id);
+        const expectedVersion = getExpectedVersion(id, noteToDelete?.version);
 
         setNotes((prev) => prev.filter((note) => note.id !== id));
         if (selectedNoteId === id) {
@@ -362,18 +427,21 @@ export function useNoteSyncEngine({
                   entity: "note",
                   operation: "delete",
                   entity_id: id,
-                  expected_version: noteToDelete?.version,
+                  expected_version: expectedVersion,
                 },
               ],
             });
             await persistWorkspaceSnapshot(response.snapshot);
+            syncServerVersionsFromSnapshot(response.snapshot);
+            delete serverVersionByNoteIdRef.current[id];
             handleSnapshotSynced(response.snapshot);
           } catch (error) {
             if (isConflictApiError(error)) {
               const apiClient = await getApi();
-              await refreshWorkspaceSnapshot(apiClient, {
+              const snapshot = await refreshWorkspaceSnapshot(apiClient, {
                 onSnapshotSynced: handleSnapshotSynced,
               });
+              syncServerVersionsFromSnapshot(snapshot);
               setRemoteStatus("failed");
               setLastError(t("sync.conflictReloaded"));
               return;
@@ -381,7 +449,7 @@ export function useNoteSyncEngine({
             console.error("Failed to delete note on server:", error);
             if (!id.startsWith("temp-")) {
               await syncQueue.addChange("delete", "note", id, undefined, {
-                expectedVersion: noteToDelete?.version,
+                expectedVersion,
               });
             }
           }
@@ -390,14 +458,24 @@ export function useNoteSyncEngine({
 
         if (!id.startsWith("temp-")) {
           await syncQueue.addChange("delete", "note", id, undefined, {
-            expectedVersion: noteToDelete?.version,
+            expectedVersion,
           });
         }
       } catch (error) {
         console.error("Failed to delete note:", error);
       }
     },
-    [cancelServerSync, getApi, handleSnapshotSynced, selectedNoteId, setNotes, setSelectedNoteId, t]
+    [
+      cancelServerSync,
+      getApi,
+      getExpectedVersion,
+      handleSnapshotSynced,
+      selectedNoteId,
+      setNotes,
+      setSelectedNoteId,
+      syncServerVersionsFromSnapshot,
+      t,
+    ]
   );
 
   const triggerServerSync = useCallback(


### PR DESCRIPTION
## Summary
- fix note sync `409 Conflict` self-conflicts caused by optimistic and debounced `expected_version`
- deploy the change to `dev` and verify the deployed stack

## Changes
- track the last server-acknowledged note version in the sync engine
- use that version for debounced update and delete `expected_version` values
- add a regression test covering rapid edits before the debounce flush

## Testing
- `make test-frontend`
- `make deploy ENV=dev`
- git hooks during commit and push

## Notes
- unrelated untracked file `backend/pyrightconfig.json` was intentionally excluded
