### PR TITLE
fix: avoid editor textarea field sizing lag

### DIFF
--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -141,6 +141,12 @@ describe('EditorPanel', () => {
     expect(textarea.value).toBe('Initial content')
   })
 
+  it('disables content field sizing for the editor textarea', () => {
+    render(<EditorPanel {...defaultProps} />)
+
+    expect(screen.getByRole('textbox', { name: /content/i })).not.toHaveClass('field-sizing-content')
+  })
+
   describe('onContentChange callback', () => {
     it('calls onContentChange with note content on mount', () => {
       // Regression test: EditorPanel must notify the parent of its initial content on

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -1285,6 +1285,7 @@ export function EditorPanel({
                   <Textarea
                     id="note-content"
                     ref={textareaRef}
+                    fieldSizing="fixed"
                     value={content}
                     onChange={(e) => handleContentChange(e.target.value)}
                     onKeyDown={handleKeyDown}

--- a/frontend/src/components/ui/textarea.test.tsx
+++ b/frontend/src/components/ui/textarea.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Textarea } from './textarea'
+
+describe('Textarea', () => {
+  it('uses content field sizing by default', () => {
+    render(<Textarea aria-label="Default textarea" />)
+
+    expect(screen.getByRole('textbox', { name: 'Default textarea' })).toHaveClass('field-sizing-content')
+  })
+
+  it('allows opting out of content field sizing', () => {
+    render(<Textarea aria-label="Fixed textarea" fieldSizing="fixed" />)
+
+    expect(screen.getByRole('textbox', { name: 'Fixed textarea' })).not.toHaveClass('field-sizing-content')
+  })
+})

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -2,12 +2,21 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+interface TextareaProps extends React.ComponentProps<"textarea"> {
+  fieldSizing?: "content" | "fixed"
+}
+
+function Textarea({
+  className,
+  fieldSizing = "content",
+  ...props
+}: TextareaProps) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        fieldSizing === "content" && "field-sizing-content",
         className
       )}
       {...props}


### PR DESCRIPTION
## 概要

1万字前後のノートで入力やIME変換がもたつく原因の一つだった、エディタ textarea の content-based field sizing を無効化しました。shared Textarea のデフォルト挙動は維持しつつ、EditorPanel の本文入力欄だけ fixed sizing に切り替えています。

## 変更内容

- shared `Textarea` に `fieldSizing` オプションを追加し、既定値は従来通り `content` のまま維持
- ノート本文エディタだけ `fieldSizing="fixed"` を指定して `field-sizing-content` を外すよう変更
- shared Textarea のデフォルト/opt-out の両方を確認する unit test を追加
- EditorPanel 側で本文 textarea が `field-sizing-content` を持たないことを確認する回帰テストを追加

## テスト方法

- [x] `cd frontend && npm run test -- --run src/components/ui/textarea.test.tsx src/components/layout/EditorPanel.test.tsx`
- [x] `make deploy ENV=dev`
- [x] pre-commit / pre-push hooks による unit / integration test 通過

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）
