### PR TITLE
fix: fix portrait print preview blank page

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -274,7 +274,7 @@
   top: -1px;
 }
 
-.note-print-content {
+.note-print-portal {
   display: none;
 }
 
@@ -283,28 +283,21 @@
     visibility: hidden !important;
   }
 
-  body.printing-note-preview .note-print-root,
-  body.printing-note-preview .note-print-root * {
+  body.printing-note-preview .note-print-portal,
+  body.printing-note-preview .note-print-portal * {
     visibility: visible !important;
   }
 
-  body.printing-note-preview .note-print-root {
-    position: absolute;
-    inset: 0;
+  body.printing-note-preview .note-print-portal {
+    display: block !important;
+    position: relative;
     width: 100%;
-    height: auto;
+    min-height: 100vh;
     overflow: visible !important;
     background: white !important;
     color: black !important;
-  }
-
-  body.printing-note-preview .note-print-screen {
-    display: none !important;
-  }
-
-  body.printing-note-preview .note-print-content {
-    display: block !important;
     padding: 24px 32px 32px;
+    box-sizing: border-box;
   }
 
   body.printing-note-preview .note-print-title {
@@ -315,22 +308,22 @@
     color: black;
   }
 
-  body.printing-note-preview .note-print-content .markdown-preview {
+  body.printing-note-preview .note-print-portal .markdown-preview {
     color: black;
   }
 
-  body.printing-note-preview .note-print-content .markdown-preview table {
+  body.printing-note-preview .note-print-portal .markdown-preview table {
     width: 100%;
     border-collapse: collapse;
   }
 
-  body.printing-note-preview .note-print-content .markdown-preview th,
-  body.printing-note-preview .note-print-content .markdown-preview td {
+  body.printing-note-preview .note-print-portal .markdown-preview th,
+  body.printing-note-preview .note-print-portal .markdown-preview td {
     border: 1px solid black !important;
     padding: 0.5rem;
   }
 
-  body.printing-note-preview .note-print-content .markdown-preview th {
+  body.printing-note-preview .note-print-portal .markdown-preview th {
     background: #f3f4f6 !important;
     color: black;
     font-weight: 600;
@@ -338,10 +331,10 @@
     print-color-adjust: exact;
   }
 
-  body.printing-note-preview .note-print-content .markdown-preview pre,
-  body.printing-note-preview .note-print-content .markdown-preview blockquote,
-  body.printing-note-preview .note-print-content .markdown-preview table,
-  body.printing-note-preview .note-print-content .markdown-preview img {
+  body.printing-note-preview .note-print-portal .markdown-preview pre,
+  body.printing-note-preview .note-print-portal .markdown-preview blockquote,
+  body.printing-note-preview .note-print-portal .markdown-preview table,
+  body.printing-note-preview .note-print-portal .markdown-preview img {
     break-inside: avoid;
   }
 }

--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -280,6 +280,8 @@ describe('EditorPanel', () => {
     fireEvent.click(screen.getByTestId('editor-print-button'))
 
     const printPreview = screen.getByTestId('editor-print-preview')
+    expect(printPreview).toHaveClass('note-print-portal')
+    expect(document.body).toContainElement(printPreview)
     expect(within(printPreview).getByText('Printed title')).toBeInTheDocument()
     expect(within(printPreview).getByText('# Printed body')).toBeInTheDocument()
     expect(document.body).toHaveClass('printing-note-preview')

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ShareDialog } from "@/components/ui/ShareDialog";
 import type { NoteShare } from "@/types";
-import { flushSync } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 
 const DESKTOP_BREAKPOINT = 768;
 const DEFAULT_EDITOR_PREVIEW_WIDTH = 50;
@@ -913,6 +913,24 @@ export function EditorPanel({
   }, [note]);
 
   const currentFolder = folders.find((f) => f.id === note?.folder_id);
+  const printPreview =
+    printSnapshot && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            className="note-print-portal"
+            aria-hidden="true"
+            data-testid="editor-print-preview"
+          >
+            <h1 className="note-print-title">{printSnapshot.title || t("noteList.untitled")}</h1>
+            <div className="markdown-preview prose prose-sm max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {printSnapshot.content || `*${t("editor.previewPlaceholder")}*`}
+              </ReactMarkdown>
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
 
   if (!note) {
     return (
@@ -978,28 +996,16 @@ export function EditorPanel({
   // --- SAVE STATUS LOGIC END ---
 
   return (
-    <div
-      ref={fullscreenContainerRef}
-      className={cn(
-        "note-print-root",
-        isFullscreen ? "flex flex-col bg-background overflow-hidden w-full h-full" : "flex-1 flex flex-col overflow-hidden"
-      )}
-    >
-      {printSnapshot && (
-        <div
-          className="note-print-content"
-          aria-hidden="true"
-          data-testid="editor-print-preview"
-        >
-          <h1 className="note-print-title">{printSnapshot.title || t("noteList.untitled")}</h1>
-          <div className="markdown-preview prose prose-sm max-w-none">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {printSnapshot.content || `*${t("editor.previewPlaceholder")}*`}
-            </ReactMarkdown>
-          </div>
-        </div>
-      )}
-      <div className="note-print-screen flex flex-1 flex-col overflow-hidden">
+    <>
+      {printPreview}
+      <div
+        ref={fullscreenContainerRef}
+        className={cn(
+          "note-print-root",
+          isFullscreen ? "flex flex-col bg-background overflow-hidden w-full h-full" : "flex-1 flex flex-col overflow-hidden"
+        )}
+      >
+        <div className="note-print-screen flex flex-1 flex-col overflow-hidden">
       {/* Toolbar */}
       <div className="flex items-center justify-between p-4 md:p-4 p-2 border-b border-border/50">
         <div className="flex items-center gap-1 md:gap-2 flex-wrap">
@@ -1425,7 +1431,8 @@ export function EditorPanel({
           }
         }}
       />
+        </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## 概要

縦向き印刷時にプレビューと出力が白紙になる不具合を修正しました。印刷用プレビューを通常のエディターレイアウトから切り離し、document.body 直下へ描画するように変更しています。

## 変更内容

- 印刷用プレビューを EditorPanel 内部ではなく body ポータルで描画するよう変更
- 印刷 CSS を note-print-portal 前提に整理し、親レイアウトの overflow や flex 制約の影響を受けないよう修正
- 印刷テストを更新し、body 直下に印刷プレビューが生成されることを検証
- dev と prd へデプロイ済み

## テスト方法

- [x] make test-frontend
- [x] make lint-frontend FRONTEND_PATH="src/components/layout/EditorPanel.tsx src/components/layout/EditorPanel.test.tsx"
- [x] make deploy ENV=dev
- [x] make deploy ENV=prd

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）
