### PR TITLE
feat: add structured logging and request tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,21 @@ tf-validate: ## Validate Terraform configuration
 logs: ## Tail Lambda logs
 	aws logs tail /aws/lambda/notes-app-api-$(ENV) --follow --profile $(AWS_PROFILE)
 
+.PHONY: api-gateway-logs
+api-gateway-logs: ## Tail API Gateway access logs for the main API
+	aws logs tail /aws/api-gateway/notes-app-api-$(ENV) --follow --profile $(AWS_PROFILE)
+
+.PHONY: logs-request
+logs-request: ## Show API Gateway and Lambda log lines that match REQUEST_ID=<id>
+	@if [ -z "$(REQUEST_ID)" ]; then \
+		echo "REQUEST_ID is required"; \
+		exit 1; \
+	fi
+	@echo "== API Gateway =="
+	@aws logs tail /aws/api-gateway/notes-app-api-$(ENV) --since 1h --profile $(AWS_PROFILE) --format short | grep -F "$(REQUEST_ID)" || true
+	@echo "== Lambda =="
+	@aws logs tail /aws/lambda/notes-app-api-$(ENV) --since 1h --profile $(AWS_PROFILE) --format short | grep -F "$(REQUEST_ID)" || true
+
 # =============================================================================
 # Cost Report Lambda
 # =============================================================================

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
@@ -8,10 +9,13 @@ from sqlmodel import Session
 from app.auth.app_user_service import AppUserService
 from app.auth.cognito import cognito_verifier
 from app.database import get_session
+from app.logging_utils import bind_user_id, log_event
 from app.models import AppUser
+from app.observability import set_sentry_user_context
 
 # Bearer token security scheme
 security = HTTPBearer()
+logger = logging.getLogger(__name__)
 
 
 async def get_current_user(
@@ -33,11 +37,28 @@ async def get_current_user(
 
     try:
         claims = await cognito_verifier.verify_token(token)
+        user_id = claims.get("sub", "")
+        if user_id:
+            bind_user_id(user_id)
+            set_sentry_user_context(user_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "security.auth.authenticated",
+            outcome="success",
+        )
         return claims
-    except JWTError as e:
+    except JWTError as exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            "security.auth.failed",
+            outcome="failure",
+            reason=exc.__class__.__name__,
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(e),
+            detail=str(exc),
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -49,6 +70,13 @@ def get_current_app_user(
     """Ensure the authenticated user has an app-local profile."""
     user_id = current_user.get("sub", "")
     if not user_id:
+        log_event(
+            logger,
+            logging.WARNING,
+            "security.auth.failed",
+            outcome="failure",
+            reason="missing_user_subject",
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing user subject",
@@ -67,6 +95,13 @@ def require_admin(
 ) -> AppUser:
     """Require the current user to have admin privileges."""
     if not app_user.admin:
+        log_event(
+            logger,
+            logging.WARNING,
+            "security.authorization.denied",
+            outcome="failure",
+            reason="admin_required",
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     app_name: str = "Notes API"
     environment: str = "local"
     debug: bool = False
+    log_level: str = ""
     sentry_dsn: str = ""
     sentry_dsn_parameter_name: str = ""
     sentry_traces_sample_rate: float | None = None
@@ -68,6 +69,12 @@ class Settings(BaseSettings):
         if self.sentry_traces_sample_rate is not None:
             return self.sentry_traces_sample_rate
         return 1.0 if self.environment in {"local", "dev"} else 0.1
+
+    @property
+    def effective_log_level(self) -> str:
+        if self.log_level:
+            return self.log_level.upper()
+        return "DEBUG" if self.environment in {"local", "dev"} else "INFO"
 
 
 @lru_cache

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, create_engine
 
 from app.bootstrap.database_bootstrap import create_database_schema
 from app.config import get_settings
+from app.logging_utils import log_event
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -24,15 +25,25 @@ def get_dsql_engine():
     """Create database engine for DSQL or local PostgreSQL."""
     global _engine
     if _engine is not None:
-        logger.info("Reusing cached database engine")
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.db.engine.reused",
+            outcome="success",
+        )
         return _engine
 
     dsql_endpoint = os.environ.get("DSQL_CLUSTER_ENDPOINT")
 
     if dsql_endpoint:
         region = os.environ.get("AWS_REGION", "ap-northeast-1")
-        logger.info(
-            f"Initializing DSQL engine: endpoint={dsql_endpoint}, region={region}"
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.db.engine.initializing",
+            database_mode="dsql",
+            region=region,
+            outcome="running",
         )
 
         def get_connection():
@@ -41,13 +52,6 @@ def get_dsql_engine():
 
             for attempt in range(max_retries):
                 try:
-                    import datetime
-
-                    now = datetime.datetime.now()
-                    logger.info(
-                        f"Attempt {attempt + 1}/{max_retries}: Generating auth token at {now} (timestamp: {now.timestamp()})"
-                    )
-
                     client = boto3.client("dsql", region_name=region)
                     token = client.generate_db_connect_admin_auth_token(
                         Hostname=f"{dsql_endpoint}.dsql.{region}.on.aws",
@@ -69,21 +73,41 @@ def get_dsql_engine():
                         "Signature expired" in error_message
                         or "Signature not yet current" in error_message
                     ):
-                        logger.warning(
-                            f"DSQL connection failed with signature error (likely clock skew): {exc}"
+                        log_event(
+                            logger,
+                            logging.WARNING,
+                            "ops.db.connection.retrying",
+                            database_mode="dsql",
+                            attempt=attempt + 1,
+                            max_retries=max_retries,
+                            outcome="retry",
+                            reason="signature_time_skew",
                         )
                         if attempt < max_retries - 1:
                             sleep_time = base_delay * (attempt + 1)
-                            logger.info(
-                                f"Sleeping for {sleep_time}s to allow clock synchronization..."
-                            )
                             time.sleep(sleep_time)
                             continue
 
-                    logger.error(f"Failed to create DSQL connection: {exc}")
+                    log_event(
+                        logger,
+                        logging.ERROR,
+                        "ops.db.connection.failed",
+                        database_mode="dsql",
+                        attempt=attempt + 1,
+                        outcome="error",
+                        reason=exc.__class__.__name__,
+                    )
                     raise
                 except Exception as exc:
-                    logger.error(f"Unexpected error connecting to DSQL: {exc}")
+                    log_event(
+                        logger,
+                        logging.ERROR,
+                        "ops.db.connection.failed",
+                        database_mode="dsql",
+                        attempt=attempt + 1,
+                        outcome="error",
+                        reason=exc.__class__.__name__,
+                    )
                     raise
 
         try:
@@ -96,18 +120,44 @@ def get_dsql_engine():
                 max_overflow=10,
                 pool_recycle=300,
             )
-            logger.info("DSQL engine created successfully")
+            log_event(
+                logger,
+                logging.INFO,
+                "ops.db.engine.created",
+                database_mode="dsql",
+                outcome="success",
+            )
         except Exception as exc:
-            logger.error(f"Failed to initialize DSQL engine: {exc}", exc_info=True)
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.db.engine.failed",
+                database_mode="dsql",
+                outcome="error",
+                reason=exc.__class__.__name__,
+                exc_info=True,
+            )
             raise
     else:
-        logger.info("Initializing local PostgreSQL engine")
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.db.engine.initializing",
+            database_mode="postgresql",
+            outcome="running",
+        )
         _engine = create_engine(
             settings.database_url,
             echo=settings.debug,
             pool_pre_ping=True,
         )
-        logger.info("Local PostgreSQL engine created successfully")
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.db.engine.created",
+            database_mode="postgresql",
+            outcome="success",
+        )
 
     return _engine
 

--- a/backend/app/features/admin/use_cases.py
+++ b/backend/app/features/admin/use_cases.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 
 from sqlalchemy import func, or_
@@ -11,6 +12,7 @@ from app.features.admin.schemas import (
     AdminUserUpdateRequest,
 )
 from app.features.assistant.usage_policy import get_usage_snapshot
+from app.logging_utils import log_event
 from app.models import (
     AVAILABLE_LANGUAGES,
     AVAILABLE_MODELS,
@@ -24,6 +26,8 @@ from app.models import (
 )
 from app.models.user_settings import DEFAULT_LANGUAGE, DEFAULT_LLM_MODEL_ID
 from app.shared import NotFound, ValidationFailed
+
+logger = logging.getLogger(__name__)
 
 
 class AdminUseCases:
@@ -133,6 +137,14 @@ class AdminUseCases:
             self.session.add(settings)
 
         commit_with_error_handling(self.session, "AdminUserUpdate")
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.admin.user.updated",
+            target_user_id=user_id,
+            changed_fields=sorted(payload.model_dump(exclude_unset=True).keys()),
+            outcome="success",
+        )
         return self.get_user_detail(user_id)
 
     def _count_for_user(

--- a/backend/app/features/assistant/gateway.py
+++ b/backend/app/features/assistant/gateway.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
 from app.config import get_settings
 from app.core.prompts import get_prompt
 from app.features.assistant.summary_cache import get_summary_cache
+from app.logging_utils import log_event
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -99,8 +100,12 @@ class BedrockGateway(AIGateway):
                 accept="application/json",
             )
         except (ConnectTimeoutError, ReadTimeoutError) as exc:
-            logger.warning(
-                "Bedrock invocation timed out for model %s", effective_model_id
+            log_event(
+                logger,
+                logging.WARNING,
+                "ops.ai.bedrock.timeout",
+                model_id=effective_model_id,
+                outcome="timeout",
             )
             raise AIGatewayTimeoutError(
                 f"Bedrock invocation timed out for model {effective_model_id}"

--- a/backend/app/features/assistant/job_runner.py
+++ b/backend/app/features/assistant/job_runner.py
@@ -18,6 +18,7 @@ from app.features.assistant.errors import (
 from app.features.assistant.gateway import AIGateway, get_ai_gateway
 from app.features.assistant.use_cases import AIInteractionUseCases
 from app.features.workspace.use_cases import WorkspaceQueryUseCases
+from app.logging_utils import log_event
 from app.models import AIEditJob
 
 logger = logging.getLogger(__name__)
@@ -41,12 +42,36 @@ async def dispatch_edit_job(
             TopicArn=topic_arn,
             Message=json.dumps({"task": PROCESS_EDIT_JOB_TASK, "job_id": str(job_id)}),
         )
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.ai_edit_job.dispatched",
+            job_id=job_id,
+            dispatch_mode="sns",
+            outcome="queued",
+        )
         return
 
     if background_tasks is not None:
         background_tasks.add_task(process_edit_job, job_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.ai_edit_job.dispatched",
+            job_id=job_id,
+            dispatch_mode="background_tasks",
+            outcome="queued",
+        )
         return
 
+    log_event(
+        logger,
+        logging.INFO,
+        "ops.ai_edit_job.dispatched",
+        job_id=job_id,
+        dispatch_mode="inline",
+        outcome="running",
+    )
     await process_edit_job(job_id)
 
 
@@ -62,7 +87,13 @@ async def process_edit_job(
     with session_factory() as session:
         job = session.get(AIEditJob, job_id)
         if job is None:
-            logger.warning("AI edit job %s not found", job_id)
+            log_event(
+                logger,
+                logging.WARNING,
+                "ops.ai_edit_job.not_found",
+                job_id=job_id,
+                outcome="failure",
+            )
             return
 
         if job.status in {"running", "completed"}:
@@ -73,6 +104,13 @@ async def process_edit_job(
         job.updated_at = job.started_at
         session.add(job)
         session.commit()
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.ai_edit_job.started",
+            job_id=job.id,
+            outcome="running",
+        )
 
         try:
             workspace_queries = WorkspaceQueryUseCases(session, job.user_id)
@@ -91,14 +129,46 @@ async def process_edit_job(
             job.edited_content = edited_content
             job.tokens_used = tokens_used
             job.error_message = None
+            log_event(
+                logger,
+                logging.INFO,
+                "ops.ai_edit_job.completed",
+                job_id=job.id,
+                tokens_used=tokens_used,
+                outcome="success",
+            )
         except AIApplicationTimeoutError:
             job.status = "failed"
             job.error_message = AI_EDIT_JOB_TIMEOUT_MESSAGE
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai_edit_job.failed",
+                job_id=job.id,
+                outcome="timeout",
+                reason="ai_timeout",
+            )
         except AITokenLimitExceededError as exc:
             job.status = "failed"
             job.error_message = str(exc)
+            log_event(
+                logger,
+                logging.WARNING,
+                "ops.ai_edit_job.failed",
+                job_id=job.id,
+                outcome="failure",
+                reason="token_limit_exceeded",
+            )
         except Exception as exc:
-            logger.exception("AI edit job %s failed", job_id)
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai_edit_job.failed",
+                job_id=job_id,
+                outcome="error",
+                reason=exc.__class__.__name__,
+                exc_info=True,
+            )
             job.status = "failed"
             job.error_message = str(exc)
         finally:
@@ -145,8 +215,13 @@ async def process_edit_job_queue_records(
 
             await process_job_fn(job_id)
         except Exception:
-            logger.exception(
-                "Failed to process AI edit job queue record %s", message_id
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai_edit_job.queue_record_failed",
+                queue_message_id=message_id,
+                outcome="error",
+                exc_info=True,
             )
             failures.append({"itemIdentifier": message_id})
 

--- a/backend/app/features/assistant/summary_cache.py
+++ b/backend/app/features/assistant/summary_cache.py
@@ -5,6 +5,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from app.config import get_settings
+from app.logging_utils import log_event
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -26,14 +27,34 @@ class SummaryCache:
 
         try:
             response = self.s3.get_object(Bucket=self.bucket, Key=s3_key)
-            logger.info(f"Cache hit (S3) for hash: {content_hash}")
+            log_event(
+                logger,
+                logging.INFO,
+                "ops.ai.summary_cache.hit",
+                cache_key=content_hash,
+                outcome="success",
+            )
             return response["Body"].read().decode("utf-8")
 
         except ClientError as exc:
             if exc.response["Error"]["Code"] == "NoSuchKey":
+                log_event(
+                    logger,
+                    logging.DEBUG,
+                    "ops.ai.summary_cache.miss",
+                    cache_key=content_hash,
+                    outcome="miss",
+                )
                 return None
 
-            logger.error(f"Error retrieving cache: {exc}")
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai.summary_cache.read_failed",
+                cache_key=content_hash,
+                outcome="error",
+                reason=exc.response["Error"]["Code"],
+            )
             return None
 
     def save_summary(self, content: str, model_id: str, summary: str):
@@ -45,10 +66,23 @@ class SummaryCache:
             self.s3.put_object(
                 Bucket=self.bucket, Key=s3_key, Body=summary.encode("utf-8")
             )
-            logger.info(f"Cache saved to S3 for hash: {content_hash}")
+            log_event(
+                logger,
+                logging.INFO,
+                "ops.ai.summary_cache.saved",
+                cache_key=content_hash,
+                outcome="success",
+            )
 
         except ClientError as exc:
-            logger.error(f"Error saving cache: {exc}")
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai.summary_cache.write_failed",
+                cache_key=content_hash,
+                outcome="error",
+                reason=exc.response["Error"]["Code"],
+            )
 
 
 summary_cache = SummaryCache()

--- a/backend/app/features/mcp/use_cases.py
+++ b/backend/app/features/mcp/use_cases.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlmodel import Session, select
 
 from app.db_commit import commit_with_error_handling
+from app.logging_utils import log_event
 from app.models.mcp import (
     MCPSettingsResponse,
     MCPTokenCreateRequest,
@@ -48,11 +49,13 @@ class MCPUseCases:
         commit_with_error_handling(self.session, "MCPToken")
         self.session.refresh(new_token)
 
-        logger.info(
-            "Generated MCP API key for user %s: %s, expires_in_days=%s",
-            self.user_id,
-            new_token.name,
-            expires_in_days,
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.mcp.token.created",
+            token_id=new_token.id,
+            expires_in_days=expires_in_days,
+            outcome="success",
         )
 
         return MCPTokenResponse(
@@ -68,11 +71,15 @@ class MCPUseCases:
         )
 
     def list_tokens(self) -> MCPTokensListResponse:
-        logger.info("Listing MCP tokens for user_id: %s", self.user_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.mcp.tokens.listed",
+            outcome="success",
+        )
         tokens = self.session.exec(
             select(MCPToken).where(MCPToken.user_id == self.user_id)
         ).all()
-        logger.info("Found %s MCP tokens for user %s", len(tokens), self.user_id)
         return MCPTokensListResponse(
             tokens=[
                 MCPTokenListItem(
@@ -106,7 +113,13 @@ class MCPUseCases:
         self.session.add(token)
         commit_with_error_handling(self.session, "MCPToken")
 
-        logger.info("Revoked MCP API key %s for user %s", token_id, self.user_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.mcp.token.revoked",
+            token_id=token_id,
+            outcome="success",
+        )
         return {"message": "API key revoked successfully"}
 
     def restore_token(self, token_id: str) -> dict[str, str]:
@@ -118,7 +131,13 @@ class MCPUseCases:
         self.session.add(token)
         commit_with_error_handling(self.session, "MCPToken")
 
-        logger.info("Restored MCP API key %s for user %s", token_id, self.user_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.mcp.token.restored",
+            token_id=token_id,
+            outcome="success",
+        )
         return {"message": "API key restored successfully"}
 
     def delete_token(self, token_id: str) -> dict[str, str]:
@@ -126,7 +145,13 @@ class MCPUseCases:
         self.session.delete(token)
         commit_with_error_handling(self.session, "MCPToken")
 
-        logger.info("Deleted MCP API key %s for user %s", token_id, self.user_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.mcp.token.deleted",
+            token_id=token_id,
+            outcome="success",
+        )
         return {"message": "API key deleted successfully"}
 
     @staticmethod

--- a/backend/app/features/settings/use_cases.py
+++ b/backend/app/features/settings/use_cases.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 
 from sqlmodel import Session
@@ -5,6 +6,7 @@ from sqlmodel import Session
 from app.db_commit import commit_with_error_handling
 from app.features.assistant.usage_policy import get_usage_info
 from app.features.settings.schemas import SettingsResponse
+from app.logging_utils import log_event
 from app.models import (
     AVAILABLE_LANGUAGES,
     AVAILABLE_MODELS,
@@ -17,6 +19,8 @@ from app.models import (
     UserSettingsUpdate,
 )
 from app.shared import ValidationFailed
+
+logger = logging.getLogger(__name__)
 
 
 class SettingsUseCases:
@@ -39,6 +43,13 @@ class SettingsUseCases:
         self, settings_in: UserSettingsUpdate
     ) -> SettingsResponse:
         settings = self._update_settings(settings_in)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.settings.updated",
+            changed_fields=sorted(settings_in.model_dump(exclude_unset=True).keys()),
+            outcome="success",
+        )
         return SettingsResponse(
             settings=self._to_settings_read(settings),
             available_models=self.available_models(),

--- a/backend/app/features/share/use_cases.py
+++ b/backend/app/features/share/use_cases.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -5,8 +6,11 @@ from sqlmodel import Session, select
 
 from app.db_commit import commit_with_error_handling
 from app.features.workspace.use_cases import WorkspaceQueryUseCases
+from app.logging_utils import log_event
 from app.models import Note, NoteShare, SharedNoteRead
 from app.shared import NotFound, ShareExpired, ValidationFailed
+
+logger = logging.getLogger(__name__)
 
 
 class ShareUseCases:
@@ -27,12 +31,28 @@ class ShareUseCases:
             select(NoteShare).where(NoteShare.note_id == note_id)
         ).first()
         if existing is not None:
+            log_event(
+                logger,
+                logging.INFO,
+                "audit.share.created",
+                note_id=note_id,
+                share_id=existing.id,
+                outcome="success",
+            )
             return existing
 
         share = NoteShare(note_id=note_id)
         self.session.add(share)
         commit_with_error_handling(self.session, "NoteShare")
         self.session.refresh(share)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.share.created",
+            note_id=note_id,
+            share_id=share.id,
+            outcome="success",
+        )
         return share
 
     def get_share(self, note_id: UUID) -> NoteShare | None:
@@ -51,6 +71,14 @@ class ShareUseCases:
 
         self.session.delete(share)
         commit_with_error_handling(self.session, "NoteShare")
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.share.revoked",
+            note_id=note_id,
+            share_id=share.id,
+            outcome="success",
+        )
 
     def get_shared_note(self, token: UUID) -> SharedNoteRead:
         share = self.session.exec(
@@ -66,6 +94,14 @@ class ShareUseCases:
         if note is None or note.deleted_at is not None:
             raise NotFound("Shared note not found")
 
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.share.accessed",
+            note_id=note.id,
+            share_id=share.id,
+            outcome="success",
+        )
         return SharedNoteRead(
             title=note.title,
             content=note.content,

--- a/backend/app/features/workspace/use_cases/changes.py
+++ b/backend/app/features/workspace/use_cases/changes.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlmodel import Session
 
 from app.features.workspace.repositories import AppliedMutationRepository
@@ -9,6 +11,7 @@ from app.features.workspace.schemas import (
 from app.features.workspace.use_cases.folders import FolderUseCases
 from app.features.workspace.use_cases.notes import NoteUseCases
 from app.features.workspace.use_cases.snapshot import WorkspaceSnapshotUseCase
+from app.logging_utils import log_event
 from app.models import (
     FolderCreate,
     FolderRead,
@@ -18,6 +21,8 @@ from app.models import (
     NoteUpdate,
 )
 from app.shared import ConflictDetected, ValidationFailed
+
+logger = logging.getLogger(__name__)
 
 
 class WorkspaceChangesUseCase:
@@ -33,6 +38,13 @@ class WorkspaceChangesUseCase:
         self, request: WorkspaceChangesRequest
     ) -> WorkspaceChangesResponse:
         applied = [self._apply_change(change) for change in request.changes]
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.workspace.changes.applied",
+            change_count=len(request.changes),
+            outcome="success",
+        )
         return WorkspaceChangesResponse(
             applied=applied,
             snapshot=self.snapshot_use_case.get_snapshot(),

--- a/backend/app/features/workspace/use_cases/folders.py
+++ b/backend/app/features/workspace/use_cases/folders.py
@@ -1,9 +1,13 @@
+import logging
 from uuid import UUID
 
 from sqlmodel import Session
 
 from app.features.workspace.repositories import FolderRepository
+from app.logging_utils import log_event
 from app.models import Folder, FolderCreate, FolderUpdate
+
+logger = logging.getLogger(__name__)
 
 
 class FolderUseCases:
@@ -16,13 +20,37 @@ class FolderUseCases:
         return self.repository.list()
 
     def create_folder(self, folder_in: FolderCreate) -> Folder:
-        return self.repository.create(folder_in)
+        folder = self.repository.create(folder_in)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.folder.created",
+            folder_id=folder.id,
+            outcome="success",
+        )
+        return folder
 
     def get_folder(self, folder_id: UUID) -> Folder:
         return self.repository.get_owned(folder_id)
 
     def update_folder(self, folder_id: UUID, folder_in: FolderUpdate) -> Folder:
-        return self.repository.update(folder_id, folder_in)
+        folder = self.repository.update(folder_id, folder_in)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.folder.updated",
+            folder_id=folder.id,
+            changed_fields=sorted(folder_in.model_dump(exclude_unset=True).keys()),
+            outcome="success",
+        )
+        return folder
 
     def delete_folder(self, folder_id: UUID) -> None:
         self.repository.soft_delete(folder_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.folder.deleted",
+            folder_id=folder_id,
+            outcome="success",
+        )

--- a/backend/app/features/workspace/use_cases/note_exports.py
+++ b/backend/app/features/workspace/use_cases/note_exports.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime
@@ -6,6 +7,9 @@ from datetime import datetime
 from sqlmodel import Session
 
 from app.features.workspace.repositories import FolderRepository, NoteRepository
+from app.logging_utils import log_event
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -66,6 +70,14 @@ class NoteExportUseCase:
                 zip_file.writestr(rel_path, note.content)
 
         filename = f"notes_export_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.notes.exported",
+            note_count=len(notes),
+            folder_count=len(folders),
+            outcome="success",
+        )
         return NoteExportArchive(filename=filename, data=zip_buffer.getvalue())
 
     @staticmethod

--- a/backend/app/features/workspace/use_cases/notes.py
+++ b/backend/app/features/workspace/use_cases/notes.py
@@ -1,9 +1,13 @@
+import logging
 from uuid import UUID
 
 from sqlmodel import Session
 
 from app.features.workspace.repositories import NoteRepository
+from app.logging_utils import log_event
 from app.models import Note, NoteCreate, NoteUpdate
+
+logger = logging.getLogger(__name__)
 
 
 class NoteUseCases:
@@ -16,13 +20,38 @@ class NoteUseCases:
         return self.repository.list(folder_id)
 
     def create_note(self, note_in: NoteCreate) -> Note:
-        return self.repository.create(note_in)
+        note = self.repository.create(note_in)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.note.created",
+            note_id=note.id,
+            folder_id=note.folder_id,
+            outcome="success",
+        )
+        return note
 
     def get_note(self, note_id: UUID) -> Note:
         return self.repository.get_owned(note_id)
 
     def update_note(self, note_id: UUID, note_in: NoteUpdate) -> Note:
-        return self.repository.update(note_id, note_in)
+        note = self.repository.update(note_id, note_in)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.note.updated",
+            note_id=note.id,
+            changed_fields=sorted(note_in.model_dump(exclude_unset=True).keys()),
+            outcome="success",
+        )
+        return note
 
     def delete_note(self, note_id: UUID) -> None:
         self.repository.soft_delete(note_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.note.deleted",
+            note_id=note_id,
+            outcome="success",
+        )

--- a/backend/app/lambda_handler.py
+++ b/backend/app/lambda_handler.py
@@ -6,9 +6,11 @@ from mangum import Mangum
 
 from app.bootstrap import run_cold_start_database_bootstrap
 from app.database import create_db_and_tables
+from app.logging_utils import configure_logging
 from app.main import app
 
 # Configure logging
+configure_logging()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 

--- a/backend/app/logging_utils.py
+++ b/backend/app/logging_utils.py
@@ -1,0 +1,233 @@
+"""Structured logging helpers for backend runtime and tests."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import sys
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from app.config import get_settings
+
+SERVICE_NAME = "notes-backend"
+TIMEZONE_NAME = "UTC"
+REDACTED = "[REDACTED]"
+DEFAULT_REDACT_KEYS = {
+    "authorization",
+    "token",
+    "token_plain",
+    "password",
+    "email",
+    "share_token",
+    "prompt",
+    "instruction",
+    "content",
+    "body",
+}
+
+_request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id",
+    default=None,
+)
+_trace_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "trace_id",
+    default=None,
+)
+_user_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "user_id",
+    default=None,
+)
+_method_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "http_method",
+    default=None,
+)
+_path_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "http_path",
+    default=None,
+)
+
+_logging_configured = False
+
+
+def _is_test_environment() -> bool:
+    return bool(os.getenv("PYTEST_CURRENT_TEST")) or "pytest" in sys.modules
+
+
+def _is_sensitive_key(key: str | None) -> bool:
+    if not key:
+        return False
+    normalized = key.lower()
+    return normalized in DEFAULT_REDACT_KEYS or normalized.endswith("_token")
+
+
+def sanitize_log_value(value: Any, *, key: str | None = None) -> Any:
+    """Remove sensitive values while keeping logs useful for analysis."""
+    if _is_sensitive_key(key):
+        return REDACTED
+
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): sanitize_log_value(item_value, key=str(item_key))
+            for item_key, item_value in value.items()
+        }
+
+    if isinstance(value, (list, tuple, set)):
+        return [sanitize_log_value(item) for item in value]
+
+    if isinstance(value, datetime):
+        value = value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+        return value.isoformat().replace("+00:00", "Z")
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    return str(value)
+
+
+def get_log_context() -> dict[str, str]:
+    """Return the currently bound request/user logging context."""
+    context: dict[str, str] = {}
+    for key, value in (
+        ("request_id", _request_id_var.get()),
+        ("trace_id", _trace_id_var.get()),
+        ("user_id", _user_id_var.get()),
+        ("method", _method_var.get()),
+        ("path", _path_var.get()),
+    ):
+        if value:
+            context[key] = value
+    return context
+
+
+def bind_log_context(
+    *,
+    request_id: str | None = None,
+    trace_id: str | None = None,
+    user_id: str | None = None,
+    method: str | None = None,
+    path: str | None = None,
+) -> dict[str, contextvars.Token[str | None]]:
+    """Bind request-scoped values to contextvars and return reset tokens."""
+    tokens: dict[str, contextvars.Token[str | None]] = {}
+    updates = {
+        "request_id": (request_id, _request_id_var),
+        "trace_id": (trace_id, _trace_id_var),
+        "user_id": (user_id, _user_id_var),
+        "method": (method, _method_var),
+        "path": (path, _path_var),
+    }
+
+    for name, (value, variable) in updates.items():
+        tokens[name] = variable.set(value)
+    return tokens
+
+
+def bind_user_id(user_id: str) -> contextvars.Token[str | None]:
+    """Bind a user ID to the current execution context."""
+    return _user_id_var.set(user_id)
+
+
+def reset_log_context(tokens: Mapping[str, contextvars.Token[str | None]]) -> None:
+    """Reset contextvars created by ``bind_log_context``."""
+    variables = {
+        "request_id": _request_id_var,
+        "trace_id": _trace_id_var,
+        "user_id": _user_id_var,
+        "method": _method_var,
+        "path": _path_var,
+    }
+    for name, token in reversed(list(tokens.items())):
+        variables[name].reset(token)
+
+
+def _coerce_log_level(log_level: str) -> int:
+    resolved = getattr(logging, log_level.upper(), None)
+    if isinstance(resolved, int):
+        return resolved
+    return logging.INFO
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Emit backend logs as one JSON object per line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        settings = get_settings()
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "timezone": TIMEZONE_NAME,
+            "level": record.levelname.lower(),
+            "event": getattr(record, "event", record.getMessage()),
+            "message": record.getMessage(),
+            "service": SERVICE_NAME,
+            "component": getattr(record, "component", record.name),
+            "environment": settings.environment,
+        }
+        payload.update(get_log_context())
+
+        details = getattr(record, "details", None)
+        if isinstance(details, Mapping):
+            payload.update(
+                {
+                    key: sanitize_log_value(value, key=key)
+                    for key, value in details.items()
+                    if value is not None
+                }
+            )
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(
+            {key: sanitize_log_value(value, key=key) for key, value in payload.items()},
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+
+
+def configure_logging() -> bool:
+    """Install structured JSON logging for runtime processes."""
+    global _logging_configured
+
+    if _logging_configured or _is_test_environment():
+        return False
+
+    settings = get_settings()
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonLogFormatter())
+    root_logger.addHandler(handler)
+    root_logger.setLevel(_coerce_log_level(settings.effective_log_level))
+
+    for noisy_logger in ("boto3", "botocore", "s3transfer", "urllib3"):
+        logging.getLogger(noisy_logger).setLevel(logging.WARNING)
+
+    _logging_configured = True
+    return True
+
+
+def log_event(
+    logger: logging.Logger,
+    level: int,
+    event: str,
+    *,
+    exc_info: bool | BaseException = False,
+    **details: Any,
+) -> None:
+    """Emit a structured log event."""
+    logger.log(
+        level,
+        event,
+        extra={
+            "event": event,
+            "details": details,
+        },
+        exc_info=exc_info,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,9 @@
+import logging
 from contextlib import asynccontextmanager
+from time import perf_counter
+from uuid import uuid4
 
+import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -15,11 +19,23 @@ from app.features.workspace import (
     snapshot_router,
 )
 from app.http_errors import to_http_exception
-from app.observability import init_sentry
+from app.logging_utils import (
+    bind_log_context,
+    configure_logging,
+    log_event,
+    reset_log_context,
+)
+from app.observability import (
+    init_sentry,
+    set_sentry_request_context,
+    set_sentry_user_context,
+)
 from app.shared import DomainError
 
 settings_app = get_settings()
+configure_logging()
 init_sentry(with_fastapi=True)
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -74,14 +90,83 @@ database_initializer = RequestDatabaseInitializer(create_db_and_tables)
 
 
 @app.middleware("http")
-async def db_init_middleware(request: Request, call_next):
-    """Ensure database migrations have run on the first request."""
-    database_initializer.ensure_ready(
+async def request_logging_middleware(request: Request, call_next):
+    """Bind request context, ensure DB readiness, and emit one access log record."""
+    request_id = request.headers.get("x-request-id") or str(uuid4())
+    sentry_trace = request.headers.get("sentry-trace", "")
+    traceparent = request.headers.get("traceparent", "")
+    trace_id = None
+
+    if sentry_trace:
+        trace_id = sentry_trace.split("-", maxsplit=1)[0] or None
+    elif traceparent:
+        segments = traceparent.split("-")
+        if len(segments) >= 2:
+            trace_id = segments[1] or None
+
+    context_tokens = bind_log_context(
+        request_id=request_id,
+        trace_id=trace_id,
+        method=request.method,
         path=request.url.path,
-        dependency_overrides=app.dependency_overrides,
-        session_dependency=get_session,
     )
-    return await call_next(request)
+    request.state.request_id = request_id
+    request.state.trace_id = trace_id
+    set_sentry_user_context(None)
+    set_sentry_request_context(
+        request_id=request_id,
+        route=request.url.path,
+        method=request.method,
+        trace_id=trace_id,
+    )
+
+    started = perf_counter()
+    outcome = "success"
+    reason = None
+
+    try:
+        database_initializer.ensure_ready(
+            path=request.url.path,
+            dependency_overrides=app.dependency_overrides,
+            session_dependency=get_session,
+        )
+        response = await call_next(request)
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
+        outcome = "error"
+        reason = "unhandled_exception"
+        response = JSONResponse(
+            status_code=500,
+            content={"detail": "Internal Server Error"},
+        )
+
+    latency_ms = round((perf_counter() - started) * 1000, 2)
+    response.headers["X-Request-ID"] = request_id
+
+    status_code = response.status_code
+    if request.url.path == "/health":
+        level = logging.DEBUG
+    elif status_code >= 500:
+        level = logging.ERROR
+    elif status_code >= 400:
+        level = logging.WARNING
+        outcome = "failure"
+    else:
+        level = logging.INFO
+
+    log_event(
+        logger,
+        level,
+        "ops.http.request.completed",
+        method=request.method,
+        path=request.url.path,
+        status_code=status_code,
+        latency_ms=latency_ms,
+        outcome=outcome,
+        reason=reason,
+    )
+    reset_log_context(context_tokens)
+    return response
 
 
 @app.get("/health")

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -11,6 +11,7 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 
 from app.config import get_settings
+from app.logging_utils import log_event
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +41,12 @@ def get_sentry_dsn() -> str:
             WithDecryption=True,
         )
     except Exception:
-        logger.warning(
-            "Failed to load Sentry DSN from SSM parameter %s",
-            settings.sentry_dsn_parameter_name,
+        log_event(
+            logger,
+            logging.WARNING,
+            "ops.sentry.dsn_load_failed",
+            parameter_name=settings.sentry_dsn_parameter_name,
+            outcome="failure",
             exc_info=True,
         )
         return ""
@@ -72,18 +76,51 @@ def init_sentry(*, with_fastapi: bool = False) -> bool:
     sentry_sdk.init(
         dsn=dsn,
         environment=settings.environment,
-        send_default_pii=True,
+        send_default_pii=False,
         traces_sample_rate=settings.effective_sentry_traces_sample_rate,
         integrations=integrations,
     )
 
     _sentry_initialized = True
     _fastapi_integration_enabled = _fastapi_integration_enabled or with_fastapi
-    logger.info(
-        "Sentry initialized",
-        extra={
-            "environment": settings.environment,
-            "with_fastapi": with_fastapi,
-        },
+    log_event(
+        logger,
+        logging.INFO,
+        "ops.sentry.initialized",
+        with_fastapi=with_fastapi,
+        outcome="success",
     )
     return True
+
+
+def set_sentry_request_context(
+    *,
+    request_id: str,
+    route: str,
+    method: str,
+    trace_id: str | None = None,
+) -> None:
+    """Bind request-scoped metadata to the active Sentry scope."""
+    if not _sentry_initialized:
+        return
+
+    sentry_sdk.set_tag("request_id", request_id)
+    sentry_sdk.set_tag("route", route)
+    if trace_id:
+        sentry_sdk.set_tag("trace_id", trace_id)
+    sentry_sdk.set_context(
+        "request",
+        {
+            "request_id": request_id,
+            "route": route,
+            "method": method,
+        },
+    )
+
+
+def set_sentry_user_context(user_id: str | None) -> None:
+    """Bind the authenticated user to the active Sentry scope."""
+    if not _sentry_initialized:
+        return
+
+    sentry_sdk.set_user({"id": user_id} if user_id else None)

--- a/backend/app/worker_lambda_handler.py
+++ b/backend/app/worker_lambda_handler.py
@@ -5,8 +5,10 @@ import logging
 from app.bootstrap import run_cold_start_database_bootstrap
 from app.database import create_db_and_tables
 from app.features.assistant import run_edit_job_queue_records
+from app.logging_utils import bind_log_context, configure_logging, reset_log_context
 from app.observability import init_sentry
 
+configure_logging()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -21,11 +23,17 @@ run_cold_start_database_bootstrap(
 
 def handler(event, context):
     """Handle SQS events for queued AI edit jobs."""
-    if not isinstance(event, dict) or not event.get("Records"):
-        raise ValueError("AI edit worker expects SQS records")
+    context_tokens = bind_log_context(
+        request_id=getattr(context, "aws_request_id", None),
+    )
+    try:
+        if not isinstance(event, dict) or not event.get("Records"):
+            raise ValueError("AI edit worker expects SQS records")
 
-    first_record = event["Records"][0]
-    if first_record.get("eventSource") != "aws:sqs":
-        raise ValueError("AI edit worker only supports SQS events")
+        first_record = event["Records"][0]
+        if first_record.get("eventSource") != "aws:sqs":
+            raise ValueError("AI edit worker only supports SQS events")
 
-    return run_edit_job_queue_records(event["Records"])
+        return run_edit_job_queue_records(event["Records"])
+    finally:
+        reset_log_context(context_tokens)

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -1,0 +1,31 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+
+def _events(caplog) -> list[str]:
+    return [getattr(record, "event", "") for record in caplog.records]
+
+
+def test_settings_response_includes_request_id_header(client: TestClient):
+    response = client.get("/api/settings")
+
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"]
+
+
+def test_settings_update_emits_access_and_audit_logs(client: TestClient, caplog):
+    with caplog.at_level(logging.INFO):
+        response = client.put("/api/settings", json={"language": "ja"})
+
+    assert response.status_code == 200
+    assert "ops.http.request.completed" in _events(caplog)
+    assert "audit.settings.updated" in _events(caplog)
+
+
+def test_admin_forbidden_emits_authorization_log(client: TestClient, caplog):
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/admin/users")
+
+    assert response.status_code == 403
+    assert "security.authorization.denied" in _events(caplog)

--- a/backend/tests/unit/test_logging_utils.py
+++ b/backend/tests/unit/test_logging_utils.py
@@ -1,0 +1,69 @@
+import json
+import logging
+
+from app.logging_utils import (
+    JsonLogFormatter,
+    bind_log_context,
+    reset_log_context,
+    sanitize_log_value,
+)
+
+
+def test_sanitize_log_value_redacts_sensitive_fields():
+    payload = {
+        "email": "user@example.com",
+        "token": "secret",
+        "user_id": "user-123",
+        "nested": {
+            "authorization": "Bearer token",
+        },
+    }
+
+    sanitized = sanitize_log_value(payload)
+
+    assert sanitized["email"] == "[REDACTED]"
+    assert sanitized["token"] == "[REDACTED]"
+    assert sanitized["user_id"] == "user-123"
+    assert sanitized["nested"]["authorization"] == "[REDACTED]"
+
+
+def test_json_log_formatter_includes_context_and_redacts_values():
+    logger = logging.getLogger("tests.logging")
+    record = logger.makeRecord(
+        name=logger.name,
+        level=logging.INFO,
+        fn=__file__,
+        lno=1,
+        msg="audit.settings.updated",
+        args=(),
+        exc_info=None,
+        extra={
+            "event": "audit.settings.updated",
+            "details": {
+                "email": "user@example.com",
+                "status_code": 200,
+            },
+        },
+    )
+    tokens = bind_log_context(
+        request_id="req-123",
+        trace_id="trace-123",
+        user_id="user-123",
+        method="PUT",
+        path="/api/settings",
+    )
+
+    try:
+        payload = json.loads(JsonLogFormatter().format(record))
+    finally:
+        reset_log_context(tokens)
+
+    assert payload["event"] == "audit.settings.updated"
+    assert payload["request_id"] == "req-123"
+    assert payload["trace_id"] == "trace-123"
+    assert payload["user_id"] == "user-123"
+    assert payload["method"] == "PUT"
+    assert payload["path"] == "/api/settings"
+    assert payload["email"] == "[REDACTED]"
+    assert payload["status_code"] == 200
+    assert payload["timezone"] == "UTC"

--- a/backend/tests/unit/test_observability.py
+++ b/backend/tests/unit/test_observability.py
@@ -52,7 +52,7 @@ def test_init_sentry_configures_lambda_and_fastapi_integrations():
     kwargs = mock_init.call_args.kwargs
     assert kwargs["dsn"] == settings.sentry_dsn
     assert kwargs["environment"] == "dev"
-    assert kwargs["send_default_pii"] is True
+    assert kwargs["send_default_pii"] is False
     assert kwargs["traces_sample_rate"] == 1.0
     assert isinstance(kwargs["integrations"][0], AwsLambdaIntegration)
     assert kwargs["integrations"][0].timeout_warning is True

--- a/frontend/src/components/layout/NoteList.tsx
+++ b/frontend/src/components/layout/NoteList.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Input } from "@/components/ui/input";
+import { logger } from "@/lib/logger";
 import type { Note } from "@/types";
 import { cn } from "@/lib/utils";
 import { 
@@ -57,7 +58,7 @@ export function NoteList({
     try {
       await onCreateNote();
     } catch (error) {
-      console.error("Failed to create note:", error);
+      logger.error("Failed to create note", error);
     } finally {
       setIsCreating(false);
     }
@@ -305,4 +306,3 @@ export function NoteList({
     </div>
   );
 }
-

--- a/frontend/src/components/layout/SettingsDialog.tsx
+++ b/frontend/src/components/layout/SettingsDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { logger } from "@/lib/logger";
 import { Loader2Icon, CheckIcon, Trash2Icon, RefreshCwIcon, KeyIcon } from "lucide-react";
 import { useApi, useTranslation } from "@/hooks";
 import type { AvailableModel, AvailableLanguage, TokenUsageRead, MCPTokenListItem, MCPSettingsResponse } from "@/types";
@@ -61,7 +62,7 @@ function NewTokenDialog({ open, onOpenChange, onTokenCreated }: NewTokenDialogPr
       });
       onTokenCreated();
     } catch (err) {
-      console.error("Failed to create API key:", err);
+      logger.error("Failed to create API key", err);
       const errorMsg = err instanceof Error ? err.message : t("common.error");
       setError(errorMsg);
     } finally {
@@ -230,7 +231,7 @@ export function SettingsDialog({
       const response = await apiClient.listMcpTokens();
       setApiKeys(response.tokens || []);
     } catch (err) {
-      console.error("Failed to load API keys:", err);
+      logger.error("Failed to load API keys", err);
       setError(t("common.error"));
     } finally {
       setIsApiKeysLoading(false);
@@ -249,7 +250,7 @@ export function SettingsDialog({
         await apiClient.restoreMcpToken(tokenId);
         await loadApiKeys();
       } catch (err) {
-        console.error("Failed to restore API key:", err);
+        logger.error("Failed to restore API key", err);
         setError(t("common.error"));
       } finally {
         setIsRestoring(null);
@@ -262,7 +263,7 @@ export function SettingsDialog({
         await apiClient.revokeMcpToken(tokenId);
         await loadApiKeys();
       } catch (err) {
-        console.error("Failed to revoke API key:", err);
+        logger.error("Failed to revoke API key", err);
         setError(t("common.error"));
       } finally {
         setIsRevoking(null);
@@ -281,7 +282,7 @@ export function SettingsDialog({
       await apiClient.deleteMcpToken(tokenId);
       await loadApiKeys();
     } catch (err) {
-      console.error("Failed to delete API key:", err);
+      logger.error("Failed to delete API key", err);
       setError(t("common.error"));
     } finally {
       setIsDeleting(null);
@@ -299,7 +300,11 @@ export function SettingsDialog({
       try {
         const apiClient = await getApi();
         const response = await apiClient.getSettings();
-        console.log("Settings API response:", response);
+        logger.debug("Settings API response received", {
+          has_settings: Boolean(response?.settings),
+          available_model_count: response?.available_models?.length ?? 0,
+          available_language_count: response?.available_languages?.length ?? 0,
+        });
 
         if (response?.settings) {
           setSelectedModelId(response.settings.llm_model_id);
@@ -320,7 +325,7 @@ export function SettingsDialog({
         const mcpSettingsResponse = await apiClient.getMcpSettings();
         setMcpSettings(mcpSettingsResponse);
       } catch (err) {
-        console.error("Failed to load settings:", err);
+        logger.error("Failed to load settings", err);
         setError(t("settings.loadError"));
       } finally {
         setIsLoading(false);
@@ -344,7 +349,7 @@ export function SettingsDialog({
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 2000);
     } catch (err) {
-      console.error("Failed to save settings:", err);
+      logger.error("Failed to save settings", err);
       setError(t("settings.saveError"));
     } finally {
       setIsSaving(false);
@@ -367,7 +372,7 @@ export function SettingsDialog({
       link.parentNode?.removeChild(link);
       window.URL.revokeObjectURL(url);
     } catch (err) {
-      console.error("Failed to export notes:", err);
+      logger.error("Failed to export notes", err);
       setError(t("common.error"));
     } finally {
       setIsExporting(false);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Input } from "@/components/ui/input";
 import type { Folder } from "@/types";
 import { cn } from "@/lib/utils";
+import { logger } from "@/lib/logger";
 import { FolderIcon, FolderPlusIcon, TrashIcon, PencilIcon, PanelLeftCloseIcon, CheckIcon, XIcon, Loader2Icon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "@/hooks";
@@ -43,7 +44,7 @@ export function Sidebar({
         setNewFolderName("");
         setIsCreating(false);
       } catch (error) {
-        console.error("Failed to create folder", error);
+        logger.error("Failed to create folder", error);
       } finally {
         setIsSubmitting(false);
       }

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { ja, en, type TranslationKeys, type Language } from "@/locales";
 import { useApi } from "@/hooks";
 import { useAuth } from "@/lib/auth-context";
+import { logger } from "@/lib/logger";
 
 interface LanguageContextType {
   language: Language;
@@ -63,7 +64,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
           return;
         }
 
-        console.error("Failed to load language settings:", error);
+        logger.error("Failed to load language settings", error);
         // Fall back to auto
         setLanguageState("auto");
       } finally {

--- a/frontend/src/hooks/useAIChat.ts
+++ b/frontend/src/hooks/useAIChat.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useApi } from "./useApi";
 import { useTranslation } from "./useTranslation";
+import { logger } from "@/lib/logger";
 import type { ChatMessage } from "@/types";
 
 export type ChatScope = "note" | "folder" | "all";
@@ -58,7 +59,7 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
       };
       setChatMessages((prev) => [...prev, summaryMessage]);
     } catch (error: unknown) {
-      console.error("Failed to summarize:", error);
+      logger.error("Failed to summarize", error);
       if ((error as { status?: number })?.status === 429) {
         setChatMessages((prev) => [...prev, { role: "assistant", content: t("aiEdit.tokenLimitExceeded") }]);
       }
@@ -97,7 +98,7 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
       };
       setChatMessages((prev) => [...prev, assistantMessage]);
     } catch (error: unknown) {
-      console.error("Failed to chat:", error);
+      logger.error("Failed to chat", error);
       if ((error as { status?: number })?.status === 429) {
         setChatMessages((prev) => [...prev, { role: "assistant", content: t("aiEdit.tokenLimitExceeded") }]);
       }
@@ -172,7 +173,7 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
         setChatMessages((prev) => [...prev, assistantMessage]);
       }
     } catch (error: unknown) {
-      console.error("Failed to edit:", error);
+      logger.error("Failed to edit", error);
       if ((error as { status?: number })?.status === 429) {
         setChatMessages((prev) => [
           ...prev,

--- a/frontend/src/hooks/useFolders.ts
+++ b/frontend/src/hooks/useFolders.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import { useApi } from "./useApi";
 import { notesDB } from "@/lib/indexedDB";
+import { logger } from "@/lib/logger";
 import { syncQueue } from "@/lib/syncQueue";
 import {
   getWorkspaceSyncRequestMetadata,
@@ -61,7 +62,7 @@ export function useFolders(
       try {
         await notesDB.saveFolder(tempFolder);
       } catch (error) {
-        console.error("Failed to save folder locally:", error);
+        logger.error("Failed to save folder locally", error);
       }
 
       if (navigator.onLine) {
@@ -88,7 +89,7 @@ export function useFolders(
             await refreshWorkspaceSnapshot(apiClient, { onSnapshotSynced });
             return;
           }
-          console.error("Failed to create folder:", error);
+          logger.error("Failed to create folder", error);
         }
       }
 
@@ -117,7 +118,7 @@ export function useFolders(
       try {
         await notesDB.saveFolder(updatedFolder);
       } catch (error) {
-        console.error("Failed to save folder locally:", error);
+        logger.error("Failed to save folder locally", error);
       }
 
       if (navigator.onLine) {
@@ -145,7 +146,7 @@ export function useFolders(
             await refreshWorkspaceSnapshot(apiClient, { onSnapshotSynced });
             return;
           }
-          console.error("Failed to rename folder:", error);
+          logger.error("Failed to rename folder", error);
         }
       }
 
@@ -171,7 +172,7 @@ export function useFolders(
       try {
         await notesDB.deleteFolder(id);
       } catch (error) {
-        console.error("Failed to delete folder locally:", error);
+        logger.error("Failed to delete folder locally", error);
       }
 
       if (id.startsWith("temp-")) {
@@ -202,7 +203,7 @@ export function useFolders(
             await refreshWorkspaceSnapshot(apiClient, { onSnapshotSynced });
             return;
           }
-          console.error("Failed to delete folder:", error);
+          logger.error("Failed to delete folder", error);
         }
       }
 

--- a/frontend/src/hooks/useOfflineSync.ts
+++ b/frontend/src/hooks/useOfflineSync.ts
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { notesDB } from "@/lib/indexedDB";
+import { logger } from "@/lib/logger";
 import { syncQueue, type SyncStatus } from "@/lib/syncQueue";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useApi } from "./useApi";
@@ -48,7 +49,7 @@ export function useOfflineSync(
       const count = await syncQueue.getPendingCount();
       setPendingChangesCount(count);
     } catch (error) {
-      console.error("Failed to get pending count:", error);
+      logger.error("Failed to get pending count", error);
     }
   }, []);
 
@@ -75,12 +76,12 @@ export function useOfflineSync(
       } else if (result.failedCount > 0) {
         setSyncStatus("error");
         setLastErrorMessage(t("sync.serverSyncFailed"));
-        console.error("Sync errors:", result.errors);
+        logger.warn("Sync errors", { errors: result.errors });
       }
 
       await updatePendingCount();
     } catch (error) {
-      console.error("Sync failed:", error);
+      logger.error("Sync failed", error);
       setSyncStatus("error");
       setLastErrorMessage(t("sync.serverSyncFailed"));
     } finally {
@@ -121,7 +122,9 @@ export function useOfflineSync(
     }
 
     // Initialize IndexedDB
-    notesDB.init().catch(console.error);
+    notesDB.init().catch((error) => {
+      logger.error("Failed to initialize IndexedDB", error);
+    });
 
     // Initial pending count
     updatePendingCount();

--- a/frontend/src/hooks/useTokenUsage.ts
+++ b/frontend/src/hooks/useTokenUsage.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect } from "react";
 import { useApi } from "./useApi";
 import type { TokenUsageRead } from "@/types";
 import { useAuth } from "@/lib/auth-context";
+import { logger } from "@/lib/logger";
 
 export function useTokenUsage(isAuthenticated: boolean) {
     const { getApi } = useApi();
@@ -19,7 +20,7 @@ export function useTokenUsage(isAuthenticated: boolean) {
                 setTokenUsage(response.token_usage);
             }
         } catch (error) {
-            console.error("Failed to fetch token usage:", error);
+            logger.error("Failed to fetch token usage", error);
         }
     }, [authLoading, isAuthenticated, getApi]);
 

--- a/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth-context";
 import { notesDB } from "@/lib/indexedDB";
+import { logger } from "@/lib/logger";
 import { mergeFolders, mergeNotes } from "@/lib/merge";
 import {
   getActiveFolders,
@@ -76,7 +77,7 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
         }
       } catch (error) {
         if (isActive) {
-          console.error("Failed to load data:", error);
+          logger.error("Failed to load workspace data", error);
         }
       } finally {
         if (isActive) {

--- a/frontend/src/lib/amplify.tsx
+++ b/frontend/src/lib/amplify.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, ReactNode } from "react";
 import { Amplify, ResourcesConfig } from "aws-amplify";
+import { logger } from "@/lib/logger";
 
 // Cognito configuration from environment variables
 const amplifyConfig: ResourcesConfig = {
@@ -40,9 +41,7 @@ export function AmplifyProvider({ children }: { children: ReactNode }) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsConfigured(true);
     } catch (error) {
-      console.error("Failed to configure Amplify:", error);
-
-
+      logger.error("Failed to configure Amplify", error);
       setIsConfigured(true); // Still render children
     }
   }, []);

--- a/frontend/src/lib/auth-context.test.tsx
+++ b/frontend/src/lib/auth-context.test.tsx
@@ -1,0 +1,31 @@
+import * as Sentry from "@sentry/nextjs";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AuthProvider, useAuth } from "./auth-context";
+
+function AuthConsumer() {
+  const { isLoading, user } = useAuth();
+
+  if (isLoading) {
+    return <div>loading</div>;
+  }
+
+  return <div>{user?.userId ?? "anonymous"}</div>;
+}
+
+describe("AuthProvider", () => {
+  it("binds the authenticated user id to Sentry", async () => {
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("test-user-id")).toBeInTheDocument();
+    });
+
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: "test-user-id" });
+  });
+});

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -19,6 +19,7 @@ import {
   type SignUpInput,
   type ConfirmSignUpInput,
 } from "aws-amplify/auth";
+import { logger } from "@/lib/logger";
 
 interface User {
   userId: string;
@@ -61,6 +62,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     checkUser();
   }, [checkUser]);
+
+  useEffect(() => {
+    logger.setUser(user?.userId ?? null);
+  }, [user]);
 
   const handleSignIn = async (email: string, password: string) => {
     const input: SignInInput = { username: email, password };

--- a/frontend/src/lib/indexedDB.ts
+++ b/frontend/src/lib/indexedDB.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Note, Folder } from "@/types";
+import { logger } from "@/lib/logger";
 
 const DB_NAME = "notes-app-db";
 const DB_VERSION = 1;
@@ -44,7 +45,7 @@ class NotesDB {
       const request = indexedDB.open(DB_NAME, DB_VERSION);
 
       request.onerror = () => {
-        console.error("Failed to open IndexedDB:", request.error);
+        logger.error("Failed to open IndexedDB", request.error);
         reject(request.error);
       };
 

--- a/frontend/src/lib/logger.test.ts
+++ b/frontend/src/lib/logger.test.ts
@@ -1,0 +1,53 @@
+import * as Sentry from "@sentry/nextjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { logger } from "./logger";
+
+describe("logger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("suppresses info logs in production console output", () => {
+    process.env.NODE_ENV = "production";
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    logger.info("Informational message");
+
+    expect(consoleInfo).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends warnings to console and Sentry", () => {
+    process.env.NODE_ENV = "production";
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    logger.warn("Sync warning", { failedCount: 2 });
+
+    expect(consoleWarn).toHaveBeenCalledWith("Sync warning", { failedCount: 2 });
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Sync warning",
+        level: "warning",
+      }),
+    );
+    expect(Sentry.captureMessage).toHaveBeenCalledWith("Sync warning", "warning");
+  });
+
+  it("captures exceptions for error logs", () => {
+    process.env.NODE_ENV = "production";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const error = new Error("boom");
+
+    logger.error("Unexpected failure", error);
+
+    expect(consoleError).toHaveBeenCalledWith("Unexpected failure", error);
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Unexpected failure",
+        level: "error",
+      }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
+  });
+});

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,105 @@
+import * as Sentry from "@sentry/nextjs";
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+type LogContext = Record<string, unknown>;
+
+function toSentryLevel(level: LogLevel): "debug" | "info" | "warning" | "error" {
+  return level === "warn" ? "warning" : level;
+}
+
+function isVerboseConsoleEnabled(): boolean {
+  return process.env.NODE_ENV === "development";
+}
+
+function normalizeContext(context?: unknown): LogContext | undefined {
+  if (context === undefined) {
+    return undefined;
+  }
+
+  if (context instanceof Error) {
+    return {
+      error_name: context.name,
+      error_message: context.message,
+    };
+  }
+
+  if (typeof context === "object" && context !== null) {
+    return context as LogContext;
+  }
+
+  return { value: context };
+}
+
+function writeConsole(level: LogLevel, message: string, context?: unknown): void {
+  if ((level === "debug" || level === "info") && !isVerboseConsoleEnabled()) {
+    return;
+  }
+
+  const method =
+    level === "debug"
+      ? console.debug
+      : level === "info"
+        ? console.info
+        : level === "warn"
+          ? console.warn
+          : console.error;
+
+  if (context === undefined) {
+    method(message);
+    return;
+  }
+
+  method(message, context);
+}
+
+function writeSentry(level: LogLevel, message: string, context?: unknown): void {
+  const data = normalizeContext(context);
+
+  Sentry.addBreadcrumb({
+    category: "app.logger",
+    level: toSentryLevel(level),
+    message,
+    data,
+  });
+
+  if (level === "warn") {
+    Sentry.captureMessage(message, "warning");
+    return;
+  }
+
+  if (level !== "error") {
+    return;
+  }
+
+  if (context instanceof Error) {
+    Sentry.captureException(context);
+    return;
+  }
+
+  Sentry.captureMessage(message, "error");
+}
+
+function log(level: LogLevel, message: string, context?: unknown): void {
+  writeConsole(level, message, context);
+  if (level === "warn" || level === "error") {
+    writeSentry(level, message, context);
+  }
+}
+
+export const logger = {
+  debug(message: string, context?: unknown) {
+    log("debug", message, context);
+  },
+  info(message: string, context?: unknown) {
+    log("info", message, context);
+  },
+  warn(message: string, context?: unknown) {
+    log("warn", message, context);
+  },
+  error(message: string, context?: unknown) {
+    log("error", message, context);
+  },
+  setUser(userId: string | null) {
+    Sentry.setUser(userId ? { id: userId } : null);
+  },
+};

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useTranslation } from "@/hooks/useTranslation";
 import { notesDB } from "@/lib/indexedDB";
+import { logger } from "@/lib/logger";
 import { syncQueue } from "@/lib/syncQueue";
 import { calculateHash } from "@/lib/utils";
 import {
@@ -161,7 +162,7 @@ export function useNoteSyncEngine({
               setLastError(t("sync.conflictReloaded"));
               return;
             }
-            console.error("Failed to sync note to server:", error);
+            logger.error("Failed to sync note to server", error);
             await syncQueue.addChange("update", "note", id, updates, {
               expectedVersion,
             });
@@ -318,7 +319,7 @@ export function useNoteSyncEngine({
           setLastError(t("sync.conflictReloaded"));
           return;
         }
-        console.error("Failed to create note on server:", error);
+        logger.error("Failed to create note on server", error);
         await syncQueue.addChange("create", "note", tempId, {
           title: "",
           content: "",
@@ -385,7 +386,7 @@ export function useNoteSyncEngine({
           setLocalStatus("saved");
         }
       } catch (error) {
-        console.error("Failed to save locally", error);
+        logger.error("Failed to save locally", error);
         setLocalStatus("failed");
         setLastError(t("sync.localSaveFailed"));
       }
@@ -446,7 +447,7 @@ export function useNoteSyncEngine({
               setLastError(t("sync.conflictReloaded"));
               return;
             }
-            console.error("Failed to delete note on server:", error);
+            logger.error("Failed to delete note on server", error);
             if (!id.startsWith("temp-")) {
               await syncQueue.addChange("delete", "note", id, undefined, {
                 expectedVersion,
@@ -462,7 +463,7 @@ export function useNoteSyncEngine({
           });
         }
       } catch (error) {
-        console.error("Failed to delete note:", error);
+        logger.error("Failed to delete note", error);
       }
     },
     [

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -5,6 +5,8 @@ vi.mock('@sentry/nextjs', () => ({
   init: vi.fn(),
   setUser: vi.fn(),
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
   captureRouterTransitionStart: vi.fn(),
   browserTracingIntegration: vi.fn((options?: unknown) => ({
     name: 'browserTracingIntegration',

--- a/terraform/cost_report.tf
+++ b/terraform/cost_report.tf
@@ -116,7 +116,7 @@ resource "aws_lambda_function" "cost_report" {
 # CloudWatch Log Group
 resource "aws_cloudwatch_log_group" "cost_report" {
   name              = "/aws/lambda/${aws_lambda_function.cost_report.function_name}"
-  retention_in_days = 14
+  retention_in_days = 90
 
   tags = {
     Name = "${var.project_name}-cost-report-${terraform.workspace}"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -81,7 +81,7 @@ resource "aws_lambda_function" "ai_edit_worker" {
 # CloudWatch Log Groups for Lambda functions (explicit declaration for retention and policy compliance)
 resource "aws_cloudwatch_log_group" "api_lambda" {
   name              = "/aws/lambda/${aws_lambda_function.api.function_name}"
-  retention_in_days = 7
+  retention_in_days = 90
 
   tags = {
     Name = "${var.project_name}-api-logs-${terraform.workspace}"
@@ -90,10 +90,19 @@ resource "aws_cloudwatch_log_group" "api_lambda" {
 
 resource "aws_cloudwatch_log_group" "ai_edit_worker_lambda" {
   name              = "/aws/lambda/${aws_lambda_function.ai_edit_worker.function_name}"
-  retention_in_days = 7
+  retention_in_days = 90
 
   tags = {
     Name = "${var.project_name}-ai-edit-worker-logs-${terraform.workspace}"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "api_gateway" {
+  name              = "/aws/api-gateway/${aws_apigatewayv2_api.api.name}"
+  retention_in_days = 90
+
+  tags = {
+    Name = "${var.project_name}-api-gateway-logs-${terraform.workspace}"
   }
 }
 
@@ -154,6 +163,21 @@ resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.api.id
   name        = "$default"
   auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gateway.arn
+    format = jsonencode({
+      requestId               = "$context.requestId"
+      ip                      = "$context.identity.sourceIp"
+      requestTime             = "$context.requestTime"
+      httpMethod              = "$context.httpMethod"
+      routeKey                = "$context.routeKey"
+      status                  = "$context.status"
+      protocol                = "$context.protocol"
+      integrationLatency      = "$context.integrationLatency"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+    })
+  }
 
   tags = {
     Name = "${var.project_name}-api-${terraform.workspace}"

--- a/terraform/mcp.tf
+++ b/terraform/mcp.tf
@@ -69,7 +69,7 @@ resource "aws_lambda_function" "mcp_server" {
 # CloudWatch Log Group for MCP Server Lambda
 resource "aws_cloudwatch_log_group" "mcp_server_lambda" {
   name              = "/aws/lambda/${aws_lambda_function.mcp_server.function_name}"
-  retention_in_days = 7
+  retention_in_days = 90
 }
 
 # API Gateway for MCP Server
@@ -108,7 +108,7 @@ resource "aws_apigatewayv2_stage" "mcp_server" {
 
 resource "aws_cloudwatch_log_group" "mcp_api_gateway" {
   name              = "/aws/api-gateway/${aws_apigatewayv2_api.mcp_server.name}"
-  retention_in_days = 7
+  retention_in_days = 90
 }
 
 # Default route for MCP server (catch-all)


### PR DESCRIPTION
## Summary

Add structured logging and request tracing across the backend, frontend, and AWS infrastructure.

## Changes

- add backend JSON logging, request IDs, Sentry scoping, and explicit audit/security/ops events
- replace frontend runtime console calls with a shared logger and bind Sentry user context
- enable main API Gateway access logs and extend CloudWatch retention to 90 days
- add tests for backend logging helpers and frontend logger/auth integration
- add Makefile helpers for API Gateway logs and request ID lookups

## Testing

- make lint-backend BACKEND_PATH=.
- cd backend && uv run --extra dev python -m pytest tests/unit/test_observability.py tests/unit/test_logging_utils.py tests/test_logging.py -q
- make lint-frontend FRONTEND_PATH=src
- make test-frontend
- make tf-validate

## Notes

- `make test-backend` includes externally dependent AI integration tests and has shown intermittent timeout behavior.
