### PR TITLE
feat: add weather widget to editor status bar (#51)

### DIFF
--- a/frontend/src/components/WeatherWidget.test.tsx
+++ b/frontend/src/components/WeatherWidget.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor, act } from "@testing-library/react";
+import { WeatherWidget } from "./WeatherWidget";
+
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const texts: Record<string, string> = {
+        "weather.title": "Weather",
+        "weather.temperature": "Temperature",
+        "weather.lastUpdated": "Updated",
+        "weather.condition.clearSky": "Clear sky",
+        "weather.condition.partlyCloudy": "Partly cloudy",
+        "weather.condition.rain": "Rain",
+        "weather.condition.snow": "Snow",
+        "weather.condition.unknown": "Unknown",
+      };
+      return texts[key] || key;
+    },
+  }),
+}));
+
+const mockGeolocationSuccess = (latitude = 35.6762, longitude = 139.6503) => {
+  vi.stubGlobal("navigator", {
+    geolocation: {
+      getCurrentPosition: vi.fn((success) =>
+        success({ coords: { latitude, longitude } })
+      ),
+    },
+  });
+};
+
+const mockGeolocationDenied = () => {
+  vi.stubGlobal("navigator", {
+    geolocation: {
+      getCurrentPosition: vi.fn((_, error) =>
+        error({ code: 1, message: "User denied Geolocation" })
+      ),
+    },
+  });
+};
+
+// happy-dom では vi.stubGlobal("fetch") が効かないため global に直接代入する
+const setupFetchMock = (temperature = 18.3, weathercode = 2) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        current: { temperature_2m: temperature, weathercode },
+      }),
+  });
+  global.fetch = fetchMock;
+  return fetchMock;
+};
+
+const setupFetchFailure = (status = 500) => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+};
+
+describe("WeatherWidget", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // -------------------------
+  // 正常系
+  // -------------------------
+
+  it("位置情報許可 + API成功時に気温と絵文字を表示する", async () => {
+    mockGeolocationSuccess();
+    setupFetchMock(18.3, 2); // ⛅ partlyCloudy
+
+    const { getByTestId, getByText } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(getByTestId("weather-widget")).toBeInTheDocument();
+    });
+
+    expect(getByText("⛅")).toBeInTheDocument();
+    expect(getByText("18°")).toBeInTheDocument();
+  });
+
+  it("気温を四捨五入して表示する", async () => {
+    mockGeolocationSuccess();
+    setupFetchMock(18.6, 0);
+
+    const { getByText } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(getByText("19°")).toBeInTheDocument();
+    });
+  });
+
+  it("天気コード 0 (快晴) は ☀️ を表示する", async () => {
+    mockGeolocationSuccess();
+    setupFetchMock(25.0, 0);
+
+    const { getByText } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(getByText("☀️")).toBeInTheDocument();
+    });
+  });
+
+  it("天気コード 61 (雨) は 🌧️ を表示する", async () => {
+    mockGeolocationSuccess();
+    setupFetchMock(12.0, 61);
+
+    const { getByText } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(getByText("🌧️")).toBeInTheDocument();
+    });
+  });
+
+  it("天気コード 71 (雪) は ❄️ を表示する", async () => {
+    mockGeolocationSuccess();
+    setupFetchMock(0.5, 71);
+
+    const { getByText } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(getByText("❄️")).toBeInTheDocument();
+    });
+  });
+
+  it("未知の天気コードは ❓ を表示する", async () => {
+    mockGeolocationSuccess();
+    setupFetchMock(20.0, 999);
+
+    const { getByText } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(getByText("❓")).toBeInTheDocument();
+    });
+  });
+
+  it("React.memo でラップされている", () => {
+    const widgetType = (WeatherWidget as unknown as { $$typeof?: symbol })?.$$typeof;
+    expect(widgetType).toBe(Symbol.for("react.memo"));
+  });
+
+  // -------------------------
+  // エラー系（null を返す）
+  // -------------------------
+
+  it("位置情報が拒否された場合は何も表示しない", async () => {
+    mockGeolocationDenied();
+
+    const { container } = render(<WeatherWidget />);
+
+    // エラーコールバックは同期的に呼ばれるため即チェック可能
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("navigator.geolocation が存在しない場合は何も表示しない", () => {
+    vi.stubGlobal("navigator", {});
+
+    const { container } = render(<WeatherWidget />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("API fetch が失敗した場合は何も表示しない", async () => {
+    mockGeolocationSuccess();
+    setupFetchFailure(500);
+
+    const { container } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("ネットワークエラー時は何も表示しない", async () => {
+    mockGeolocationSuccess();
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network Error"));
+
+    const { container } = render(<WeatherWidget />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  // -------------------------
+  // 更新サイクル（fake timers を使用）
+  // -------------------------
+
+  describe("インターバル更新", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("30分後に fetch が再び呼ばれる", async () => {
+      mockGeolocationSuccess();
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ current: { temperature_2m: 20, weathercode: 0 } }),
+      });
+      global.fetch = fetchMock;
+
+      render(<WeatherWidget />);
+
+      // 初回 fetch の Promise チェーンを flush
+      await act(async () => {});
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // 30分経過でインターバル発火
+      await act(async () => {
+        vi.advanceTimersByTime(30 * 60 * 1000);
+      });
+      await act(async () => {});
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("アンマウント後は 30分経過しても fetch が呼ばれない", async () => {
+      mockGeolocationSuccess();
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ current: { temperature_2m: 20, weathercode: 0 } }),
+      });
+      global.fetch = fetchMock;
+
+      const { unmount } = render(<WeatherWidget />);
+
+      // 初回 fetch の Promise チェーンを flush
+      await act(async () => {});
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      // アンマウント後に 30分経過
+      vi.advanceTimersByTime(30 * 60 * 1000);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/components/WeatherWidget.tsx
+++ b/frontend/src/components/WeatherWidget.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { memo, useEffect, useRef, useState } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type WeatherState =
+  | { status: "idle" | "loading" | "error" }
+  | { status: "success"; temperature: number; weatherCode: number; updatedAt: Date };
+
+type WeatherConditionKey =
+  | "clearSky"
+  | "mainlyClear"
+  | "partlyCloudy"
+  | "overcast"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "snow"
+  | "rainShowers"
+  | "thunderstorm"
+  | "unknown";
+
+const WMO_MAP: Record<number, { emoji: string; labelKey: WeatherConditionKey }> = {
+  0:  { emoji: "☀️",  labelKey: "clearSky" },
+  1:  { emoji: "🌤️", labelKey: "mainlyClear" },
+  2:  { emoji: "⛅",  labelKey: "partlyCloudy" },
+  3:  { emoji: "☁️",  labelKey: "overcast" },
+  45: { emoji: "🌫️", labelKey: "fog" },
+  48: { emoji: "🌫️", labelKey: "fog" },
+  51: { emoji: "🌦️", labelKey: "drizzle" },
+  53: { emoji: "🌦️", labelKey: "drizzle" },
+  55: { emoji: "🌦️", labelKey: "drizzle" },
+  61: { emoji: "🌧️", labelKey: "rain" },
+  63: { emoji: "🌧️", labelKey: "rain" },
+  65: { emoji: "🌧️", labelKey: "rain" },
+  71: { emoji: "❄️",  labelKey: "snow" },
+  73: { emoji: "❄️",  labelKey: "snow" },
+  75: { emoji: "❄️",  labelKey: "snow" },
+  80: { emoji: "🌦️", labelKey: "rainShowers" },
+  81: { emoji: "🌦️", labelKey: "rainShowers" },
+  82: { emoji: "🌦️", labelKey: "rainShowers" },
+  95: { emoji: "⛈️",  labelKey: "thunderstorm" },
+  96: { emoji: "⛈️",  labelKey: "thunderstorm" },
+  99: { emoji: "⛈️",  labelKey: "thunderstorm" },
+};
+
+function getWeatherInfo(code: number): { emoji: string; labelKey: WeatherConditionKey } {
+  return WMO_MAP[code] ?? { emoji: "❓", labelKey: "unknown" };
+}
+
+function useWeather(): WeatherState {
+  const [state, setState] = useState<WeatherState>({ status: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      return;
+    }
+
+    const fetchWeather = (lat: number, lon: number) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setState({ status: "loading" });
+
+      fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weathercode&temperature_unit=celsius`,
+        { signal: controller.signal }
+      )
+        .then((res) => {
+          if (!res.ok) throw new Error("weather fetch failed");
+          return res.json();
+        })
+        .then((data) => {
+          setState({
+            status: "success",
+            temperature: data.current.temperature_2m,
+            weatherCode: data.current.weathercode,
+            updatedAt: new Date(),
+          });
+        })
+        .catch((err) => {
+          if (err.name !== "AbortError") {
+            setState({ status: "error" });
+          }
+        });
+    };
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        fetchWeather(latitude, longitude);
+        intervalRef.current = setInterval(
+          () => fetchWeather(latitude, longitude),
+          30 * 60 * 1000
+        );
+      },
+      () => {
+        setState({ status: "error" });
+      },
+      { timeout: 10_000 }
+    );
+
+    return () => {
+      abortRef.current?.abort();
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return state;
+}
+
+export const WeatherWidget = memo(function WeatherWidget() {
+  const { t } = useTranslation();
+  const state = useWeather();
+
+  if (state.status !== "success") {
+    return null;
+  }
+
+  const { temperature, weatherCode, updatedAt } = state;
+  const { emoji, labelKey } = getWeatherInfo(weatherCode);
+  const conditionLabel = t(`weather.condition.${labelKey}` as Parameters<typeof t>[0]);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex items-center gap-1.5 text-xs font-mono cursor-help bg-accent/50 hover:bg-accent px-2 py-1 rounded-md transition-colors"
+            data-testid="weather-widget"
+          >
+            <span>{emoji}</span>
+            <span className="text-muted-foreground">{Math.round(temperature)}°</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent align="center" sideOffset={5}>
+          <div className="space-y-1 text-sm font-sans">
+            <p className="font-semibold">{t("weather.title")}</p>
+            <p>{conditionLabel}</p>
+            <p className="text-muted-foreground">
+              {t("weather.temperature")}: {Math.round(temperature)}°C
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {t("weather.lastUpdated")}:{" "}
+              {updatedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </p>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+});

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Clock } from "@/components/Clock";
+import { WeatherWidget } from "@/components/WeatherWidget";
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import type { Note, Folder, TokenUsageRead, EditProposal } from "@/types";
@@ -1448,9 +1449,10 @@ export function EditorPanel({
           </div>
         </div>
 
-        {/* Clock and Token Usage - Absolutely centered */}
+        {/* Clock, Weather and Token Usage - Absolutely centered */}
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-4">
           <Clock />
+          <WeatherWidget />
           {tokenUsage && (
             <TokenUsageIndicator
               tokensUsed={tokenUsage.tokens_used}

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -256,6 +256,26 @@ export const en = {
     resetDate: "Reset Date",
     exceeded: "Monthly token limit exceeded. Your usage will reset at the beginning of next month.",
   },
+
+  // Weather
+  weather: {
+    title: "Weather",
+    temperature: "Temperature",
+    lastUpdated: "Updated",
+    condition: {
+      clearSky: "Clear sky",
+      mainlyClear: "Mainly clear",
+      partlyCloudy: "Partly cloudy",
+      overcast: "Overcast",
+      fog: "Fog",
+      drizzle: "Drizzle",
+      rain: "Rain",
+      snow: "Snow",
+      rainShowers: "Rain showers",
+      thunderstorm: "Thunderstorm",
+      unknown: "Unknown",
+    },
+  },
 };
 
 // Export type
@@ -489,5 +509,23 @@ export type TranslationKeys = {
     limit: string;
     resetDate: string;
     exceeded: string;
+  };
+  weather: {
+    title: string;
+    temperature: string;
+    lastUpdated: string;
+    condition: {
+      clearSky: string;
+      mainlyClear: string;
+      partlyCloudy: string;
+      overcast: string;
+      fog: string;
+      drizzle: string;
+      rain: string;
+      snow: string;
+      rainShowers: string;
+      thunderstorm: string;
+      unknown: string;
+    };
   };
 };

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -256,6 +256,26 @@ export const ja = {
     resetDate: "リセット日",
     exceeded: "月間のトークン上限に達しました。使用量は来月の初めにリセットされます。",
   },
+
+  // Weather
+  weather: {
+    title: "天気",
+    temperature: "気温",
+    lastUpdated: "更新",
+    condition: {
+      clearSky: "快晴",
+      mainlyClear: "ほぼ晴れ",
+      partlyCloudy: "一部曇り",
+      overcast: "曇り",
+      fog: "霧",
+      drizzle: "霧雨",
+      rain: "雨",
+      snow: "雪",
+      rainShowers: "にわか雨",
+      thunderstorm: "雷雨",
+      unknown: "不明",
+    },
+  },
 } as const;
 
 // Structural type for translations (allows different string values)
@@ -486,5 +506,23 @@ export type TranslationKeys = {
     limit: string;
     resetDate: string;
     exceeded: string;
+  };
+  weather: {
+    title: string;
+    temperature: string;
+    lastUpdated: string;
+    condition: {
+      clearSky: string;
+      mainlyClear: string;
+      partlyCloudy: string;
+      overcast: string;
+      fog: string;
+      drizzle: string;
+      rain: string;
+      snow: string;
+      rainShowers: string;
+      thunderstorm: string;
+      unknown: string;
+    };
   };
 };


### PR DESCRIPTION
## 概要

ステータスバーの時計の隣に天気情報を表示する機能を追加します（Issue #51）。ブラウザの位置情報APIとOpen-Meteo（無料・APIキー不要）を使用して、現在地の気温と天気概況をMacメニューバー風のコンパクなデザインで表示します。

## 変更内容

- `frontend/src/components/WeatherWidget.tsx` (新規): 天気情報を取得・表示するコンポーネント。位置情報の取得拒否やネットワークエラー時はサイレントに非表示。30分ごとに自動更新
- `frontend/src/components/layout/EditorPanel.tsx`: ステータスバーの時計とトークン使用量の間に `<WeatherWidget />` を挿入
- `frontend/src/locales/en.ts`: `weather.*` 翻訳キーと型定義を追加
- `frontend/src/locales/ja.ts`: 日本語の `weather.*` 翻訳を追加

## テスト方法

- [ ] エディタを開いてノートを選択する
- [ ] 位置情報の許可を求めるダイアログが表示されたら「許可」を選択 → ステータスバーの時計横に `⛅ 18°` のように表示される
- [ ] 天気ウィジェットにホバーすると天気概況・気温・更新時刻のツールチップが表示される
- [ ] 位置情報の許可を拒否した場合、天気ウィジェットが表示されない（エラー表示なし）

## チェックリスト

- [ ] テストを追加・更新した
- [x] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（en.ts / ja.ts）