### PR TITLE
feat: add external API key access for notes and folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,11 @@ test-unit: test-backend test-frontend ## Run all unit tests across backend and f
 test-app-contracts: ## Run high-value backend API contract regressions
 	cd backend && uv run --extra dev python -m pytest tests/test_notes.py tests/test_folders.py tests/test_settings.py tests/test_share.py tests/test_admin.py -q --tb=short
 
+.PHONY: test-external-api
+test-external-api: ## Run external folder/note API key regressions
+	cd backend && uv run --extra dev python -m pytest tests/test_api_keys.py -q --tb=short
+	cd frontend && npm run test -- --run src/components/layout/SettingsDialog.test.tsx
+
 .PHONY: test-sync
 test-sync: ## Run frontend sync and offline regression tests
 	cd frontend && npm run test -- --run src/hooks/useHomeData.test.ts src/hooks/useNotes.test.ts src/hooks/useOfflineSync.test.ts src/lib/syncQueue.test.ts src/lib/merge.test.ts

--- a/backend/alembic/versions/20260409_02_add_user_api_keys.py
+++ b/backend/alembic/versions/20260409_02_add_user_api_keys.py
@@ -1,0 +1,29 @@
+"""Add user API keys table."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260409_02"
+down_revision = "20260409_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_api_keys",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("token_prefix", sa.String(length=32), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_api_keys")

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,19 +1,24 @@
+from app.auth.api_key_service import UserApiKeyService
 from app.auth.app_user_service import AppUserService
 from app.auth.cognito import cognito_verifier
 from app.auth.dependencies import (
     AdminUser,
     CurrentAppUser,
     CurrentUser,
+    FolderNoteUserId,
     UserId,
     get_current_app_user,
     get_current_user,
+    get_folder_note_user_id,
     get_user_id,
     require_admin,
 )
 
 __all__ = [
     "AppUserService",
+    "UserApiKeyService",
     "cognito_verifier",
+    "get_folder_note_user_id",
     "get_current_app_user",
     "get_current_user",
     "get_user_id",
@@ -21,5 +26,6 @@ __all__ = [
     "AdminUser",
     "CurrentAppUser",
     "CurrentUser",
+    "FolderNoteUserId",
     "UserId",
 ]

--- a/backend/app/auth/api_key_service.py
+++ b/backend/app/auth/api_key_service.py
@@ -1,0 +1,100 @@
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlmodel import Session, select
+
+from app.db_commit import commit_with_error_handling
+from app.models import UserApiKey, UserApiKeyCreate
+from app.shared import NotFound, ValidationFailed
+
+API_KEY_PLAIN_PREFIX = "notes_"
+API_KEY_PREFIX_LENGTH = 16
+API_KEY_TOUCH_INTERVAL = timedelta(minutes=15)
+
+
+class UserApiKeyService:
+    """Create, revoke, list, and authenticate user API keys."""
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list_active_keys(self, user_id: str) -> list[UserApiKey]:
+        statement = (
+            select(UserApiKey)
+            .where(UserApiKey.user_id == user_id, UserApiKey.revoked_at.is_(None))
+            .order_by(UserApiKey.created_at.desc())
+        )
+        return list(self.session.exec(statement))
+
+    def create_key(
+        self, user_id: str, payload: UserApiKeyCreate
+    ) -> tuple[UserApiKey, str]:
+        name = payload.name.strip()
+        if not name:
+            raise ValidationFailed("API key name is required")
+
+        token_plain = self._generate_plain_token()
+        api_key = UserApiKey(
+            user_id=user_id,
+            name=name,
+            token_hash=self._hash_token(token_plain),
+            token_prefix=token_plain[:API_KEY_PREFIX_LENGTH],
+        )
+        self.session.add(api_key)
+        commit_with_error_handling(self.session, "UserApiKey", max_retries=3)
+        self.session.refresh(api_key)
+        return api_key, token_plain
+
+    def revoke_key(self, user_id: str, key_id: UUID) -> None:
+        api_key = self._get_owned_active_key(user_id, key_id)
+        api_key.revoked_at = datetime.now(UTC)
+        commit_with_error_handling(self.session, "UserApiKey", max_retries=3)
+
+    def authenticate(self, token_plain: str) -> UserApiKey | None:
+        token = token_plain.strip()
+        if not token:
+            return None
+
+        statement = select(UserApiKey).where(
+            UserApiKey.token_hash == self._hash_token(token),
+            UserApiKey.revoked_at.is_(None),
+        )
+        api_key = self.session.exec(statement).first()
+        if api_key is None:
+            return None
+
+        self._touch_last_used(api_key)
+        return api_key
+
+    def _get_owned_active_key(self, user_id: str, key_id: UUID) -> UserApiKey:
+        statement = select(UserApiKey).where(
+            UserApiKey.id == key_id,
+            UserApiKey.user_id == user_id,
+            UserApiKey.revoked_at.is_(None),
+        )
+        api_key = self.session.exec(statement).first()
+        if api_key is None:
+            raise NotFound("API key not found")
+        return api_key
+
+    def _touch_last_used(self, api_key: UserApiKey) -> None:
+        now = datetime.now(UTC)
+        last_used_at = api_key.last_used_at
+        if last_used_at is not None and last_used_at.tzinfo is None:
+            last_used_at = last_used_at.replace(tzinfo=UTC)
+
+        if last_used_at is not None and now - last_used_at < API_KEY_TOUCH_INTERVAL:
+            return
+
+        api_key.last_used_at = now
+        commit_with_error_handling(self.session, "UserApiKey", max_retries=3)
+
+    @staticmethod
+    def _generate_plain_token() -> str:
+        return f"{API_KEY_PLAIN_PREFIX}{secrets.token_urlsafe(32)}"
+
+    @staticmethod
+    def _hash_token(token_plain: str) -> str:
+        return hashlib.sha256(token_plain.encode("utf-8")).hexdigest()

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,11 +1,12 @@
 import logging
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError
 from sqlmodel import Session
 
+from app.auth.api_key_service import UserApiKeyService
 from app.auth.app_user_service import AppUserService
 from app.auth.cognito import cognito_verifier
 from app.database import get_session
@@ -15,26 +16,12 @@ from app.observability import set_sentry_user_context
 
 # Bearer token security scheme
 security = HTTPBearer()
+optional_bearer_security = HTTPBearer(auto_error=False)
+api_key_header_security = APIKeyHeader(name="X-API-Key", auto_error=False)
 logger = logging.getLogger(__name__)
 
 
-async def get_current_user(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
-) -> dict:
-    """
-    Dependency to get the current authenticated user.
-
-    Args:
-        credentials: Bearer token from Authorization header
-
-    Returns:
-        The decoded JWT claims
-
-    Raises:
-        HTTPException: If authentication fails
-    """
-    token = credentials.credentials
-
+async def _verify_bearer_token(token: str) -> dict:
     try:
         claims = await cognito_verifier.verify_token(token)
         user_id = claims.get("sub", "")
@@ -61,6 +48,24 @@ async def get_current_user(
             detail=str(exc),
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+
+async def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+) -> dict:
+    """
+    Dependency to get the current authenticated user.
+
+    Args:
+        credentials: Bearer token from Authorization header
+
+    Returns:
+        The decoded JWT claims
+
+    Raises:
+        HTTPException: If authentication fails
+    """
+    return await _verify_bearer_token(credentials.credentials)
 
 
 def get_current_app_user(
@@ -109,8 +114,54 @@ def require_admin(
     return app_user
 
 
+async def get_folder_note_user_id(
+    bearer_credentials: Annotated[
+        HTTPAuthorizationCredentials | None, Security(optional_bearer_security)
+    ],
+    api_key: Annotated[str | None, Security(api_key_header_security)],
+    session: Annotated[Session, Depends(get_session)],
+) -> str:
+    """Authenticate folder/note CRUD with either a user JWT or a user API key."""
+    if bearer_credentials is not None:
+        claims = await _verify_bearer_token(bearer_credentials.credentials)
+        return AppUserService(session).ensure_app_user(claims).user_id
+
+    if api_key is not None:
+        stored_key = UserApiKeyService(session).authenticate(api_key)
+        if stored_key is not None:
+            bind_user_id(stored_key.user_id)
+            set_sentry_user_context(stored_key.user_id)
+            log_event(
+                logger,
+                logging.INFO,
+                "security.auth.api_key_authenticated",
+                outcome="success",
+                api_key_id=stored_key.id,
+            )
+            return stored_key.user_id
+
+        log_event(
+            logger,
+            logging.WARNING,
+            "security.auth.failed",
+            outcome="failure",
+            reason="invalid_api_key",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
 # Type alias for dependency injection
 CurrentUser = Annotated[dict, Depends(get_current_user)]
 CurrentAppUser = Annotated[AppUser, Depends(get_current_app_user)]
 AdminUser = Annotated[AppUser, Depends(require_admin)]
 UserId = Annotated[str, Depends(get_user_id)]
+FolderNoteUserId = Annotated[str, Depends(get_folder_note_user_id)]

--- a/backend/app/features/settings/dependencies.py
+++ b/backend/app/features/settings/dependencies.py
@@ -5,7 +5,7 @@ from sqlmodel import Session
 
 from app.auth import UserId
 from app.database import get_session
-from app.features.settings.use_cases import SettingsUseCases
+from app.features.settings.use_cases import ApiKeyUseCases, SettingsUseCases
 
 
 def get_settings_use_cases(
@@ -13,3 +13,10 @@ def get_settings_use_cases(
     user_id: UserId,
 ) -> SettingsUseCases:
     return SettingsUseCases(session, user_id)
+
+
+def get_api_key_use_cases(
+    session: Annotated[Session, Depends(get_session)],
+    user_id: UserId,
+) -> ApiKeyUseCases:
+    return ApiKeyUseCases(session, user_id)

--- a/backend/app/features/settings/router.py
+++ b/backend/app/features/settings/router.py
@@ -1,11 +1,20 @@
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 
-from app.features.settings.dependencies import get_settings_use_cases
+from app.features.settings.dependencies import (
+    get_api_key_use_cases,
+    get_settings_use_cases,
+)
 from app.features.settings.schemas import SettingsResponse
-from app.features.settings.use_cases import SettingsUseCases
-from app.models import UserSettingsUpdate
+from app.features.settings.use_cases import ApiKeyUseCases, SettingsUseCases
+from app.models import (
+    UserApiKeyCreate,
+    UserApiKeyCreateResponse,
+    UserApiKeyRead,
+    UserSettingsUpdate,
+)
 
 router = APIRouter()
 
@@ -25,3 +34,33 @@ async def update_settings(
 ):
     """Update user settings."""
     return use_cases.update_settings_response(settings_in)
+
+
+@router.get("/api-keys", response_model=list[UserApiKeyRead])
+async def list_api_keys(
+    use_cases: Annotated[ApiKeyUseCases, Depends(get_api_key_use_cases)],
+):
+    """List active API keys for the current user."""
+    return use_cases.list_api_keys()
+
+
+@router.post(
+    "/api-keys",
+    response_model=UserApiKeyCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_api_key(
+    payload: UserApiKeyCreate,
+    use_cases: Annotated[ApiKeyUseCases, Depends(get_api_key_use_cases)],
+):
+    """Create a new API key and return the plaintext secret once."""
+    return use_cases.create_api_key(payload)
+
+
+@router.delete("/api-keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_api_key(
+    key_id: UUID,
+    use_cases: Annotated[ApiKeyUseCases, Depends(get_api_key_use_cases)],
+):
+    """Revoke an API key for the current user."""
+    use_cases.revoke_api_key(key_id)

--- a/backend/app/features/settings/use_cases.py
+++ b/backend/app/features/settings/use_cases.py
@@ -1,8 +1,10 @@
 import logging
 from datetime import UTC, datetime
+from uuid import UUID
 
 from sqlmodel import Session
 
+from app.auth import UserApiKeyService
 from app.db_commit import commit_with_error_handling
 from app.features.assistant.usage_policy import get_usage_info
 from app.features.settings.schemas import SettingsResponse
@@ -14,6 +16,9 @@ from app.models import (
     DEFAULT_LLM_MODEL_ID,
     AvailableLanguage,
     AvailableModel,
+    UserApiKeyCreate,
+    UserApiKeyCreateResponse,
+    UserApiKeyRead,
     UserSettings,
     UserSettingsRead,
     UserSettingsUpdate,
@@ -121,3 +126,41 @@ class SettingsUseCases:
     @staticmethod
     def available_languages() -> list[AvailableLanguage]:
         return [AvailableLanguage(**language) for language in AVAILABLE_LANGUAGES]
+
+
+class ApiKeyUseCases:
+    """Application use cases for self-managed API keys."""
+
+    def __init__(self, session: Session, user_id: str):
+        self.user_id = user_id
+        self.service = UserApiKeyService(session)
+
+    def list_api_keys(self) -> list[UserApiKeyRead]:
+        return [
+            UserApiKeyRead.model_validate(item)
+            for item in self.service.list_active_keys(self.user_id)
+        ]
+
+    def create_api_key(self, payload: UserApiKeyCreate) -> UserApiKeyCreateResponse:
+        api_key, token_plain = self.service.create_key(self.user_id, payload)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.api_key.created",
+            api_key_id=api_key.id,
+            outcome="success",
+        )
+        return UserApiKeyCreateResponse(
+            api_key=UserApiKeyRead.model_validate(api_key),
+            token_plain=token_plain,
+        )
+
+    def revoke_api_key(self, key_id: UUID) -> None:
+        self.service.revoke_key(self.user_id, key_id)
+        log_event(
+            logger,
+            logging.INFO,
+            "audit.api_key.revoked",
+            api_key_id=key_id,
+            outcome="success",
+        )

--- a/backend/app/features/workspace/dependencies.py
+++ b/backend/app/features/workspace/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 from sqlmodel import Session
 
-from app.auth import UserId
+from app.auth import FolderNoteUserId, UserId
 from app.database import get_session
 from app.features.workspace.use_cases import (
     FolderUseCases,
@@ -17,14 +17,14 @@ from app.features.workspace.use_cases import (
 
 def get_folder_use_cases(
     session: Annotated[Session, Depends(get_session)],
-    user_id: UserId,
+    user_id: FolderNoteUserId,
 ) -> FolderUseCases:
     return FolderUseCases(session, user_id)
 
 
 def get_note_use_cases(
     session: Annotated[Session, Depends(get_session)],
-    user_id: UserId,
+    user_id: FolderNoteUserId,
 ) -> NoteUseCases:
     return NoteUseCases(session, user_id)
 

--- a/backend/app/logging_utils.py
+++ b/backend/app/logging_utils.py
@@ -18,11 +18,13 @@ TIMEZONE_NAME = "UTC"
 REDACTED = "[REDACTED]"
 DEFAULT_REDACT_KEYS = {
     "authorization",
+    "api_key",
     "token",
     "token_plain",
     "password",
     "email",
     "share_token",
+    "x-api-key",
     "prompt",
     "instruction",
     "content",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,12 @@ from app.models.token_usage import (
     TokenUsage,
     TokenUsageRead,
 )
+from app.models.user_api_key import (
+    UserApiKey,
+    UserApiKeyCreate,
+    UserApiKeyCreateResponse,
+    UserApiKeyRead,
+)
 from app.models.user_settings import (
     AVAILABLE_LANGUAGES,
     AVAILABLE_MODELS,
@@ -64,6 +70,10 @@ __all__ = [
     "SharedNoteRead",
     "TokenUsage",
     "TokenUsageRead",
+    "UserApiKey",
+    "UserApiKeyCreate",
+    "UserApiKeyCreateResponse",
+    "UserApiKeyRead",
     "UserSettings",
     "UserSettingsRead",
     "UserSettingsUpdate",

--- a/backend/app/models/user_api_key.py
+++ b/backend/app/models/user_api_key.py
@@ -1,0 +1,54 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from pydantic import field_validator
+from sqlmodel import Field, SQLModel
+
+
+class UserApiKeyBase(SQLModel):
+    """Shared API key fields."""
+
+    name: str = Field(min_length=1, max_length=255)
+
+
+class UserApiKey(UserApiKeyBase, table=True):
+    """Stored API key metadata for an application user."""
+
+    __tablename__ = "user_api_keys"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    user_id: str = Field()
+    token_hash: str = Field(max_length=64)
+    token_prefix: str = Field(max_length=32)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    last_used_at: datetime | None = Field(default=None)
+    revoked_at: datetime | None = Field(default=None)
+
+
+class UserApiKeyCreate(UserApiKeyBase):
+    """Request schema for creating a user API key."""
+
+
+class UserApiKeyRead(UserApiKeyBase):
+    """Response schema for API key metadata."""
+
+    id: UUID
+    user_id: str
+    token_prefix: str
+    created_at: datetime
+    last_used_at: datetime | None
+    revoked_at: datetime | None
+
+    @field_validator("created_at", "last_used_at", "revoked_at", mode="before")
+    @classmethod
+    def ensure_utc_timezone(cls, value: datetime | None) -> datetime | None:
+        if isinstance(value, datetime) and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+
+class UserApiKeyCreateResponse(SQLModel):
+    """Response schema returned once when a new API key is created."""
+
+    api_key: UserApiKeyRead
+    token_plain: str

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
-from app.auth import get_current_user, get_user_id
+from app.auth import get_current_user, get_folder_note_user_id, get_user_id
 from app.database import get_session
 from app.main import app
 
@@ -51,6 +51,7 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
 
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_user_id] = get_user_id_override
+    app.dependency_overrides[get_folder_note_user_id] = get_user_id_override
     app.dependency_overrides[get_current_user] = get_current_user_override
 
     with TestClient(app) as client:
@@ -84,6 +85,7 @@ def make_client_fixture(
 
         app.dependency_overrides[get_session] = get_session_override
         app.dependency_overrides[get_user_id] = get_user_id_override
+        app.dependency_overrides[get_folder_note_user_id] = get_user_id_override
         app.dependency_overrides[get_current_user] = get_current_user_override
 
         client = TestClient(app)
@@ -94,4 +96,19 @@ def make_client_fixture(
 
     for client in clients:
         client.close()
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(name="client_without_auth")
+def client_without_auth_fixture(session: Session) -> Generator[TestClient, None, None]:
+    """Create a test client with only the database dependency overridden."""
+
+    def get_session_override():
+        yield session
+
+    app.dependency_overrides[get_session] = get_session_override
+
+    with TestClient(app) as client:
+        yield client
+
     app.dependency_overrides.clear()

--- a/backend/tests/test_api_keys.py
+++ b/backend/tests/test_api_keys.py
@@ -1,0 +1,170 @@
+"""Tests for user API key management and external CRUD access."""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.auth import UserApiKeyService
+from app.database import get_session
+from app.main import app
+from app.models import Folder, UserApiKey, UserApiKeyCreate
+
+
+@contextmanager
+def _make_external_client(session: Session) -> Generator[TestClient, None, None]:
+    def get_session_override():
+        yield session
+
+    app.dependency_overrides.clear()
+    app.dependency_overrides[get_session] = get_session_override
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+class TestApiKeyManagement:
+    def test_create_api_key_returns_secret_once_and_stores_hash(
+        self, client, session: Session
+    ):
+        response = client.post("/api/settings/api-keys", json={"name": "CLI key"})
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["api_key"]["name"] == "CLI key"
+        assert data["api_key"]["token_prefix"] == data["token_plain"][:16]
+        assert data["token_plain"].startswith("notes_")
+
+        stored_key = session.exec(select(UserApiKey)).one()
+        assert stored_key.name == "CLI key"
+        assert stored_key.token_hash != data["token_plain"]
+        assert stored_key.token_prefix == data["api_key"]["token_prefix"]
+
+        list_response = client.get("/api/settings/api-keys")
+        assert list_response.status_code == 200
+        assert list_response.json() == [data["api_key"]]
+
+    def test_revoke_api_key_removes_it_from_active_list(self, client, session: Session):
+        created = client.post("/api/settings/api-keys", json={"name": "Temp key"})
+        assert created.status_code == 201
+        key_id = created.json()["api_key"]["id"]
+        token_plain = created.json()["token_plain"]
+
+        delete_response = client.delete(f"/api/settings/api-keys/{key_id}")
+        assert delete_response.status_code == 204
+
+        list_response = client.get("/api/settings/api-keys")
+        assert list_response.status_code == 200
+        assert list_response.json() == []
+
+        with _make_external_client(session) as external_client:
+            folders_response = external_client.get(
+                "/api/folders",
+                headers={"X-API-Key": token_plain},
+            )
+            assert folders_response.status_code == 401
+
+
+class TestApiKeyCrudAccess:
+    def test_api_key_can_perform_folder_and_note_crud(self, session: Session):
+        _, token_plain = UserApiKeyService(session).create_key(
+            "test-user-123",
+            UserApiKeyCreate(name="External app"),
+        )
+        headers = {"X-API-Key": token_plain}
+
+        with _make_external_client(session) as external_client:
+            create_folder = external_client.post(
+                "/api/folders",
+                json={"name": "External Folder"},
+                headers=headers,
+            )
+            assert create_folder.status_code == 201
+            folder_id = create_folder.json()["id"]
+
+            list_folders = external_client.get("/api/folders", headers=headers)
+            assert list_folders.status_code == 200
+            assert [item["name"] for item in list_folders.json()] == ["External Folder"]
+
+            rename_folder = external_client.patch(
+                f"/api/folders/{folder_id}",
+                json={"name": "Renamed Folder"},
+                headers=headers,
+            )
+            assert rename_folder.status_code == 200
+            assert rename_folder.json()["name"] == "Renamed Folder"
+
+            create_note = external_client.post(
+                "/api/notes",
+                json={
+                    "title": "External Note",
+                    "content": "Created over API key",
+                    "folder_id": folder_id,
+                },
+                headers=headers,
+            )
+            assert create_note.status_code == 201
+            note_id = create_note.json()["id"]
+
+            list_notes = external_client.get(
+                f"/api/notes?folder_id={folder_id}",
+                headers=headers,
+            )
+            assert list_notes.status_code == 200
+            assert [item["title"] for item in list_notes.json()] == ["External Note"]
+
+            update_note = external_client.patch(
+                f"/api/notes/{note_id}",
+                json={"title": "Updated External Note"},
+                headers=headers,
+            )
+            assert update_note.status_code == 200
+            assert update_note.json()["title"] == "Updated External Note"
+
+            delete_note = external_client.delete(
+                f"/api/notes/{note_id}",
+                headers=headers,
+            )
+            delete_folder = external_client.delete(
+                f"/api/folders/{folder_id}",
+                headers=headers,
+            )
+            assert delete_note.status_code == 204
+            assert delete_folder.status_code == 204
+
+    def test_api_key_remains_user_scoped(self, session: Session):
+        _, token_plain = UserApiKeyService(session).create_key(
+            "test-user-123",
+            UserApiKeyCreate(name="Scoped key"),
+        )
+        session.add(Folder(user_id="other-user", name="Other Folder"))
+        session.commit()
+
+        with _make_external_client(session) as external_client:
+            folders_response = external_client.get(
+                "/api/folders",
+                headers={"X-API-Key": token_plain},
+            )
+            assert folders_response.status_code == 200
+            assert folders_response.json() == []
+
+    def test_non_crud_routes_do_not_accept_api_key(self, session: Session):
+        _, token_plain = UserApiKeyService(session).create_key(
+            "test-user-123",
+            UserApiKeyCreate(name="Limited key"),
+        )
+        headers = {"X-API-Key": token_plain}
+
+        with _make_external_client(session) as external_client:
+            snapshot_response = external_client.get(
+                "/api/workspace/snapshot", headers=headers
+            )
+            export_response = external_client.get(
+                "/api/notes/export/all", headers=headers
+            )
+
+            assert snapshot_response.status_code == 401
+            assert export_response.status_code == 401

--- a/backend/tests/test_migration.py
+++ b/backend/tests/test_migration.py
@@ -105,6 +105,7 @@ def test_migration_applies_initial_revision_to_fresh_db():
         "note_shares",
         "notes",
         "token_usage",
+        "user_api_keys",
         "user_settings",
     }
 
@@ -200,6 +201,7 @@ def test_migration_bootstraps_existing_dsql_revision_to_head():
     assert "ai_edit_jobs" in inspector.get_table_names()
     assert "applied_mutations" in inspector.get_table_names()
     assert "mcp_tokens" not in inspector.get_table_names()
+    assert "user_api_keys" in inspector.get_table_names()
     folder_columns = {column["name"] for column in inspector.get_columns("folders")}
     note_columns = {column["name"] for column in inspector.get_columns("notes")}
     assert "version" in folder_columns

--- a/frontend/src/components/layout/SettingsDialog.test.tsx
+++ b/frontend/src/components/layout/SettingsDialog.test.tsx
@@ -36,6 +36,21 @@ const mockT = vi.fn((key: string) => {
     "settings.selectLanguage": "Select language",
     "settings.loadError": "Failed to load settings",
     "settings.saveError": "Failed to save settings",
+    "settings.apiKeysTitle": "API Keys",
+    "settings.apiKeysDescription": "Create API keys for external folder and note clients.",
+    "settings.apiKeysEmpty": "No API keys yet.",
+    "settings.apiKeysNameLabel": "Key name",
+    "settings.apiKeysNamePlaceholder": "External client",
+    "settings.apiKeysCreateButton": "Create API key",
+    "settings.apiKeysCreateError": "Failed to create API key",
+    "settings.apiKeysListError": "Failed to load API keys",
+    "settings.apiKeysRevokeButton": "Revoke",
+    "settings.apiKeysRevokeConfirm": "Revoke this API key?",
+    "settings.apiKeysRevokeError": "Failed to revoke API key",
+    "settings.apiKeysCreatedTitle": "New API key",
+    "settings.apiKeysCreatedDescription": "Copy this secret now. It will only be shown once.",
+    "settings.apiKeysLastUsed": "Last used",
+    "settings.apiKeysNeverUsed": "Never used",
     "settings.exportTitle": "Data Export",
     "settings.exportDescription": "Export all notes",
     "settings.exportButton": "Download ZIP",
@@ -81,6 +96,20 @@ describe("SettingsDialog", () => {
       ],
     }),
     updateSettings: vi.fn().mockResolvedValue({}),
+    listApiKeys: vi.fn().mockResolvedValue([]),
+    createApiKey: vi.fn().mockResolvedValue({
+      api_key: {
+        id: "key-1",
+        user_id: "test-user",
+        name: "External client",
+        token_prefix: "notes_test_secret",
+        created_at: new Date().toISOString(),
+        last_used_at: null,
+        revoked_at: null,
+      },
+      token_plain: "notes_test_secret_value",
+    }),
+    revokeApiKey: vi.fn().mockResolvedValue(undefined),
     exportNotes: vi.fn().mockResolvedValue(new Blob()),
   };
 
@@ -99,6 +128,13 @@ describe("SettingsDialog", () => {
     vi.clearAllMocks();
     window.URL.createObjectURL = createObjectURLMock;
     window.URL.revokeObjectURL = revokeObjectURLMock;
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
     const { createApiClient } = await import("@/lib/api");
     vi.mocked(createApiClient).mockReturnValue(
       mockApi as unknown as ReturnType<typeof createApiClient>
@@ -124,7 +160,55 @@ describe("SettingsDialog", () => {
 
     await waitFor(() => {
       expect(mockApi.getSettings).toHaveBeenCalled();
+      expect(mockApi.listApiKeys).toHaveBeenCalled();
+      expect(screen.getByText("API Keys")).toBeInTheDocument();
       expect(screen.getByText("Data Export")).toBeInTheDocument();
+    });
+  });
+
+  it("creates an API key and shows the secret once", async () => {
+    renderWithAuth(<SettingsDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create API key")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Key name"), {
+      target: { value: "External client" },
+    });
+    fireEvent.click(screen.getByText("Create API key"));
+
+    await waitFor(() => {
+      expect(mockApi.createApiKey).toHaveBeenCalledWith({ name: "External client" });
+      expect(screen.getByText("New API key")).toBeInTheDocument();
+      expect(screen.getByText("notes_test_secret_value")).toBeInTheDocument();
+    });
+  });
+
+  it("revokes an existing API key", async () => {
+    mockApi.listApiKeys.mockResolvedValueOnce([
+      {
+        id: "key-1",
+        user_id: "test-user",
+        name: "Existing key",
+        token_prefix: "notes_existing",
+        created_at: new Date().toISOString(),
+        last_used_at: null,
+        revoked_at: null,
+      },
+    ]);
+
+    renderWithAuth(<SettingsDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Existing key")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Revoke"));
+
+    await waitFor(() => {
+      expect(mockApi.revokeApiKey).toHaveBeenCalledWith("key-1");
+      expect(screen.queryByText("Existing key")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/layout/SettingsDialog.test.tsx
+++ b/frontend/src/components/layout/SettingsDialog.test.tsx
@@ -63,11 +63,17 @@ const mockT = vi.fn((key: string) => {
   return translations[key] || key;
 });
 
+const alternateMockT = vi.fn((key: string) => mockT(key));
+let currentTranslationFn = mockT;
+const setLanguageMock = vi.fn(() => {
+  currentTranslationFn = alternateMockT;
+});
+
 vi.mock("@/hooks/useTranslation", () => ({
   useTranslation: () => ({
-    t: mockT,
+    t: currentTranslationFn,
     language: "en",
-    setLanguage: vi.fn(),
+    setLanguage: setLanguageMock,
   }),
 }));
 
@@ -126,6 +132,7 @@ describe("SettingsDialog", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    currentTranslationFn = mockT;
     window.URL.createObjectURL = createObjectURLMock;
     window.URL.revokeObjectURL = revokeObjectURLMock;
     vi.stubGlobal("confirm", vi.fn(() => true));
@@ -185,6 +192,38 @@ describe("SettingsDialog", () => {
     });
   });
 
+  it("keeps the one-time secret visible after a settings save rerender", async () => {
+    const view = renderWithAuth(<SettingsDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create API key")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Key name"), {
+      target: { value: "External client" },
+    });
+    fireEvent.click(screen.getByText("Create API key"));
+
+    await waitFor(() => {
+      expect(screen.getByText("notes_test_secret_value")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockApi.updateSettings).toHaveBeenCalled();
+      expect(setLanguageMock).toHaveBeenCalled();
+    });
+
+    view.rerender(
+      <AuthProvider>
+        <SettingsDialog {...defaultProps} />
+      </AuthProvider>
+    );
+
+    expect(screen.getByText("notes_test_secret_value")).toBeInTheDocument();
+  });
+
   it("revokes an existing API key", async () => {
     mockApi.listApiKeys.mockResolvedValueOnce([
       {
@@ -210,6 +249,21 @@ describe("SettingsDialog", () => {
       expect(mockApi.revokeApiKey).toHaveBeenCalledWith("key-1");
       expect(screen.queryByText("Existing key")).not.toBeInTheDocument();
     });
+  });
+
+  it("shows API key errors without blocking the rest of settings", async () => {
+    mockApi.listApiKeys.mockRejectedValueOnce(new Error("api keys unavailable"));
+
+    renderWithAuth(<SettingsDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockApi.getSettings).toHaveBeenCalled();
+      expect(screen.getByText("Download ZIP")).toBeInTheDocument();
+      expect(screen.getByText("Failed to load API keys")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Save")).toBeInTheDocument();
+    expect(screen.getByText("Create API key")).toBeInTheDocument();
   });
 
   it("calls exportNotes when export button is clicked", async () => {

--- a/frontend/src/components/layout/SettingsDialog.tsx
+++ b/frontend/src/components/layout/SettingsDialog.tsx
@@ -33,6 +33,13 @@ interface SettingsDialogProps {
   tokenUsage?: TokenUsageRead | null;
 }
 
+type SettingsErrorKey = "settings.loadError" | "settings.saveError" | "common.error";
+type ApiKeysErrorKey =
+  | "settings.apiKeysListError"
+  | "settings.apiKeysCreateError"
+  | "settings.apiKeysRevokeError"
+  | "common.error";
+
 export function SettingsDialog({
   open,
   onOpenChange,
@@ -50,34 +57,61 @@ export function SettingsDialog({
   const [apiKeyName, setApiKeyName] = useState("");
   const [newApiKeySecret, setNewApiKeySecret] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isApiKeysLoading, setIsApiKeysLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isCreatingApiKey, setIsCreatingApiKey] = useState(false);
   const [revokingApiKeyId, setRevokingApiKeyId] = useState<string | null>(null);
   const [secretCopied, setSecretCopied] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<SettingsErrorKey | null>(null);
+  const [apiKeysErrorKey, setApiKeysErrorKey] = useState<ApiKeysErrorKey | null>(
+    null
+  );
 
   useEffect(() => {
+    let isMounted = true;
+
+    async function loadApiKeys(apiClient: Awaited<ReturnType<typeof getApi>>) {
+      setIsApiKeysLoading(true);
+      setApiKeysErrorKey(null);
+
+      try {
+        const userApiKeys = await apiClient.listApiKeys();
+        if (!isMounted) return;
+
+        logger.debug("Settings API keys response received", {
+          api_key_count: userApiKeys.length,
+        });
+        setApiKeys(userApiKeys);
+      } catch (err) {
+        if (!isMounted) return;
+
+        logger.error("Failed to load API keys", err);
+        setApiKeysErrorKey("settings.apiKeysListError");
+      } finally {
+        if (isMounted) {
+          setIsApiKeysLoading(false);
+        }
+      }
+    }
+
     async function loadSettings() {
       if (!open) return;
       setIsLoading(true);
-      setError(null);
+      setErrorKey(null);
+      setApiKeysErrorKey(null);
       setSaveSuccess(false);
-      setNewApiKeySecret(null);
-      setSecretCopied(false);
 
       try {
         const apiClient = await getApi();
-        const [response, userApiKeys] = await Promise.all([
-          apiClient.getSettings(),
-          apiClient.listApiKeys(),
-        ]);
+        const response = await apiClient.getSettings();
+        if (!isMounted) return;
+
         logger.debug("Settings API response received", {
           has_settings: Boolean(response?.settings),
           available_model_count: response?.available_models?.length ?? 0,
           available_language_count: response?.available_languages?.length ?? 0,
-          api_key_count: userApiKeys.length,
         });
 
         if (response?.settings) {
@@ -93,21 +127,41 @@ export function SettingsDialog({
           setAvailableLanguages(response.available_languages);
         }
 
-        setApiKeys(userApiKeys);
-      } catch (err) {
-        logger.error("Failed to load settings", err);
-        setError(t("settings.apiKeysListError"));
-      } finally {
         setIsLoading(false);
+        void loadApiKeys(apiClient);
+      } catch (err) {
+        if (!isMounted) return;
+
+        logger.error("Failed to load settings", err);
+        setErrorKey("settings.loadError");
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
       }
     }
 
     void loadSettings();
-  }, [open, getApi, t]);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [open, getApi]);
+
+  useEffect(() => {
+    if (open) return;
+
+    setApiKeyName("");
+    setNewApiKeySecret(null);
+    setSecretCopied(false);
+    setErrorKey(null);
+    setApiKeysErrorKey(null);
+    setSaveSuccess(false);
+  }, [open]);
 
   const handleSave = async () => {
     setIsSaving(true);
-    setError(null);
+    setErrorKey(null);
     setSaveSuccess(false);
     try {
       const apiClient = await getApi();
@@ -120,7 +174,7 @@ export function SettingsDialog({
       setTimeout(() => setSaveSuccess(false), 2000);
     } catch (err) {
       logger.error("Failed to save settings", err);
-      setError(t("settings.saveError"));
+      setErrorKey("settings.saveError");
     } finally {
       setIsSaving(false);
     }
@@ -128,7 +182,7 @@ export function SettingsDialog({
 
   const handleExport = async () => {
     setIsExporting(true);
-    setError(null);
+    setErrorKey(null);
     try {
       const apiClient = await getApi();
       const blob = await apiClient.exportNotes();
@@ -145,7 +199,7 @@ export function SettingsDialog({
       window.URL.revokeObjectURL(url);
     } catch (err) {
       logger.error("Failed to export notes", err);
-      setError(t("common.error"));
+      setErrorKey("common.error");
     } finally {
       setIsExporting(false);
     }
@@ -158,7 +212,7 @@ export function SettingsDialog({
     }
 
     setIsCreatingApiKey(true);
-    setError(null);
+    setApiKeysErrorKey(null);
     setSecretCopied(false);
 
     try {
@@ -169,7 +223,7 @@ export function SettingsDialog({
       setNewApiKeySecret(response.token_plain);
     } catch (err) {
       logger.error("Failed to create API key", err);
-      setError(t("settings.apiKeysCreateError"));
+      setApiKeysErrorKey("settings.apiKeysCreateError");
     } finally {
       setIsCreatingApiKey(false);
     }
@@ -186,7 +240,7 @@ export function SettingsDialog({
       setTimeout(() => setSecretCopied(false), 2000);
     } catch (err) {
       logger.error("Failed to copy API key", err);
-      setError(t("common.error"));
+      setApiKeysErrorKey("common.error");
     }
   };
 
@@ -196,7 +250,7 @@ export function SettingsDialog({
     }
 
     setRevokingApiKeyId(keyId);
-    setError(null);
+    setApiKeysErrorKey(null);
 
     try {
       const apiClient = await getApi();
@@ -204,7 +258,7 @@ export function SettingsDialog({
       setApiKeys((prev) => prev.filter((key) => key.id !== keyId));
     } catch (err) {
       logger.error("Failed to revoke API key", err);
-      setError(t("settings.apiKeysRevokeError"));
+      setApiKeysErrorKey("settings.apiKeysRevokeError");
     } finally {
       setRevokingApiKeyId(null);
     }
@@ -230,8 +284,8 @@ export function SettingsDialog({
           <div className="flex items-center justify-center py-8">
             <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
-        ) : error ? (
-          <div className="py-4 text-sm text-red-500">{error}</div>
+        ) : errorKey ? (
+          <div className="py-4 text-sm text-red-500">{t(errorKey)}</div>
         ) : (
           <div className="flex max-h-[80vh] flex-col overflow-hidden">
             <div className="flex-1 space-y-6 overflow-y-auto px-1 py-4 pr-6 -mr-6">
@@ -350,6 +404,10 @@ export function SettingsDialog({
                   </div>
                 </div>
 
+                {apiKeysErrorKey ? (
+                  <p className="text-sm text-red-500">{t(apiKeysErrorKey)}</p>
+                ) : null}
+
                 {newApiKeySecret ? (
                   <div className="space-y-2 rounded-md border p-3">
                     <div className="space-y-1">
@@ -370,7 +428,12 @@ export function SettingsDialog({
                 ) : null}
 
                 <div className="space-y-2">
-                  {apiKeys.length === 0 ? (
+                  {isApiKeysLoading ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2Icon className="h-4 w-4 animate-spin" />
+                      <span>{t("common.loading")}</span>
+                    </div>
+                  ) : apiKeys.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
                       {t("settings.apiKeysEmpty")}
                     </p>

--- a/frontend/src/components/layout/SettingsDialog.tsx
+++ b/frontend/src/components/layout/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { logger } from "@/lib/logger";
 import { CheckIcon, Loader2Icon } from "lucide-react";
@@ -23,6 +24,7 @@ import type {
   AvailableLanguage,
   AvailableModel,
   TokenUsageRead,
+  UserApiKey,
 } from "@/types";
 
 interface SettingsDialogProps {
@@ -44,9 +46,15 @@ export function SettingsDialog({
   const [availableLanguages, setAvailableLanguages] = useState<AvailableLanguage[]>(
     []
   );
+  const [apiKeys, setApiKeys] = useState<UserApiKey[]>([]);
+  const [apiKeyName, setApiKeyName] = useState("");
+  const [newApiKeySecret, setNewApiKeySecret] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isCreatingApiKey, setIsCreatingApiKey] = useState(false);
+  const [revokingApiKeyId, setRevokingApiKeyId] = useState<string | null>(null);
+  const [secretCopied, setSecretCopied] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,14 +64,20 @@ export function SettingsDialog({
       setIsLoading(true);
       setError(null);
       setSaveSuccess(false);
+      setNewApiKeySecret(null);
+      setSecretCopied(false);
 
       try {
         const apiClient = await getApi();
-        const response = await apiClient.getSettings();
+        const [response, userApiKeys] = await Promise.all([
+          apiClient.getSettings(),
+          apiClient.listApiKeys(),
+        ]);
         logger.debug("Settings API response received", {
           has_settings: Boolean(response?.settings),
           available_model_count: response?.available_models?.length ?? 0,
           available_language_count: response?.available_languages?.length ?? 0,
+          api_key_count: userApiKeys.length,
         });
 
         if (response?.settings) {
@@ -78,9 +92,11 @@ export function SettingsDialog({
         if (response?.available_languages) {
           setAvailableLanguages(response.available_languages);
         }
+
+        setApiKeys(userApiKeys);
       } catch (err) {
         logger.error("Failed to load settings", err);
-        setError(t("settings.loadError"));
+        setError(t("settings.apiKeysListError"));
       } finally {
         setIsLoading(false);
       }
@@ -133,6 +149,73 @@ export function SettingsDialog({
     } finally {
       setIsExporting(false);
     }
+  };
+
+  const handleCreateApiKey = async () => {
+    const trimmedName = apiKeyName.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    setIsCreatingApiKey(true);
+    setError(null);
+    setSecretCopied(false);
+
+    try {
+      const apiClient = await getApi();
+      const response = await apiClient.createApiKey({ name: trimmedName });
+      setApiKeys((prev) => [response.api_key, ...prev]);
+      setApiKeyName("");
+      setNewApiKeySecret(response.token_plain);
+    } catch (err) {
+      logger.error("Failed to create API key", err);
+      setError(t("settings.apiKeysCreateError"));
+    } finally {
+      setIsCreatingApiKey(false);
+    }
+  };
+
+  const handleCopyApiKey = async () => {
+    if (!newApiKeySecret) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(newApiKeySecret);
+      setSecretCopied(true);
+      setTimeout(() => setSecretCopied(false), 2000);
+    } catch (err) {
+      logger.error("Failed to copy API key", err);
+      setError(t("common.error"));
+    }
+  };
+
+  const handleRevokeApiKey = async (keyId: string) => {
+    if (!confirm(t("settings.apiKeysRevokeConfirm"))) {
+      return;
+    }
+
+    setRevokingApiKeyId(keyId);
+    setError(null);
+
+    try {
+      const apiClient = await getApi();
+      await apiClient.revokeApiKey(keyId);
+      setApiKeys((prev) => prev.filter((key) => key.id !== keyId));
+    } catch (err) {
+      logger.error("Failed to revoke API key", err);
+      setError(t("settings.apiKeysRevokeError"));
+    } finally {
+      setRevokingApiKeyId(null);
+    }
+  };
+
+  const formatLastUsed = (value: string | null) => {
+    if (!value) {
+      return t("settings.apiKeysNeverUsed");
+    }
+
+    return new Date(value).toLocaleString();
   };
 
   return (
@@ -235,6 +318,92 @@ export function SettingsDialog({
                   </div>
                 </div>
               )}
+
+              <div className="space-y-4 border-t pt-6">
+                <div className="space-y-1">
+                  <h4 className="text-sm font-medium leading-none">
+                    {t("settings.apiKeysTitle")}
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    {t("settings.apiKeysDescription")}
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="api-key-name">{t("settings.apiKeysNameLabel")}</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="api-key-name"
+                      value={apiKeyName}
+                      onChange={(event) => setApiKeyName(event.target.value)}
+                      placeholder={t("settings.apiKeysNamePlaceholder")}
+                    />
+                    <Button
+                      onClick={handleCreateApiKey}
+                      disabled={isCreatingApiKey || apiKeyName.trim().length === 0}
+                    >
+                      {isCreatingApiKey ? (
+                        <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                      ) : null}
+                      {t("settings.apiKeysCreateButton")}
+                    </Button>
+                  </div>
+                </div>
+
+                {newApiKeySecret ? (
+                  <div className="space-y-2 rounded-md border p-3">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium">
+                        {t("settings.apiKeysCreatedTitle")}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {t("settings.apiKeysCreatedDescription")}
+                      </p>
+                    </div>
+                    <code className="block overflow-x-auto rounded bg-muted px-3 py-2 text-sm">
+                      {newApiKeySecret}
+                    </code>
+                    <Button variant="outline" onClick={handleCopyApiKey}>
+                      {secretCopied ? t("common.copied") : t("common.copy")}
+                    </Button>
+                  </div>
+                ) : null}
+
+                <div className="space-y-2">
+                  {apiKeys.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      {t("settings.apiKeysEmpty")}
+                    </p>
+                  ) : (
+                    apiKeys.map((key) => (
+                      <div
+                        key={key.id}
+                        className="flex items-center justify-between rounded-md border p-3"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium">{key.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {key.token_prefix}...
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {t("settings.apiKeysLastUsed")}: {formatLastUsed(key.last_used_at)}
+                          </p>
+                        </div>
+                        <Button
+                          variant="outline"
+                          onClick={() => handleRevokeApiKey(key.id)}
+                          disabled={revokingApiKeyId === key.id}
+                        >
+                          {revokingApiKeyId === key.id ? (
+                            <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                          ) : null}
+                          {t("settings.apiKeysRevokeButton")}
+                        </Button>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
 
               <div className="space-y-4 border-t pt-6">
                 <div className="space-y-1">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,9 @@ import type {
   SummarizeRequest,
   SummarizeResponse,
   UserSettingsUpdate,
+  UserApiKey,
+  UserApiKeyCreate,
+  UserApiKeyCreateResponse,
   AppUser,
   AdminUserDetailResponse,
   AdminUsersListResponse,
@@ -201,6 +204,23 @@ class ApiClient {
     return this.request<SettingsResponse>("/api/settings", {
       method: "PUT",
       body: JSON.stringify(data),
+    });
+  }
+
+  async listApiKeys(): Promise<UserApiKey[]> {
+    return this.request<UserApiKey[]>("/api/settings/api-keys");
+  }
+
+  async createApiKey(data: UserApiKeyCreate): Promise<UserApiKeyCreateResponse> {
+    return this.request<UserApiKeyCreateResponse>("/api/settings/api-keys", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async revokeApiKey(keyId: string): Promise<void> {
+    return this.request<void>(`/api/settings/api-keys/${keyId}`, {
+      method: "DELETE",
     });
   }
 

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -31,6 +31,21 @@ export const en = {
     selectLanguage: "Select language",
     loadError: "Failed to load settings",
     saveError: "Failed to save settings",
+    apiKeysTitle: "API Keys",
+    apiKeysDescription: "Create API keys for external folder and note clients.",
+    apiKeysEmpty: "No API keys yet.",
+    apiKeysNameLabel: "Key name",
+    apiKeysNamePlaceholder: "External client",
+    apiKeysCreateButton: "Create API key",
+    apiKeysCreateError: "Failed to create API key",
+    apiKeysListError: "Failed to load API keys",
+    apiKeysRevokeButton: "Revoke",
+    apiKeysRevokeConfirm: "Revoke this API key?",
+    apiKeysRevokeError: "Failed to revoke API key",
+    apiKeysCreatedTitle: "New API key",
+    apiKeysCreatedDescription: "Copy this secret now. It will only be shown once.",
+    apiKeysLastUsed: "Last used",
+    apiKeysNeverUsed: "Never used",
     exportTitle: "Data Export",
     exportDescription: "Export all notes as a ZIP file.",
     exportButton: "Download ZIP",
@@ -280,6 +295,21 @@ export type TranslationKeys = {
     selectLanguage: string;
     loadError: string;
     saveError: string;
+    apiKeysTitle: string;
+    apiKeysDescription: string;
+    apiKeysEmpty: string;
+    apiKeysNameLabel: string;
+    apiKeysNamePlaceholder: string;
+    apiKeysCreateButton: string;
+    apiKeysCreateError: string;
+    apiKeysListError: string;
+    apiKeysRevokeButton: string;
+    apiKeysRevokeConfirm: string;
+    apiKeysRevokeError: string;
+    apiKeysCreatedTitle: string;
+    apiKeysCreatedDescription: string;
+    apiKeysLastUsed: string;
+    apiKeysNeverUsed: string;
     exportTitle: string;
     exportDescription: string;
     exportButton: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -31,6 +31,21 @@ export const ja = {
     selectLanguage: "言語を選択",
     loadError: "設定の読み込みに失敗しました",
     saveError: "設定の保存に失敗しました",
+    apiKeysTitle: "APIキー",
+    apiKeysDescription: "外部クライアントからフォルダやノートを操作するためのAPIキーを発行します。",
+    apiKeysEmpty: "APIキーはまだありません。",
+    apiKeysNameLabel: "キー名",
+    apiKeysNamePlaceholder: "外部クライアント",
+    apiKeysCreateButton: "APIキーを作成",
+    apiKeysCreateError: "APIキーの作成に失敗しました",
+    apiKeysListError: "APIキーの読み込みに失敗しました",
+    apiKeysRevokeButton: "失効",
+    apiKeysRevokeConfirm: "このAPIキーを失効しますか？",
+    apiKeysRevokeError: "APIキーの失効に失敗しました",
+    apiKeysCreatedTitle: "新しいAPIキー",
+    apiKeysCreatedDescription: "このシークレットは今だけ表示されます。必ず控えてください。",
+    apiKeysLastUsed: "最終使用",
+    apiKeysNeverUsed: "未使用",
     exportTitle: "データエクスポート",
     exportDescription: "すべてのノートをZIP形式でエクスポートします。",
     exportButton: "ZIPをダウンロード",
@@ -280,6 +295,21 @@ export type TranslationKeys = {
     selectLanguage: string;
     loadError: string;
     saveError: string;
+    apiKeysTitle: string;
+    apiKeysDescription: string;
+    apiKeysEmpty: string;
+    apiKeysNameLabel: string;
+    apiKeysNamePlaceholder: string;
+    apiKeysCreateButton: string;
+    apiKeysCreateError: string;
+    apiKeysListError: string;
+    apiKeysRevokeButton: string;
+    apiKeysRevokeConfirm: string;
+    apiKeysRevokeError: string;
+    apiKeysCreatedTitle: string;
+    apiKeysCreatedDescription: string;
+    apiKeysLastUsed: string;
+    apiKeysNeverUsed: string;
     exportTitle: string;
     exportDescription: string;
     exportButton: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -179,6 +179,25 @@ export interface TokenUsageRead {
   period_end: string;
 }
 
+export interface UserApiKey {
+  id: string;
+  user_id: string;
+  name: string;
+  token_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface UserApiKeyCreate {
+  name: string;
+}
+
+export interface UserApiKeyCreateResponse {
+  api_key: UserApiKey;
+  token_plain: string;
+}
+
 export interface SettingsResponse {
   settings: UserSettings;
   available_models: AvailableModel[];


### PR DESCRIPTION
## Summary

Add user-managed API keys so external clients can call the folder and note CRUD APIs without the removed MCP server flow.
This keeps the existing bearer-token flow intact while adding a settings-based self-service management path.

## Changes

- add a `user_api_keys` backend model, migration, auth service, and dual-auth dependency for folder/note CRUD
- add settings API endpoints for listing, creating, and revoking API keys
- add settings dialog UI, API client methods, frontend types, and i18n strings for API key management
- add focused backend/frontend regression coverage and a root `make test-external-api` target

## Testing

- `make test-external-api`
- `make lint-backend`
- `make lint-frontend`
- `make test-backend`
- `make test-frontend`

## Notes

- Existing unrelated worktree changes were intentionally left out of this branch and commit.