### PR TITLE
feat: 日射マップに現在地を赤いドットで表示 (#58)

### DIFF
--- a/frontend/src/components/SunlightMap.test.tsx
+++ b/frontend/src/components/SunlightMap.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/hooks/useTranslation", () => ({
       const texts: Record<string, string> = {
         "sunlightMap.title": "Sunlight Map",
         "sunlightMap.description": "Current day and night areas on Earth",
+        "sunlightMap.yourLocation": "Your current location",
       };
       return texts[key] || key;
     },
@@ -21,6 +22,7 @@ vi.mock("@/hooks/useTranslation", () => ({
 describe("SunlightMap", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("SVG要素が描画される", () => {
@@ -37,6 +39,39 @@ describe("SunlightMap", () => {
     expect(
       (SunlightMap as unknown as { $$typeof?: symbol })?.$$typeof
     ).toBe(Symbol.for("react.memo"));
+  });
+
+  it("ジオロケーションが利用可能な場合に現在地ドットが表示される", async () => {
+    const mockGeolocation = {
+      getCurrentPosition: vi.fn((success) =>
+        success({ coords: { latitude: 35.6762, longitude: 139.6503 } })
+      ),
+    };
+    vi.stubGlobal("navigator", { geolocation: mockGeolocation });
+
+    const { findByTestId } = render(<SunlightMap />);
+    const dot = await findByTestId("sunlight-map-location");
+    expect(dot).toBeInTheDocument();
+    expect(dot.getAttribute("cx")).toBe(String(139.6503 + 180));
+    expect(dot.getAttribute("cy")).toBe(String(90 - 35.6762));
+    expect(dot.getAttribute("fill")).toBe("red");
+  });
+
+  it("ジオロケーションが拒否された場合は現在地ドットが表示されない", () => {
+    const mockGeolocation = {
+      getCurrentPosition: vi.fn((_success, error) => error(new Error("denied"))),
+    };
+    vi.stubGlobal("navigator", { geolocation: mockGeolocation });
+
+    const { queryByTestId } = render(<SunlightMap />);
+    expect(queryByTestId("sunlight-map-location")).not.toBeInTheDocument();
+  });
+
+  it("ジオロケーションが存在しない場合は現在地ドットが表示されない", () => {
+    vi.stubGlobal("navigator", {});
+
+    const { queryByTestId } = render(<SunlightMap />);
+    expect(queryByTestId("sunlight-map-location")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/SunlightMap.tsx
+++ b/frontend/src/components/SunlightMap.tsx
@@ -69,9 +69,30 @@ function useSolarTerminator() {
   return solar;
 }
 
+function useGeolocation(): { lat: number; lon: number } | null {
+  const [position, setPosition] = useState<{ lat: number; lon: number } | null>(null);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setPosition({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+      },
+      () => {
+        // Geolocation denied or unavailable — no dot
+      },
+      { timeout: 10_000 }
+    );
+  }, []);
+
+  return position;
+}
+
 export const SunlightMap = memo(function SunlightMap() {
   const { t } = useTranslation();
   const { lat: sunLat, lon: sunLon } = useSolarTerminator();
+  const userPosition = useGeolocation();
 
   const nightPath = useMemo(
     () => calculateTerminatorPath(sunLat, sunLon),
@@ -121,6 +142,19 @@ export const SunlightMap = memo(function SunlightMap() {
                   <path key={i} d={d} />
                 ))}
               </g>
+              {/* Current location dot */}
+              {userPosition && (
+                <circle
+                  data-testid="sunlight-map-location"
+                  cx={userPosition.lon + 180}
+                  cy={90 - userPosition.lat}
+                  r={3}
+                  fill="red"
+                  stroke="white"
+                  strokeWidth={0.8}
+                  aria-label={t("sunlightMap.yourLocation")}
+                />
+              )}
             </svg>
           </div>
         </TooltipTrigger>

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -263,6 +263,7 @@ export const en = {
   sunlightMap: {
     title: "Sunlight Map",
     description: "Current day and night areas on Earth",
+    yourLocation: "Your current location",
   },
 };
 
@@ -501,5 +502,6 @@ export type TranslationKeys = {
   sunlightMap: {
     title: string;
     description: string;
+    yourLocation: string;
   };
 };

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -263,6 +263,7 @@ export const ja = {
   sunlightMap: {
     title: "日照マップ",
     description: "地球上の現在の昼夜エリア",
+    yourLocation: "現在地",
   },
 } as const;
 
@@ -499,5 +500,6 @@ export type TranslationKeys = {
   sunlightMap: {
     title: string;
     description: string;
+    yourLocation: string;
   };
 };


### PR DESCRIPTION
## 概要

日射マップ（SunlightMap）に現在地を赤いドットで表示する機能を追加します。`navigator.geolocation` で取得した緯度経度を SVG 座標に変換し、既存の昼夜オーバーレイの上にオーバーレイ表示します。

Closes #58

## 変更内容

- `SunlightMap.tsx`: `useGeolocation()` フックを追加し、現在地取得後に赤い `<circle>` 要素をレンダリング（白縁付き、ジオロケーション未許可時は非表示）
- `SunlightMap.test.tsx`: ジオロケーション許可・拒否・未対応の3ケースのテストを追加
- `en.ts` / `ja.ts`: `sunlightMap.yourLocation` i18n キーを追加・型定義を更新

## テスト方法

- [ ] ブラウザでアプリを開き、ジオロケーションを許可 → マップ上に赤いドットが表示される
- [ ] ジオロケーションを拒否 → ドットが表示されない
- [ ] `make test-frontend` で全テスト通過を確認

## チェックリスト

- [x] テストを追加・更新した
- [x] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った