### PR TITLE
feat: AIパネルで選択テキストをコンテキストとして使用できるようにする (closes #59)

### DIFF
--- a/backend/app/features/assistant/router.py
+++ b/backend/app/features/assistant/router.py
@@ -73,6 +73,7 @@ async def chat_with_context(
             history=request.history,
             note_id=request.note_id,
             folder_id=request.folder_id,
+            selected_content=request.selected_content,
         )
     except (AITokenLimitExceededError, AIApplicationTimeoutError) as exc:
         _raise_ai_http_error(exc)

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -27,6 +27,7 @@ class ChatRequest(BaseModel):
     folder_id: UUID | None = None
     question: str
     history: list[dict] | None = None
+    selected_content: str | None = None
 
 
 class ChatResponse(BaseModel):

--- a/backend/app/features/assistant/use_cases/ai_interactions.py
+++ b/backend/app/features/assistant/use_cases/ai_interactions.py
@@ -51,10 +51,15 @@ class AIInteractionUseCases:
         history: list[dict] | None = None,
         note_id: UUID | None = None,
         folder_id: UUID | None = None,
+        selected_content: str | None = None,
     ) -> tuple[str, int]:
-        content = self.context_builder.build(
-            scope=scope, note_id=note_id, folder_id=folder_id
-        )
+        if scope == ChatScope.SELECTION:
+            require_non_empty(selected_content or "", "Selected content is empty")
+            content = selected_content or ""
+        else:
+            content = self.context_builder.build(
+                scope=scope, note_id=note_id, folder_id=folder_id
+            )
         return await self._run_ai_call(
             lambda model_id, language: self.ai_gateway.chat(
                 content=content,

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -5,3 +5,4 @@ class ChatScope(StrEnum):
     NOTE = "note"
     FOLDER = "folder"
     ALL = "all"
+    SELECTION = "selection"

--- a/backend/tests/test_ai_application_service.py
+++ b/backend/tests/test_ai_application_service.py
@@ -7,7 +7,8 @@ from app.features.assistant.usage_policy import get_usage_info, record_usage
 from app.features.assistant.use_cases import AIInteractionUseCases, EditJobUseCases
 from app.features.workspace.use_cases import WorkspaceQueryUseCases
 from app.models import AIEditJob, Note, UserSettings
-from app.shared import NotFound
+from app.models.enums import ChatScope
+from app.shared import NotFound, ValidationFailed
 from tests.conftest import OTHER_USER_ID, TEST_USER_ID
 
 
@@ -139,3 +140,47 @@ def test_get_edit_job_enforces_user_scope(session: Session):
         use_cases.get_job(job.id)
 
     assert exc_info.value.detail == "Edit job not found"
+
+
+@pytest.mark.asyncio
+async def test_chat_with_selection_scope_uses_selected_content(session: Session):
+    session.add(UserSettings(user_id=TEST_USER_ID, llm_model_id="model", language="en"))
+    session.commit()
+
+    ai_gateway = CapturingAIGateway()
+    use_cases = AIInteractionUseCases(
+        session,
+        TEST_USER_ID,
+        ai_gateway,
+        WorkspaceQueryUseCases(session, TEST_USER_ID),
+    )
+
+    answer, _ = await use_cases.chat_with_context(
+        scope=ChatScope.SELECTION,
+        question="What does this mean?",
+        selected_content="# Hello\nThis is selected text.",
+    )
+
+    assert answer == "answer"
+    assert ai_gateway.calls[0]["content"] == "# Hello\nThis is selected text."
+    assert ai_gateway.calls[0]["operation"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_chat_with_selection_scope_raises_when_content_empty(session: Session):
+    session.add(UserSettings(user_id=TEST_USER_ID, llm_model_id="model", language="en"))
+    session.commit()
+
+    use_cases = AIInteractionUseCases(
+        session,
+        TEST_USER_ID,
+        CapturingAIGateway(),
+        WorkspaceQueryUseCases(session, TEST_USER_ID),
+    )
+
+    with pytest.raises(ValidationFailed):
+        await use_cases.chat_with_context(
+            scope=ChatScope.SELECTION,
+            question="What does this mean?",
+            selected_content="",
+        )

--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -38,7 +38,8 @@ interface AIChatPanelProps {
     message: string,
     scope: ChatScope,
     noteId?: string | null,
-    folderId?: string | null
+    folderId?: string | null,
+    selectedContent?: string
   ) => void;
   onClearChat: () => void;
   isLoading: boolean;
@@ -50,10 +51,11 @@ interface AIChatPanelProps {
   // Edit mode props
   isEditMode?: boolean;
   onToggleEditMode?: (editMode: boolean) => void;
-  onSendEditRequest?: (instruction: string, currentContent: string, noteId?: string) => void;
+  onSendEditRequest?: (instruction: string, currentContent: string, noteId?: string, selectionRange?: { start: number; end: number }) => void;
   onAcceptEdit?: (messageIndex: number) => void;
   onRejectEdit?: (messageIndex: number) => void;
   currentEditorContent?: string;
+  selectedText?: string;
 }
 
 export function AIChatPanel({
@@ -74,6 +76,7 @@ export function AIChatPanel({
   onAcceptEdit,
   onRejectEdit,
   currentEditorContent = "",
+  selectedText = "",
 }: AIChatPanelProps) {
   const { t } = useTranslation();
   const [input, setInput] = useState("");
@@ -106,20 +109,29 @@ export function AIChatPanel({
     }
   }, [messages]);
 
+  const selectionRange = selectedText && currentEditorContent
+    ? (() => {
+        const start = currentEditorContent.indexOf(selectedText);
+        return start !== -1 ? { start, end: start + selectedText.length } : undefined;
+      })()
+    : undefined;
+
   const handleSend = () => {
     if (input.trim() && !isLoading) {
       if (isEditMode && onSendEditRequest) {
         onSendEditRequest(
           input.trim(),
           currentEditorContent,
-          selectedNote?.id
+          selectedNote?.id,
+          selectionRange
         );
       } else {
         onSendMessage(
           input.trim(),
           scope,
           scope === "note" ? selectedNote?.id : null,
-          scope === "folder" ? (selectedFolder?.id || selectedNote?.folder_id) : null
+          scope === "folder" ? (selectedFolder?.id || selectedNote?.folder_id) : null,
+          scope === "selection" ? selectedText : undefined
         );
       }
       setInput("");
@@ -254,6 +266,14 @@ export function AIChatPanel({
                     <span>{t("ai.allNotes")}</span>
                   </div>
                 </SelectItem>
+                {selectedText && (
+                  <SelectItem value="selection">
+                    <div className="flex items-center gap-2">
+                      <SparklesIcon className="h-3 w-3" />
+                      <span>{t("ai.selection")}</span>
+                    </div>
+                  </SelectItem>
+                )}
               </SelectContent>
             </Select>
 
@@ -262,6 +282,9 @@ export function AIChatPanel({
               {scope === "note" && (selectedNote ? (selectedNote.title || t("ai.untitled")) : t("ai.noNoteSelected"))}
               {scope === "folder" && (selectedFolder?.name || t("ai.noFolderSelected"))}
               {scope === "all" && t("ai.allNotesAndFolders")}
+              {scope === "selection" && (selectedText
+                ? t("ai.selectedLines").replace("{{count}}", String(selectedText.split("\n").length))
+                : t("ai.noTextSelected"))}
             </div>
           </div>
         )}
@@ -270,7 +293,9 @@ export function AIChatPanel({
         {isEditMode && (
           <div className="text-[11px] text-muted-foreground truncate px-1">
             {selectedNote
-              ? (selectedNote.title || t("ai.untitled"))
+              ? (selectedText
+                  ? t("ai.selectedLines").replace("{{count}}", String(selectedText.split("\n").length))
+                  : (selectedNote.title || t("ai.untitled")))
               : t("aiEdit.noNoteForEdit")}
           </div>
         )}
@@ -303,7 +328,7 @@ export function AIChatPanel({
               <p className="text-xs text-muted-foreground">
                 {isEditMode
                   ? t("aiEdit.editPlaceholder")
-                  : scope === "all" ? t("ai.askAboutNotes") : scope === "folder" ? t("ai.askAboutFolder") : t("ai.askAboutNote")}
+                  : scope === "all" ? t("ai.askAboutNotes") : scope === "folder" ? t("ai.askAboutFolder") : scope === "selection" ? t("ai.askAboutSelection") : t("ai.askAboutNote")}
               </p>
             </div>
           ) : (
@@ -433,6 +458,7 @@ export function AIChatPanel({
                 ? t("aiEdit.editPlaceholder")
                 : scope === "note" ? t("ai.askAboutCurrentNote") :
                   scope === "folder" ? t("ai.askAboutThisFolder") :
+                  scope === "selection" ? t("ai.askAboutCurrentSelection") :
                   t("ai.askAboutAllNotes")
             }
             onKeyDown={(e) => {

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -52,6 +52,7 @@ interface EditorPanelProps {
   savedHash?: string;
   tokenUsage?: TokenUsageRead | null;
   onContentChange?: (content: string) => void;
+  onSelectionChange?: (selectedText: string) => void;
   contentOverride?: { content: string; version: number } | null;
   pendingEditProposal?: EditProposal | null;
   onAcceptEdit?: () => void;
@@ -69,6 +70,7 @@ export function EditorPanel({
   isSummarizing = false,
   syncStatus,
   onContentChange,
+  onSelectionChange,
   contentOverride,
   triggerServerSync,
   savedHash,
@@ -778,13 +780,17 @@ export function EditorPanel({
   const handleSelect = useCallback(() => {
     const textarea = textareaRef.current;
     if (!textarea) return;
-    const { value, selectionStart } = textarea;
+    const { value, selectionStart, selectionEnd } = textarea;
     if (isCursorAtLineStart(value, selectionStart)) {
       showIndentGuidesForCurrentPosition(value, selectionStart);
     } else {
       setShowIndentGuides(false);
     }
-  }, [isCursorAtLineStart, showIndentGuidesForCurrentPosition]);
+    if (onSelectionChange) {
+      const selectedText = selectionStart !== selectionEnd ? value.slice(selectionStart, selectionEnd) : "";
+      onSelectionChange(selectedText);
+    }
+  }, [isCursorAtLineStart, showIndentGuidesForCurrentPosition, onSelectionChange]);
 
   // Fullscreen API toggle
   const toggleFullscreen = useCallback(async () => {

--- a/frontend/src/components/workspace/AuthenticatedWorkspace.tsx
+++ b/frontend/src/components/workspace/AuthenticatedWorkspace.tsx
@@ -112,6 +112,7 @@ export function AuthenticatedWorkspace({
               }
               tokenUsage={workspace.tokenUsage}
               onContentChange={workspace.handleEditorContentChange}
+              onSelectionChange={workspace.handleEditorSelectionChange}
               contentOverride={workspace.contentOverride}
               pendingEditProposal={pendingEditEntry?.message.editProposal ?? null}
               onAcceptEdit={
@@ -139,16 +140,18 @@ export function AuthenticatedWorkspace({
               onResizeStart={workspace.chatPanelResize.handleMouseDown}
               isEditMode={workspace.isEditMode}
               onToggleEditMode={workspace.setIsEditMode}
-              onSendEditRequest={(instruction, _content, noteId) =>
+              onSendEditRequest={(instruction, _content, noteId, selectionRange) =>
                 workspace.handleSendEditRequest(
                   instruction,
                   workspace.getCurrentEditorContent(),
-                  noteId
+                  noteId,
+                  selectionRange
                 )
               }
               onAcceptEdit={workspace.handleAcceptEditAndApply}
               onRejectEdit={workspace.handleRejectEdit}
-              currentEditorContent=""
+              currentEditorContent={workspace.getCurrentEditorContent()}
+              selectedText={workspace.getCurrentEditorSelectedText()}
             />
           </div>
         }

--- a/frontend/src/hooks/useAIChat.ts
+++ b/frontend/src/hooks/useAIChat.ts
@@ -6,7 +6,7 @@ import { useTranslation } from "./useTranslation";
 import { logger } from "@/lib/logger";
 import type { ChatMessage } from "@/types";
 
-export type ChatScope = "note" | "folder" | "all";
+export type ChatScope = "note" | "folder" | "all" | "selection";
 const EDIT_JOB_POLL_INTERVAL_MS = 1500;
 const EDIT_JOB_TIMEOUT_MS = 120000;
 
@@ -20,12 +20,14 @@ interface UseAIChatReturn {
     message: string,
     scope: ChatScope,
     noteId?: string | null,
-    folderId?: string | null
+    folderId?: string | null,
+    selectedContent?: string
   ) => Promise<void>;
   handleSendEditRequest: (
     instruction: string,
     currentContent: string,
-    noteId?: string
+    noteId?: string,
+    selectionRange?: { start: number; end: number }
   ) => Promise<void>;
   handleAcceptEdit: (messageIndex: number) => string | null;
   handleRejectEdit: (messageIndex: number) => void;
@@ -72,7 +74,8 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
     message: string,
     scope: ChatScope,
     noteId?: string | null,
-    folderId?: string | null
+    folderId?: string | null,
+    selectedContent?: string
   ) => {
     const userMessage: ChatMessage = { role: "user", content: message };
     setChatMessages((prev) => [...prev, userMessage]);
@@ -86,6 +89,7 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
         folder_id: folderId || undefined,
         question: message,
         history: chatMessages,
+        selected_content: scope === "selection" ? selectedContent : undefined,
       });
 
       if (result.tokens_used && onTokenUsage) {
@@ -110,16 +114,21 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
   const handleSendEditRequest = async (
     instruction: string,
     currentContent: string,
-    noteId?: string
+    noteId?: string,
+    selectionRange?: { start: number; end: number }
   ) => {
     const userMessage: ChatMessage = { role: "user", content: instruction };
     setChatMessages((prev) => [...prev, userMessage]);
     setIsAILoading(true);
 
+    const contentToEdit = selectionRange
+      ? currentContent.slice(selectionRange.start, selectionRange.end)
+      : currentContent;
+
     try {
       const apiClient = await getApi();
       const createResult = await apiClient.createEditJob({
-        content: currentContent,
+        content: contentToEdit,
         instruction,
         note_id: noteId,
       });
@@ -151,18 +160,21 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
 
       const assistantMessage: ChatMessage = {
         role: "assistant",
-        content: result.edited_content === currentContent
+        content: result.edited_content === contentToEdit
           ? instruction
           : "",
         editProposal: {
           originalContent: currentContent,
-          editedContent: result.edited_content,
-          status: result.edited_content === currentContent ? undefined : "pending",
+          editedContent: selectionRange
+            ? currentContent.slice(0, selectionRange.start) + result.edited_content + currentContent.slice(selectionRange.end)
+            : result.edited_content,
+          status: result.edited_content === contentToEdit ? undefined : "pending",
+          selectionRange,
         },
       };
 
       // If no changes, show a message instead of diff
-      if (result.edited_content === currentContent) {
+      if (result.edited_content === contentToEdit) {
         assistantMessage.content = "";
         assistantMessage.editProposal = undefined;
         setChatMessages((prev) => [

--- a/frontend/src/hooks/workspace/useWorkspaceState.test.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.test.ts
@@ -175,4 +175,22 @@ describe("useWorkspaceState", () => {
       version: 1,
     });
   });
+
+  it("tracks editor selected text via handleEditorSelectionChange", () => {
+    const { result } = renderHook(() => useWorkspaceState(true));
+
+    expect(result.current.getCurrentEditorSelectedText()).toBe("");
+
+    act(() => {
+      result.current.handleEditorSelectionChange("selected text");
+    });
+
+    expect(result.current.getCurrentEditorSelectedText()).toBe("selected text");
+
+    act(() => {
+      result.current.handleEditorSelectionChange("");
+    });
+
+    expect(result.current.getCurrentEditorSelectedText()).toBe("");
+  });
 });

--- a/frontend/src/hooks/workspace/useWorkspaceState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.ts
@@ -27,6 +27,7 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   } | null>(null);
 
   const editorContentRef = useRef("");
+  const editorSelectedTextRef = useRef("");
 
   const {
     folders,
@@ -94,6 +95,10 @@ export function useWorkspaceState(isAuthenticated: boolean) {
 
   const handleEditorContentChange = useCallback((content: string) => {
     editorContentRef.current = content;
+  }, []);
+
+  const handleEditorSelectionChange = useCallback((selectedText: string) => {
+    editorSelectedTextRef.current = selectedText;
   }, []);
 
   const handleAcceptEditAndApply = useCallback(
@@ -186,6 +191,8 @@ export function useWorkspaceState(isAuthenticated: boolean) {
     handleRejectEdit,
     clearChat,
     handleEditorContentChange,
+    handleEditorSelectionChange,
     getCurrentEditorContent: () => editorContentRef.current,
+    getCurrentEditorSelectedText: () => editorSelectedTextRef.current,
   };
 }

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -153,6 +153,11 @@ export const en = {
     askAboutThisFolder: "Ask about this folder...",
     askAboutAllNotes: "Ask about all your notes...",
     openAIChat: "Open AI Chat",
+    selection: "Selection",
+    selectedLines: "Selected text ({{count}} lines)",
+    askAboutSelection: "Ask about the selected text.",
+    askAboutCurrentSelection: "Ask about the selected text...",
+    noTextSelected: "No text selected",
   },
 
   // AI Edit
@@ -410,6 +415,11 @@ export type TranslationKeys = {
     askAboutThisFolder: string;
     askAboutAllNotes: string;
     openAIChat: string;
+    selection: string;
+    selectedLines: string;
+    askAboutSelection: string;
+    askAboutCurrentSelection: string;
+    noTextSelected: string;
   };
   aiEdit: {
     edit: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -153,6 +153,11 @@ export const ja = {
     askAboutThisFolder: "このフォルダについて質問...",
     askAboutAllNotes: "すべてのノートについて質問...",
     openAIChat: "AIチャットを開く",
+    selection: "選択範囲",
+    selectedLines: "選択テキスト（{{count}}行）",
+    askAboutSelection: "選択テキストについて質問してください。",
+    askAboutCurrentSelection: "選択テキストについて質問...",
+    noTextSelected: "テキストが選択されていません",
   },
 
   // AI Edit
@@ -410,6 +415,11 @@ export type TranslationKeys = {
     askAboutThisFolder: string;
     askAboutAllNotes: string;
     openAIChat: string;
+    selection: string;
+    selectedLines: string;
+    askAboutSelection: string;
+    askAboutCurrentSelection: string;
+    noTextSelected: string;
   };
   aiEdit: {
     edit: string;
@@ -421,6 +431,8 @@ export type TranslationKeys = {
     noNoteForEdit: string;
     noChanges: string;
     reviewInEditor: string;
+    tokenLimitExceeded: string;
+    editFailed: string;
   };
   auth: {
     login: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -95,6 +95,7 @@ export interface EditProposal {
   originalContent: string;
   editedContent: string;
   status?: "pending" | "accepted" | "rejected";
+  selectionRange?: { start: number; end: number };
 }
 
 export interface ChatMessage {
@@ -104,11 +105,12 @@ export interface ChatMessage {
 }
 
 export interface ChatRequest {
-  scope?: "note" | "folder" | "all";
+  scope?: "note" | "folder" | "all" | "selection";
   note_id?: string;
   folder_id?: string;
   question: string;
   history?: ChatMessage[];
+  selected_content?: string;
 }
 
 export interface ChatResponse {


### PR DESCRIPTION
## 概要

Cursorエディタに似た「選択範囲スコープ」機能をAIパネルに追加します。ユーザーがエディタでテキストを選択した状態でAIチャット・編集を実行すると、ノート全体ではなく選択したテキストのみをコンテキストとして使用できます。

Closes #59

## 変更内容

**バックエンド**
- `backend/app/models/enums.py`: `ChatScope` enumに `SELECTION` を追加
- `backend/app/features/assistant/schemas.py`: `ChatRequest` に `selected_content` フィールドを追加
- `backend/app/features/assistant/use_cases/ai_interactions.py`: `chat_with_context` がSELECTIONスコープ時に `selected_content` を使用するよう対応
- `backend/app/features/assistant/router.py`: `selected_content` をユースケースに渡すよう対応

**フロントエンド**
- `frontend/src/types/index.ts`: `ChatScope` 型と `ChatRequest` に `selection` / `selected_content` を追加、`EditProposal` に `selectionRange` を追加
- `frontend/src/hooks/useAIChat.ts`: SELECTIONスコープ対応、編集モードで選択範囲のみを編集してフルコンテンツに結果をマージ
- `frontend/src/hooks/workspace/useWorkspaceState.ts`: 選択テキストの参照 (`editorSelectedTextRef`) と `handleEditorSelectionChange` / `getCurrentEditorSelectedText` を追加
- `frontend/src/components/layout/EditorPanel.tsx`: `onSelectionChange` コールバックを追加し、テキスト選択変更時に発火
- `frontend/src/components/ai/AIChatPanel.tsx`: SELECTIONスコープのUI（セレクト項目・インジケーター・プレースホルダー）を追加
- `frontend/src/components/workspace/AuthenticatedWorkspace.tsx`: 各コンポーネントに新規propsを接続
- `frontend/src/locales/en.ts` / `ja.ts`: SELECTIONスコープ関連の翻訳キーを追加

**テスト**
- `backend/tests/test_ai_application_service.py`: SELECTIONスコープのチャットとバリデーションのテストを追加
- `frontend/src/hooks/workspace/useWorkspaceState.test.ts`: 選択テキストのトラッキングテストを追加

## テスト方法

- [ ] エディタでテキストを複数行選択する
- [ ] AIチャットパネルのスコープセレクトに「選択範囲」オプションが表示されることを確認する
- [ ] 「選択範囲」を選択して質問を送信し、選択テキストのみがコンテキストとして使われることを確認する
- [ ] 編集モードで選択テキストがある場合、選択範囲のみが編集されてフルコンテンツに反映されることを確認する
- [ ] テキストを選択していない場合、「選択範囲」オプションが表示されないことを確認する

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）