### PR TITLE
perf(3.1-3.4): fix content-only save path and stabilize notes[] memo deps

### DIFF
--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -198,7 +198,8 @@ describe('EditorPanel', () => {
     // Fast forward debounce
     vi.advanceTimersByTime(600)
 
-    expect(defaultProps.onUpdateNote).toHaveBeenCalledWith('1', { title: 'Initial content', content: 'New content' })
+    // Only changed fields are sent; title was not modified, so only content is included.
+    expect(defaultProps.onUpdateNote).toHaveBeenCalledWith('1', { content: 'New content' })
     vi.useRealTimers()
   })
 
@@ -824,8 +825,8 @@ describe('EditorPanel', () => {
 
       act(() => { vi.advanceTimersByTime(600) })
 
+      // Only changed fields are sent; title was not modified, so only content is included.
       expect(onUpdateNote).toHaveBeenCalledWith('2', {
-        title: 'Task note',
         content: '- [x] task item\n- [x] done item',
       })
       vi.useRealTimers()

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -168,18 +168,17 @@ export function EditorPanel({
   const currentTitleRef = useRef(title);
   const currentContentRef = useRef(content);
 
-  // Update refs when note changes to a different one (switched notes)
+  // Update refs on mount (key={note.id} remounts on note switch).
+  // lastSaved refs track the persisted baseline; current refs track the live editor state.
+  // Use the initialized `content` state (which prefers noteBodyStore over note?.content)
+  // so that prior unsaved edits aren't clobbered by the stale prop value.
   useEffect(() => {
     lastSavedTitle.current = note?.title ?? "";
     lastSavedContent.current = note?.content ?? "";
     currentTitleRef.current = note?.title ?? "";
-    currentContentRef.current = note?.content ?? "";
-    // We also need to update local state if the note prop changes and it's NOT what we just saved.
-    // However, the existing logic `useState(note?.title)` only runs on mount.
-    // The key={note.id} in parent ensures re-mount on switch.
-    // So we don't need to sync state here, just refs.
-    onContentChange?.(note?.content ?? "");
-  }, [note?.id, note?.title, note?.content]); // eslint-disable-line react-hooks/exhaustive-deps
+    currentContentRef.current = content;
+    onContentChange?.(content);
+  }, [note?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Apply content override from AI edit accept
   const contentOverrideVersionRef = useRef<number>(-1);
@@ -416,8 +415,11 @@ export function EditorPanel({
     }
 
     const handler = setTimeout(() => {
-      onUpdateNote(note.id, { title, content });
-      // Update refs to reflect that we've triggered a save for this content
+      const updates: { title?: string; content?: string } = {};
+      if (title !== lastSavedTitle.current) updates.title = title;
+      if (content !== lastSavedContent.current) updates.content = content;
+      if (Object.keys(updates).length === 0) return;
+      onUpdateNote(note.id, updates);
       lastSavedTitle.current = title;
       lastSavedContent.current = content;
     }, 500);
@@ -481,7 +483,10 @@ export function EditorPanel({
   const handleBlur = () => {
     // Use refs to check for changes to ensure we have the latest values
     if (note && (currentTitleRef.current !== lastSavedTitle.current || currentContentRef.current !== lastSavedContent.current)) {
-      onUpdateNote(note.id, { title: currentTitleRef.current, content: currentContentRef.current });
+      const updates: { title?: string; content?: string } = {};
+      if (currentTitleRef.current !== lastSavedTitle.current) updates.title = currentTitleRef.current;
+      if (currentContentRef.current !== lastSavedContent.current) updates.content = currentContentRef.current;
+      onUpdateNote(note.id, updates);
       lastSavedTitle.current = currentTitleRef.current;
       lastSavedContent.current = currentContentRef.current;
     }
@@ -1120,7 +1125,10 @@ export function EditorPanel({
             onClick={() => {
               // Ensure we save any pending changes before summarizing
               if (note && (currentTitleRef.current !== lastSavedTitle.current || currentContentRef.current !== lastSavedContent.current)) {
-                onUpdateNote(note.id, { title: currentTitleRef.current, content: currentContentRef.current });
+                const updates: { title?: string; content?: string } = {};
+                if (currentTitleRef.current !== lastSavedTitle.current) updates.title = currentTitleRef.current;
+                if (currentContentRef.current !== lastSavedContent.current) updates.content = currentContentRef.current;
+                onUpdateNote(note.id, updates);
                 lastSavedTitle.current = currentTitleRef.current;
                 lastSavedContent.current = currentContentRef.current;
               }

--- a/frontend/src/hooks/useNoteFilter.ts
+++ b/frontend/src/hooks/useNoteFilter.ts
@@ -7,10 +7,20 @@ export function useNoteFilter(
   selectedFolderId: string | null,
   searchQuery: string
 ) {
+  // Fingerprint tracks only folder membership changes (id + folder_id), not snippet/updated_at.
+  // This prevents folderFiltered from re-running on every auto-save that doesn't move notes.
+  const folderFingerprint = useMemo(
+    () => notes.map((n) => `${n.id}:${n.folder_id ?? ""}`).join("|"),
+    [notes]
+  );
+
   // Stage 1: folder filter — never touches content
   const folderFiltered = useMemo(
     () => (selectedFolderId ? notes.filter((n) => n.folder_id === selectedFolderId) : notes),
-    [notes, selectedFolderId]
+    // Depend on folderFingerprint instead of notes to skip re-runs when only
+    // snippet/updated_at/version change (which can't affect folder membership).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [folderFingerprint, selectedFolderId]
   );
 
   // Stage 2: search filter — skipped entirely when query is empty

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -393,18 +393,19 @@ export function useNoteSyncEngine({
         if (updates.content !== undefined) {
           noteBodyStore.set(id, updates.content);
         }
+        // Keep content out of notes[] — only metadata and snippet live there.
+        const { content: bodyOnly, ...metadataUpdates } = updates;
+        const now = new Date().toISOString();
         setNotes((prev) => {
           noteForLocalSave = prev.find((note) => note.id === id);
           return prev.map((note) =>
             note.id === id
               ? {
                   ...note,
-                  ...updates,
-                  ...(updates.content !== undefined
-                    ? { snippet: updates.content.slice(0, 80) }
-                    : {}),
+                  ...metadataUpdates,
+                  ...(bodyOnly !== undefined ? { snippet: bodyOnly.slice(0, 80) } : {}),
                   version: note.version + 1,
-                  updated_at: new Date().toISOString(),
+                  updated_at: now,
                   deleted_at: null,
                 }
               : note
@@ -412,14 +413,18 @@ export function useNoteSyncEngine({
         });
         try {
           if (noteForLocalSave) {
+            // For metadata-only changes: noteBodyStore may have a newer body than notes[]
+            // (because isContentOnly saves update the store but not notes[]).
+            // Use the store value as the authoritative body for the IDB record.
+            const latestBody =
+              bodyOnly ?? noteBodyStore.get(id) ?? noteForLocalSave.content ?? "";
             const updatedNote = {
               ...noteForLocalSave,
-              ...updates,
-              ...(updates.content !== undefined
-                ? { snippet: updates.content.slice(0, 80) }
-                : {}),
+              ...metadataUpdates,
+              content: latestBody,
+              ...(bodyOnly !== undefined ? { snippet: bodyOnly.slice(0, 80) } : {}),
               version: noteForLocalSave.version + 1,
-              updated_at: new Date().toISOString(),
+              updated_at: now,
               deleted_at: null,
             };
             await notesDB.saveNote(updatedNote);


### PR DESCRIPTION
## 概要

段階2.3 で追加した `isContentOnly` 軽量保存パスが、EditorPanel が常に `{ title, content }` を一緒に送っていたため実際には発火していなかった問題を修正します。併せて、`notes[]` へのコンテンツ漏れを防ぎ、フォルダフィルタの不要な再評価を抑制します。

## 変更内容

- **3.1 (EditorPanel.tsx)** — 自動保存・blur・サマリー前保存の全箇所で、変化したフィールドのみ `onUpdateNote` に渡すよう変更。本文だけ変わった打鍵バーストでは `{ content }` のみ送られ、`isContentOnly` 分岐が実際に発火するようになった。
- **3.2 (useNoteSyncEngine.ts)** — 非 `isContentOnly` 分岐（title/folder_id 変更）でも `...updates` から `content` を除外し、notes[] 要素にコンテンツが漏れないよう修正。IDB 書き込み時は `noteBodyStore` から最新本文を取得してデータ損失を防止。
- **3.3 (EditorPanel.tsx)** — マウント時 effect で `currentContentRef` と `onContentChange` に `note?.content`（notes[] の古い値）ではなく初期化済み `content` state を渡すよう修正。`editorContentRef` / `noteBodyStore` が初回レンダから正しい値を保持する。
- **3.4 (useNoteFilter.ts)** — `folderFiltered` の memo 依存を `notes` 配列全体から `folderFingerprint`（id + folder_id のペア文字列）に変更。snippet / updated_at / version だけが変わる 500ms 自動保存でフォルダフィルタが再評価されなくなる。

## テスト方法

- [ ] `make test-frontend` — 全 233 テスト通過を確認
- [ ] 10k〜30k 文字のノートを連続入力し、React DevTools Profiler で commit duration が改善されていることを確認（段階3着手前と比較）
- [ ] 本文編集中にタイトルを変更した後、ノートを切り替えて戻ったとき本文が正しく表示されることを確認
- [ ] フォルダフィルタが正しく動作することを確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)