### PR TITLE
revert: PR #66 — IME composition setContent skip broke input entirely

### DIFF
--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -428,13 +428,12 @@ export function EditorPanel({
   };
 
   const handleContentChange = useCallback((value: string) => {
-    currentContentRef.current = value;
-    if (isComposingRef.current) {
-      return;
-    }
     setContent(value);
-    setCommittedContent(value);
-    onContentChange?.(value);
+    currentContentRef.current = value;
+    if (!isComposingRef.current) {
+      setCommittedContent(value);
+      onContentChange?.(value);
+    }
   }, [onContentChange]);
 
   const handleCompositionStart = useCallback(() => {


### PR DESCRIPTION
## 概要

PR #66 をマージ・デプロイしたところ、**日本語入力が不可になり、一度壊れると Enter 含む英字入力まで不可になる** 深刻な回帰が発生したため緊急リバートする。

## 原因（暫定分析）

PR #66 は `isComposingRef.current === true` のとき `setContent` 自体をスキップする変更だったが、これにより controlled textarea の `value={content}` と DOM 値が composition 中に乖離する状況が生まれた。

変換中に `onKeyUp` → `handleSelect` → `setShowIndentGuides` / `setIndentGuideCount` などで **別経路の state 更新** が走ると、EditorPanel が再レンダされる。再レンダ時に React は controlled textarea の `value` prop（古い `content`）を DOM に書き戻し、IME が編集中だった DOM 値を巻き戻す。巻き戻された textarea は IME から見て壊れた状態になり、後続の入力（日本語・英字・Enter すべて）を受け付けられなくなる。

つまり「他の state 変化が composition 中に発生しない」という前提が成り立っていなかった。

## 変更内容

- `65c5c0b`（PR #66 のマージコミット）を `git revert -m 1` で取り消す
- `handleContentChange` は PR #65 時点の実装に戻る：
  ```ts
  setContent(value);
  currentContentRef.current = value;
  if (!isComposingRef.current) {
    setCommittedContent(value);
    onContentChange?.(value);
  }
  ```
- これにより長文 IME の遅延問題は未解決の状態に戻るが、入力不可の回帰は解消される

## テスト方法

- [ ] `make test-frontend` — 全 235 テスト通過
- [ ] デプロイ後に日本語・英字・Enter が通常通り入力できること
- [ ] プレビュー閉での長文日本語入力は PR #64 + #65 相当の体感（遅延は残るが入力は可能）に戻ること

## 次のアクション

この PR をマージ・デプロイして入力可能状態に戻してから、composition 中の IME clobber を起こさないより慎重なアプローチを設計する（例：composition 中は indent-guide 更新も抑制する、key-based 再マウントで controlled の同期を切り離す、uncontrolled defaultValue + imperative setter に切り替える、など）。

## チェックリスト

- [x] テストを追加・更新した（既存 235 件が全通）
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当なし）