### PR TITLE
feat: migrate editor to CodeMirror 6 to eliminate IME lag on long notes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.13.2",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -2244,6 +2249,136 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -3714,6 +3849,79 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -10083,6 +10291,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -16056,6 +16270,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -17074,6 +17294,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,11 @@
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^6.13.2",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",

--- a/frontend/src/components/editor/MarkdownEditor.tsx
+++ b/frontend/src/components/editor/MarkdownEditor.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, drawSelection, placeholder as cmPlaceholder } from "@codemirror/view";
+import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
+import { markdown } from "@codemirror/lang-markdown";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+
+export interface MarkdownEditorHandle {
+  getValue: () => string;
+  setValue: (value: string) => void;
+  focus: () => void;
+  view: () => EditorView | null;
+}
+
+interface MarkdownEditorProps {
+  initialValue: string;
+  onChange?: (value: string) => void;
+  onBlur?: () => void;
+  onSelectionChange?: (selectedText: string) => void;
+  onPasteImage?: (file: File) => void;
+  className?: string;
+  placeholder?: string;
+  "data-testid"?: string;
+}
+
+export const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
+  function MarkdownEditor(
+    {
+      initialValue,
+      onChange,
+      onBlur,
+      onSelectionChange,
+      onPasteImage,
+      className,
+      placeholder: placeholderText,
+      "data-testid": testId,
+    },
+    ref
+  ) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const viewRef = useRef<EditorView | null>(null);
+
+    // Stable callback refs — extensions read from these so they never need to be recreated
+    const onChangeRef = useRef(onChange);
+    const onBlurRef = useRef(onBlur);
+    const onSelectionChangeRef = useRef(onSelectionChange);
+    const onPasteImageRef = useRef(onPasteImage);
+    onChangeRef.current = onChange;
+    onBlurRef.current = onBlur;
+    onSelectionChangeRef.current = onSelectionChange;
+    onPasteImageRef.current = onPasteImage;
+
+    useEffect(() => {
+      if (!containerRef.current) return;
+
+      const extensions = [
+        history(),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        markdown(),
+        drawSelection(),
+        EditorView.lineWrapping,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current?.(update.state.doc.toString());
+          }
+          if (update.selectionSet && onSelectionChangeRef.current) {
+            const { from, to } = update.state.selection.main;
+            onSelectionChangeRef.current(
+              from === to ? "" : update.state.sliceDoc(from, to)
+            );
+          }
+        }),
+        EditorView.theme({
+          "&": { height: "100%" },
+          ".cm-scroller": {
+            fontFamily:
+              "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace)",
+            fontSize: "1rem",
+            lineHeight: "1.625",
+          },
+          ".cm-content": { padding: "0", minHeight: "400px" },
+          "&.cm-focused": { outline: "none" },
+          ".cm-line": { padding: "0" },
+          // Remove CM6 default selection color so Tailwind / OS selection is visible
+          ".cm-selectionBackground": { background: "Highlight" },
+          "&.cm-focused .cm-selectionBackground": { background: "Highlight" },
+        }),
+        EditorView.contentAttributes.of({
+          spellcheck: "false",
+          autocorrect: "off",
+          autocapitalize: "off",
+          "aria-label": "Note content",
+          ...(testId ? { "data-testid": testId } : {}),
+        }),
+        EditorView.domEventHandlers({
+          blur: () => {
+            onBlurRef.current?.();
+            return false;
+          },
+          paste: (event) => {
+            const file = event.clipboardData?.files[0];
+            if (file?.type.startsWith("image/")) {
+              event.preventDefault();
+              onPasteImageRef.current?.(file);
+              return true;
+            }
+            return false;
+          },
+        }),
+      ];
+
+      if (placeholderText) {
+        extensions.push(cmPlaceholder(placeholderText));
+      }
+
+      const state = EditorState.create({ doc: initialValue, extensions });
+      const view = new EditorView({ state, parent: containerRef.current });
+      viewRef.current = view;
+
+      return () => {
+        view.destroy();
+        viewRef.current = null;
+      };
+      // Only runs on mount/unmount — parent uses key={note.id} to force remount on note switch
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      getValue: () => viewRef.current?.state.doc.toString() ?? "",
+      setValue: (value: string) => {
+        const view = viewRef.current;
+        if (!view) return;
+        view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: value } });
+      },
+      focus: () => viewRef.current?.focus(),
+      view: () => viewRef.current,
+    }));
+
+    return <div ref={containerRef} className={className} />;
+  }
+);

--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -50,6 +50,49 @@ vi.mock('@/components/ai/DiffView', () => ({
   ),
 }))
 
+// Mock MarkdownEditor with a textarea facade so existing tests work unchanged
+vi.mock('@/components/editor/MarkdownEditor', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockMarkdownEditor = React.forwardRef(function MockMarkdownEditor(props: any, ref: any) {
+    const { initialValue, onChange, onBlur, onPasteImage, placeholder, className } = props
+    const testId = props['data-testid']
+    const [value, setValue] = React.useState(initialValue ?? '')
+    React.useImperativeHandle(ref, () => ({
+      getValue: () => value,
+      setValue: (newValue: string) => {
+        setValue(newValue)
+        onChange?.(newValue)
+      },
+      focus: () => {},
+      view: () => null,
+    }), [value, onChange])
+    return React.createElement('textarea', {
+      'aria-label': 'Note content',
+      'data-testid': testId,
+      className,
+      placeholder,
+      value,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onChange: (e: any) => {
+        setValue(e.target.value)
+        onChange?.(e.target.value)
+      },
+      onBlur,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onPaste: (e: any) => {
+        const file = e.clipboardData?.files[0]
+        if (file?.type.startsWith('image/')) {
+          e.preventDefault()
+          onPasteImage?.(file)
+        }
+      },
+    })
+  })
+  return { MarkdownEditor: MockMarkdownEditor }
+})
+
 // Mock document.execCommand (not implemented in happy-dom)
 Object.defineProperty(document, 'execCommand', {
   value: vi.fn().mockReturnValue(true),
@@ -654,7 +697,7 @@ describe('EditorPanel', () => {
       })
     })
 
-    describe('Scroll RAF throttling', () => {
+    describe.skip('Scroll RAF throttling', () => {
       let originalRaf: typeof requestAnimationFrame
       let originalCaf: typeof cancelAnimationFrame
 
@@ -833,7 +876,7 @@ describe('EditorPanel', () => {
     })
   })
 
-  describe('Indent guides', () => {
+  describe.skip('Indent guides', () => {
     const indentedNote = { ...mockNote, content: '  - item' }
 
     it('shows indent guide overlay when Tab is pressed on an indented line', async () => {

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import type { Note, Folder, TokenUsageRead, EditProposal } from "@/types";
 import { DiffView } from "@/components/ai/DiffView";
 import { useApi, useTranslation } from "@/hooks";
-import { useEffect, useState, useRef, useCallback, useMemo, KeyboardEvent, useDeferredValue, startTransition } from "react";
+import { useEffect, useState, useRef, useCallback, useMemo, useDeferredValue, startTransition, type KeyboardEvent } from "react";
+import { MarkdownEditor, type MarkdownEditorHandle } from "@/components/editor/MarkdownEditor";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -100,19 +99,13 @@ export function EditorPanel({
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [imageUploadError, setImageUploadError] = useState<string | null>(null);
   const [printSnapshot, setPrintSnapshot] = useState<{ title: string; content: string } | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<MarkdownEditorHandle>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const editorPreviewLayoutRef = useRef<HTMLDivElement>(null);
-  const isScrollingRef = useRef(false);
-  const scrollRafRef = useRef<number | null>(null);
   const editorPreviewWidthRef = useRef(editorPreviewWidth);
   const lastExpandedEditorPreviewWidthRef = useRef(lastExpandedEditorPreviewWidth);
   const printCleanupRef = useRef<(() => void) | null>(null);
-  const [showIndentGuides, setShowIndentGuides] = useState(false);
-  const [indentGuideCount, setIndentGuideCount] = useState(0);
-  const charMeasureRef = useRef<HTMLSpanElement>(null);
-  const isComposingRef = useRef(false);
 
   useEffect(() => {
     editorPreviewWidthRef.current = editorPreviewWidth;
@@ -175,12 +168,10 @@ export function EditorPanel({
 
   // Apply content override from AI edit accept
   const contentOverrideVersionRef = useRef<number>(-1);
-  // setEditorContent is defined later; access via ref to avoid circular deps
-  const setEditorContentRef = useRef<(v: string) => void>(() => {});
   useEffect(() => {
     if (contentOverride && contentOverride.version !== contentOverrideVersionRef.current) {
       contentOverrideVersionRef.current = contentOverride.version;
-      setEditorContentRef.current(contentOverride.content);
+      editorRef.current?.setValue(contentOverride.content);
     }
   }, [contentOverride]);
 
@@ -191,12 +182,9 @@ export function EditorPanel({
     noteIdRef.current = note?.id;
   }, [note?.id]);
 
-  // Clean up pending RAF on unmount
+  // Clean up print mode on unmount
   useEffect(() => {
     return () => {
-      if (scrollRafRef.current !== null) {
-        cancelAnimationFrame(scrollRafRef.current);
-      }
       printCleanupRef.current?.();
     };
   }, []);
@@ -429,58 +417,19 @@ export function EditorPanel({
     currentTitleRef.current = value;
   };
 
-  // Called by textarea onChange only — never updates the textarea DOM (browser already did it).
-  // setContent / setCommittedContent are wrapped in a transition so the React re-render does
-  // not block the next keystroke; safe because the textarea is uncontrolled.
-  const handleContentChange = useCallback((value: string) => {
+  // Called by CM6's updateListener on every doc change (after compositionEnd for IME input).
+  const handleEditorChange = useCallback((value: string) => {
     currentContentRef.current = value;
-    if (isComposingRef.current) return;
     onContentChange?.(value);
-    startTransition(() => {
-      setContent(value);
-      setCommittedContent(value);
-    });
-  }, [onContentChange]);
-
-  // Called for programmatic content changes (contentOverride, checkbox, image paste).
-  // Updates the textarea DOM imperatively because the textarea is uncontrolled.
-  const setEditorContent = useCallback((value: string) => {
-    currentContentRef.current = value;
-    if (textareaRef.current) {
-      const focused = document.activeElement === textareaRef.current;
-      const sel = focused ? textareaRef.current.selectionStart : null;
-      textareaRef.current.value = value;
-      if (focused && sel !== null) {
-        const clamped = Math.min(sel, value.length);
-        textareaRef.current.setSelectionRange(clamped, clamped);
-      }
-    }
     setContent(value);
-    setCommittedContent(value);
-    onContentChange?.(value);
+    startTransition(() => setCommittedContent(value));
   }, [onContentChange]);
-  // Keep the ref in sync so the contentOverride effect (defined earlier) can call it.
-  setEditorContentRef.current = setEditorContent;
 
-  const handleCompositionStart = useCallback(() => {
-    isComposingRef.current = true;
+  // Called for programmatic content changes (checkbox, image paste).
+  // CM6's setValue triggers handleEditorChange automatically via updateListener.
+  const setEditorContent = useCallback((value: string) => {
+    editorRef.current?.setValue(value);
   }, []);
-
-  const handleCompositionEnd = useCallback(
-    (e: React.CompositionEvent<HTMLTextAreaElement>) => {
-      isComposingRef.current = false;
-      const value = e.currentTarget.value;
-      currentContentRef.current = value;
-      onContentChange?.(value);
-      // Defer the React re-render so the user can immediately start the next composition
-      // without waiting for EditorPanel's reconciliation to finish.
-      startTransition(() => {
-        setContent(value);
-        setCommittedContent(value);
-      });
-    },
-    [onContentChange]
-  );
 
   const markdownComponents = useMemo((): Components => ({
     input(props) {
@@ -535,12 +484,12 @@ export function EditorPanel({
     }
 
     const placeholder = `![${t("editor.uploading")}]()`;
-    const textarea = textareaRef.current;
     const currentValue = currentContentRef.current;
-    const insertPos = textarea ? textarea.selectionStart : currentValue.length;
+    const view = editorRef.current?.view();
+    const insertPos = view?.state.selection.main.from ?? currentValue.length;
 
     setEditorContent(currentValue.slice(0, insertPos) + placeholder + currentValue.slice(insertPos));
-    textarea?.setSelectionRange(insertPos + placeholder.length, insertPos + placeholder.length);
+    view?.dispatch({ selection: { anchor: insertPos + placeholder.length } });
 
     try {
       const api = await getApi();
@@ -551,271 +500,9 @@ export function EditorPanel({
     }
   }, [getApi, setEditorContent, t]);
 
-  // Helper: Get list marker information from current line
-  interface ListMarkerInfo {
-    fullMatch: string;
-    indent: string;
-    marker: string | undefined;
-    markerSpace: string;
-    contentAfterMarker: string;
-  }
 
-  const getListMarkerInfo = useCallback((currentLine: string): ListMarkerInfo | null => {
-    // Match leading whitespace and optional list markers
-    // Supports: -, *, +, 1., 2., etc.
-    const match = currentLine.match(/^(\s*)([-*+]|\d+\.)?(\s*)/);
-    if (!match) return null;
 
-    const [fullMatch, indent, marker, markerSpace] = match;
-    return {
-      fullMatch,
-      indent: indent || "",
-      marker,
-      markerSpace: markerSpace || "",
-      contentAfterMarker: currentLine.slice(fullMatch.length),
-    };
-  }, []);
 
-  const getCharWidth = useCallback((): number => {
-    if (!charMeasureRef.current) return 0;
-    return charMeasureRef.current.getBoundingClientRect().width;
-  }, []);
-
-  const getCurrentLineIndentLevel = useCallback((text: string, cursorPos: number): number => {
-    const lineStart = text.lastIndexOf("\n", cursorPos - 1) + 1;
-    const lineEnd = text.indexOf("\n", cursorPos);
-    const currentLine = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd);
-    const m = currentLine.match(/^(\s*)/);
-    return m ? Math.floor(m[1].length / 2) : 0;
-  }, []);
-
-  const isCursorAtLineStart = useCallback((text: string, cursorPos: number): boolean => {
-    const lineStart = text.lastIndexOf("\n", cursorPos - 1) + 1;
-    const cursorOffsetInLine = cursorPos - lineStart;
-    const lineEnd = text.indexOf("\n", cursorPos);
-    const currentLine = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd);
-    const info = getListMarkerInfo(currentLine);
-    if (!info) return false;
-    const prefixLen = info.indent.length + (info.marker?.length ?? 0) + info.markerSpace.length;
-    return cursorOffsetInLine <= prefixLen;
-  }, [getListMarkerInfo]);
-
-  const showIndentGuidesForCurrentPosition = useCallback((text: string, cursorPos: number) => {
-    const level = getCurrentLineIndentLevel(text, cursorPos);
-    if (level === 0) {
-      setShowIndentGuides(false);
-      return;
-    }
-    setIndentGuideCount(level);
-    setShowIndentGuides(true);
-  }, [getCurrentLineIndentLevel]);
-
-  // Handle Tab/Shift+Tab for indentation
-  const handleTabKey = useCallback((
-    e: KeyboardEvent<HTMLTextAreaElement>,
-    textarea: HTMLTextAreaElement
-  ): void => {
-    e.preventDefault();
-
-    const { selectionStart, selectionEnd, value } = textarea;
-
-    // Handle multi-line selection
-    if (selectionStart !== selectionEnd) {
-      const startPos = value.lastIndexOf("\n", selectionStart - 1) + 1;
-      const endPos = value.indexOf("\n", selectionEnd);
-      const effectiveEndPos = endPos === -1 ? value.length : endPos;
-
-      const selection = value.slice(startPos, effectiveEndPos);
-      const lines = selection.split("\n");
-      let newSelection = "";
-      let totalOffsetStart = 0;
-      let totalOffsetEnd = 0;
-
-      if (e.shiftKey) {
-        // Unindent multiple lines
-        newSelection = lines
-          .map((line, index) => {
-            const indentMatch = line.match(/^(\s{1,2})/);
-            const spacesToRemove = indentMatch ? indentMatch[1].length : 0;
-
-            if (index === 0) {
-              totalOffsetStart -= Math.min(spacesToRemove, Math.max(0, selectionStart - startPos));
-            }
-            totalOffsetEnd -= spacesToRemove;
-
-            return line.slice(spacesToRemove);
-          })
-          .join("\n");
-      } else {
-        // Indent multiple lines
-        newSelection = lines
-          .map((line) => {
-            totalOffsetEnd += 2;
-            return "  " + line;
-          })
-          .join("\n");
-        totalOffsetStart = 2;
-      }
-
-      // Use document.execCommand to preserve undo history
-      textarea.setSelectionRange(startPos, effectiveEndPos);
-      document.execCommand("insertText", false, newSelection);
-
-      // Adjust cursor position
-      const newStart = Math.max(startPos, selectionStart + totalOffsetStart);
-      const newEnd = selectionEnd + totalOffsetEnd;
-      textarea.setSelectionRange(newStart, newEnd);
-      showIndentGuidesForCurrentPosition(textarea.value, textarea.selectionStart);
-      return;
-    }
-
-    // Find the start of the current line
-    const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
-    const currentLine = value.slice(lineStart, selectionStart);
-
-    // Check if the line is a list item (starts with optional whitespace + list marker)
-    const listMatch = currentLine.match(/^(\s*)([-*+]|\d+\.)\s/);
-
-    if (listMatch || currentLine.match(/^\s+/)) {
-      // We're in a list item or indented line
-      if (e.shiftKey) {
-        // Shift+Tab: Remove indentation (2 spaces from the beginning of the line)
-        const lineContent = value.slice(lineStart);
-        const indentMatch = lineContent.match(/^(\s{1,2})/);
-
-        if (indentMatch) {
-          const spacesToRemove = indentMatch[1].length;
-
-          // Use document.execCommand to preserve undo history
-          textarea.setSelectionRange(lineStart, lineStart + spacesToRemove);
-          document.execCommand("delete");
-
-          // Adjust cursor position
-          const newPos = Math.max(lineStart, selectionStart - spacesToRemove);
-          textarea.setSelectionRange(newPos, newPos);
-        }
-      } else {
-        // Tab: Add indentation (2 spaces at the beginning of the line)
-        textarea.setSelectionRange(lineStart, lineStart);
-        document.execCommand("insertText", false, "  ");
-
-        // Adjust cursor position
-        const newPos = selectionStart + 2;
-        textarea.setSelectionRange(newPos, newPos);
-      }
-    } else {
-      // Not in a list item - insert tab characters at cursor position
-      if (e.shiftKey) {
-        // Optional: handle Shift+Tab even for non-list items if it has leading spaces
-        const lineContent = value.slice(lineStart);
-        const indentMatch = lineContent.match(/^(\s{1,2})/);
-        if (indentMatch) {
-          const spacesToRemove = indentMatch[1].length;
-
-          // Use document.execCommand to preserve undo history
-          textarea.setSelectionRange(lineStart, lineStart + spacesToRemove);
-          document.execCommand("delete");
-
-          const newPos = Math.max(lineStart, selectionStart - spacesToRemove);
-          textarea.setSelectionRange(newPos, newPos);
-          showIndentGuidesForCurrentPosition(textarea.value, textarea.selectionStart);
-          return;
-        }
-      }
-
-      // Insert 2 spaces at current cursor position
-      document.execCommand("insertText", false, "  ");
-    }
-    showIndentGuidesForCurrentPosition(textarea.value, textarea.selectionStart);
-  }, [showIndentGuidesForCurrentPosition]);
-
-  // Handle Enter key for list continuation
-  const handleEnterKey = useCallback((
-    e: KeyboardEvent<HTMLTextAreaElement>,
-    textarea: HTMLTextAreaElement
-  ): void => {
-    const { selectionStart, value } = textarea;
-
-    // Find the start of the current line
-    const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
-    const currentLine = value.slice(lineStart, selectionStart);
-
-    const markerInfo = getListMarkerInfo(currentLine);
-    if (!markerInfo) return;
-
-    const { indent, marker, markerSpace, contentAfterMarker } = markerInfo;
-
-    // Check if the line only contains the marker (empty list item)
-    if (marker && contentAfterMarker.trim() === "") {
-      // Empty list item - remove the marker and indent on Enter
-      e.preventDefault();
-
-      // Use document.execCommand to preserve undo history
-      textarea.setSelectionRange(lineStart, selectionStart);
-      document.execCommand("insertText", false, "\n");
-      return;
-    }
-
-    // Build the continuation string
-    let continuation = indent;
-    if (marker) {
-      // Increment number for ordered lists
-      const numMatch = marker.match(/^(\d+)\.$/);
-      if (numMatch) {
-        continuation += (parseInt(numMatch[1], 10) + 1) + "." + markerSpace;
-      } else {
-        continuation += marker + markerSpace;
-      }
-    }
-
-    // Only intercept if there's something to continue
-    if (continuation) {
-      e.preventDefault();
-
-      // Use document.execCommand to preserve undo history
-      document.execCommand("insertText", false, "\n" + continuation);
-
-      // Scroll to keep cursor visible
-      requestAnimationFrame(() => {
-        textarea.blur();
-        textarea.focus();
-      });
-    }
-  }, [getListMarkerInfo]);
-
-  // Main keyboard event handler - delegates to specific handlers
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // Skip handling during IME composition (e.g., Japanese input)
-    if (e.nativeEvent.isComposing) return;
-
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    if (e.key === "Tab") {
-      handleTabKey(e, textarea);
-      return;
-    }
-
-    if (e.key === "Enter") {
-      handleEnterKey(e, textarea);
-    }
-  }, [handleTabKey, handleEnterKey]);
-
-  const handleSelect = useCallback(() => {
-    if (isComposingRef.current) return;
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    const { value, selectionStart, selectionEnd } = textarea;
-    if (isCursorAtLineStart(value, selectionStart)) {
-      showIndentGuidesForCurrentPosition(value, selectionStart);
-    } else {
-      setShowIndentGuides(false);
-    }
-    if (onSelectionChange) {
-      const selectedText = selectionStart !== selectionEnd ? value.slice(selectionStart, selectionEnd) : "";
-      onSelectionChange(selectedText);
-    }
-  }, [isCursorAtLineStart, showIndentGuidesForCurrentPosition, onSelectionChange]);
 
   // Fullscreen API toggle
   const toggleFullscreen = useCallback(async () => {
@@ -849,93 +536,6 @@ export function EditorPanel({
 
   const isDesktopSplitPreview = isPreviewOpen && isDesktopViewport;
   const isEditorCollapsed = isDesktopSplitPreview && editorPreviewWidth <= 0;
-  const isSplitPreviewVisible = isDesktopSplitPreview && !isEditorCollapsed;
-
-  // Scroll Sync Handlers (throttled with requestAnimationFrame, no content dependency)
-  const handleEditorScroll = useCallback(() => {
-    if (isScrollingRef.current || !isSplitPreviewVisible || !textareaRef.current || !previewContainerRef.current) return;
-    if (scrollRafRef.current !== null) return;
-
-    scrollRafRef.current = requestAnimationFrame(() => {
-      scrollRafRef.current = null;
-      if (!textareaRef.current || !previewContainerRef.current) return;
-
-      isScrollingRef.current = true;
-
-      const editor = textareaRef.current;
-      const preview = previewContainerRef.current;
-
-      const val = editor.value;
-      let contentLines = 1;
-      for (let i = 0; i < val.length; i++) {
-        if (val.charCodeAt(i) === 10) contentLines++;
-      }
-      const scrollPercentage = editor.scrollTop / (editor.scrollHeight - editor.clientHeight || 1);
-      const targetLine = Math.floor(contentLines * scrollPercentage);
-
-      const elements = Array.from(preview.querySelectorAll("[data-source-line]")) as HTMLElement[];
-      let targetElement = null;
-
-      for (const el of elements) {
-        const line = parseInt(el.getAttribute("data-source-line") || "0", 10);
-        if (line >= targetLine) {
-          targetElement = el;
-          break;
-        }
-      }
-
-      if (targetElement) {
-        preview.scrollTop = targetElement.offsetTop - preview.offsetTop;
-      } else if (scrollPercentage > 0.99) {
-        preview.scrollTop = preview.scrollHeight;
-      }
-
-      setTimeout(() => {
-        isScrollingRef.current = false;
-      }, 50);
-    });
-  }, [isSplitPreviewVisible]);
-
-  const handlePreviewScroll = useCallback(() => {
-    if (isScrollingRef.current || !isSplitPreviewVisible || !textareaRef.current || !previewContainerRef.current) return;
-    if (scrollRafRef.current !== null) return;
-
-    scrollRafRef.current = requestAnimationFrame(() => {
-      scrollRafRef.current = null;
-      if (!textareaRef.current || !previewContainerRef.current) return;
-
-      isScrollingRef.current = true;
-
-      const editor = textareaRef.current;
-      const preview = previewContainerRef.current;
-
-      const val = editor.value;
-      let contentLines = 1;
-      for (let i = 0; i < val.length; i++) {
-        if (val.charCodeAt(i) === 10) contentLines++;
-      }
-
-      const elements = Array.from(preview.querySelectorAll("[data-source-line]")) as HTMLElement[];
-      let visibleElement: HTMLElement | null = null;
-
-      for (const el of elements) {
-        if (el.offsetTop - preview.offsetTop >= preview.scrollTop) {
-          visibleElement = el;
-          break;
-        }
-      }
-
-      if (visibleElement) {
-        const line = parseInt(visibleElement.getAttribute("data-source-line") || "0", 10);
-        const targetScrollTop = (line / contentLines) * (editor.scrollHeight - editor.clientHeight);
-        editor.scrollTop = targetScrollTop;
-      }
-
-      setTimeout(() => {
-        isScrollingRef.current = false;
-      }, 50);
-    });
-  }, [isSplitPreviewVisible]);
 
   // JSON export handlers
   const handleExportMarkdown = useCallback(() => {
@@ -1134,53 +734,18 @@ export function EditorPanel({
                         if (file) await handleImageUpload(file);
                       }}
                     >
-                      <label htmlFor="note-content" className="sr-only">
-                        Note content
-                      </label>
-                      <Textarea
-                        id="note-content"
-                        ref={textareaRef}
-                        fieldSizing="fixed"
-                        defaultValue={note?.content ?? ""}
-                        onChange={(e) => handleContentChange(e.target.value)}
-                        onCompositionStart={handleCompositionStart}
-                        onCompositionEnd={handleCompositionEnd}
-                        onKeyDown={handleKeyDown}
-                        onScroll={handleEditorScroll}
+                      <MarkdownEditor
+                        ref={editorRef}
+                        key={note?.id}
+                        initialValue={note?.content ?? ""}
+                        onChange={handleEditorChange}
                         onBlur={handleBlur}
-                        onPaste={async (e) => {
-                          const file = e.clipboardData.files[0];
-                          if (file?.type.startsWith("image/")) {
-                            e.preventDefault();
-                            await handleImageUpload(file);
-                          }
-                        }}
+                        onSelectionChange={onSelectionChange}
+                        onPasteImage={handleImageUpload}
                         placeholder={t("editor.noteContentPlaceholder")}
-                        className="h-full resize-none border-none shadow-none focus-visible:ring-0 px-0 text-base leading-relaxed min-h-[400px] font-mono"
+                        className="h-full min-h-[400px]"
                         data-testid="editor-content-input"
-                        onKeyUp={handleSelect}
-                        onMouseUp={handleSelect}
-                        spellCheck={false}
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="off"
                       />
-                      {showIndentGuides && (
-                        <div
-                          className="absolute inset-0 pointer-events-none overflow-hidden"
-                          data-testid="indent-guide-overlay"
-                          aria-hidden="true"
-                        >
-                          {Array.from({ length: indentGuideCount }, (_, i) => (
-                            <div
-                              key={i}
-                              className="absolute top-0 bottom-0 w-px bg-gray-400/40 dark:bg-gray-500/40"
-                              style={{ left: `${(i + 1) * 2 * getCharWidth()}px` }}
-                              data-testid={`indent-guide-line-${i}`}
-                            />
-                          ))}
-                        </div>
-                      )}
                     </div>
                   )}
 
@@ -1209,9 +774,7 @@ export function EditorPanel({
                         deferredContent={deferredContent}
                         markdownComponents={markdownComponents}
                         previewContainerRef={previewContainerRef}
-                        onPreviewScroll={
-                          isSplitPreviewVisible ? handlePreviewScroll : undefined
-                        }
+                        onPreviewScroll={undefined}
                         isDesktopViewport={isDesktopViewport}
                         previewPlaceholder={t("editor.previewPlaceholder")}
                       />
@@ -1232,14 +795,6 @@ export function EditorPanel({
           />
         </div>
       </div>
-      <span
-        ref={charMeasureRef}
-        className="font-mono invisible absolute -z-10 whitespace-pre"
-        aria-hidden="true"
-        style={{ fontSize: "inherit", lineHeight: "inherit" }}
-      >
-        x
-      </span>
     </>
   );
 }


### PR DESCRIPTION
## 概要

Linux IME（IBus/Fcitx）⇔ Chrome 間の `surrounding_text` IPC が原因で、30k 字以上のノートで日本語入力が 1 文字あたり 300-500ms かかっていた。Chrome DevTools Performance trace で確認済み（4.4s の Long Task のうち JS 実行は 40ms、残りはメインスレッドがアイドルで IME イベント待機）。

CodeMirror 6（CM6）は contentEditable + ビューポート仮想化で動作するため、IME に渡される surrounding text が表示領域の数百字に限定され、IPC ラウンドトリップが大幅に軽量化される。これにより長文ノートでも英字入力と同等のレイテンシで日本語入力できるようになる（PR-A の主目的）。

## 変更内容

- `frontend/src/components/editor/MarkdownEditor.tsx`（新設）: CM6 薄ラッパーコンポーネント。`EditorState`/`EditorView` を `useEffect` でマウント時のみ初期化し、stable callback refs パターンで React 再レンダリングをまたいで extensions を安定保持。`useImperativeHandle` で `getValue/setValue/focus/view` を公開。
- `frontend/src/components/layout/EditorPanel.tsx`: `<Textarea>` を `<MarkdownEditor ref={editorRef}>` に置換。`textareaRef`・`isComposingRef`・`scrollRafRef`・`charMeasureRef` 等を削除。`handleTabKey`・`handleEnterKey`・`handleKeyDown`・`handleSelect`・`handleEditorScroll`・`handlePreviewScroll`・インデントガイド関連（PR-B/C スコープ）を削除。`handleEditorChange` を CM6 の `onChange` コールバックとして接続。
- `frontend/package.json`: `@codemirror/{state,view,commands,language,lang-markdown}` を追加。
- `frontend/src/components/layout/EditorPanel.test.tsx`: `MarkdownEditor` の textarea ファサードモックを追加し既存テストを最小変更で通過。`Scroll RAF throttling`・`Indent guides` の describe ブロックを `describe.skip` に変更（PR-B/C で復活予定）。

## テスト方法

- [ ] `make test-frontend` — 224 tests pass, 11 skipped（skip は PR-B/C で解除予定）
- [ ] Fedora Chrome でプレビュー非表示・30k 字以上のノートを開き日本語 8 文字連続入力 → 英字入力と同等のレイテンシ（1 文字あたり 50ms 未満）になることを確認
- [ ] 通常編集（タイトル・本文）・onBlur 保存・AI edit accept・画像 D&D・画像 paste・チェックボックス click を一通り確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）

## 関連

PR-A（このPR）: CM6 移行・IME 遅延解消  
PR-B（予定）: Tab/Enter インデント・リスト継続・インデントガイドの復活  
PR-C（予定）: スクロール同期・テーマ微調整・E2E