### PR TITLE
fix: make CM6 cursor visible in light/dark mode

### DIFF
--- a/frontend/src/components/editor/MarkdownEditor.tsx
+++ b/frontend/src/components/editor/MarkdownEditor.tsx
@@ -94,6 +94,12 @@ export const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorPro
           // Remove CM6 default selection color so Tailwind / OS selection is visible
           ".cm-selectionBackground": { background: "Highlight" },
           "&.cm-focused .cm-selectionBackground": { background: "Highlight" },
+          ".cm-cursor, .cm-dropCursor": {
+            borderLeftColor: "var(--foreground)",
+          },
+          "&.cm-focused .cm-cursor": {
+            borderLeftColor: "var(--foreground)",
+          },
         }),
         EditorView.contentAttributes.of({
           spellcheck: "false",


### PR DESCRIPTION
## 概要

PR-B（#74）で CodeMirror 6 に移行した際、エディタのキャレット（カーソル）がダークモードで見えなくなる問題を修正。

## 変更内容

- `MarkdownEditor.tsx` の `EditorView.theme(...)` に `.cm-cursor` と `.cm-dropCursor` の `borderLeftColor` オーバーライドを追加
- 色は `var(--foreground)`（`globals.css` で light/dark 両モードに定義済み）を使用し、テーマ切替に自動追従する

## 原因

`drawSelection()` 拡張は:
1. `.cm-content` に `caret-color: transparent` を設定してブラウザ既定のシステムキャレットを非表示にする
2. 代わりに `.cm-cursor` div を `border-left: 1.2px solid black`（CM6 既定色）で描画する

CM6 はアプリのダークモード（`.dark` クラス）を知らないため、ダークテーマの濃色背景では黒キャレットが見えなくなる。

## テスト方法

- [ ] ダークモードでエディタにフォーカスしてキャレットが表示される（白っぽい色）
- [ ] ライトモードでエディタにフォーカスしてキャレットが表示される（黒色）
- [ ] IME レイテンシに劣化なし（30k 字ノートで日本語連続入力）
- [ ] Tab/Shift+Tab、Enter リスト継続、インデントガイドが PR-B 時点と同等に動作

## チェックリスト

- [x] テストを追加・更新した（CSS テーマ変更のため単体テストでの検証対象外、手動確認で代替）
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）