### PR TITLE
feat: PR-C — scroll sync, syntax highlighting, skip 0 tests, E2E fix

### DIFF
--- a/frontend/src/components/editor/MarkdownEditor.tsx
+++ b/frontend/src/components/editor/MarkdownEditor.tsx
@@ -4,6 +4,7 @@ import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, drawSelection, placeholder as cmPlaceholder } from "@codemirror/view";
 import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
+import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { markdownIndentKeymap } from "./extensions/markdownIndent";
 import { markdownListContinuationKeymap } from "./extensions/markdownListContinuation";
@@ -66,6 +67,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorPro
           ...historyKeymap,
         ]),
         markdown(),
+        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         drawSelection(),
         EditorView.lineWrapping,
         indentGuide,

--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -50,7 +50,8 @@ vi.mock('@/components/ai/DiffView', () => ({
   ),
 }))
 
-// Mock MarkdownEditor with a textarea facade so existing tests work unchanged
+// Mock MarkdownEditor with a textarea facade so existing tests work unchanged.
+// The wrapper div acts as scrollDOM so scroll-sync tests can fire events on it.
 vi.mock('@/components/editor/MarkdownEditor', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const React = require('react')
@@ -59,6 +60,7 @@ vi.mock('@/components/editor/MarkdownEditor', () => {
     const { initialValue, onChange, onBlur, onPasteImage, placeholder, className } = props
     const testId = props['data-testid']
     const [value, setValue] = React.useState(initialValue ?? '')
+    const scrollDOMRef = React.useRef(null)
     React.useImperativeHandle(ref, () => ({
       getValue: () => value,
       setValue: (newValue: string) => {
@@ -66,29 +68,36 @@ vi.mock('@/components/editor/MarkdownEditor', () => {
         onChange?.(newValue)
       },
       focus: () => {},
-      view: () => null,
+      view: () => scrollDOMRef.current ? {
+        scrollDOM: scrollDOMRef.current,
+        state: { selection: { main: { from: 0, to: 0 } } },
+        dispatch: () => {},
+      } : null,
     }), [value, onChange])
-    return React.createElement('textarea', {
-      'aria-label': 'Note content',
-      'data-testid': testId,
-      className,
-      placeholder,
-      value,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onChange: (e: any) => {
-        setValue(e.target.value)
-        onChange?.(e.target.value)
-      },
-      onBlur,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onPaste: (e: any) => {
-        const file = e.clipboardData?.files[0]
-        if (file?.type.startsWith('image/')) {
-          e.preventDefault()
-          onPasteImage?.(file)
-        }
-      },
-    })
+     
+    return React.createElement('div',
+      { ref: scrollDOMRef, 'data-testid': 'mock-cm-scroller', className }, // eslint-disable-line react-hooks/refs
+      React.createElement('textarea', {
+        'aria-label': 'Note content',
+        'data-testid': testId,
+        placeholder,
+        value,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onChange: (e: any) => {
+          setValue(e.target.value)
+          onChange?.(e.target.value)
+        },
+        onBlur,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onPaste: (e: any) => {
+          const file = e.clipboardData?.files[0]
+          if (file?.type.startsWith('image/')) {
+            e.preventDefault()
+            onPasteImage?.(file)
+          }
+        },
+      })
+    )
   })
   return { MarkdownEditor: MockMarkdownEditor }
 })
@@ -697,7 +706,7 @@ describe('EditorPanel', () => {
       })
     })
 
-    describe.skip('Scroll RAF throttling', () => {
+    describe('Scroll RAF throttling', () => {
       let originalRaf: typeof requestAnimationFrame
       let originalCaf: typeof cancelAnimationFrame
 
@@ -717,16 +726,12 @@ describe('EditorPanel', () => {
 
         render(<EditorPanel {...defaultProps} />)
 
-        // Open preview to enable scroll sync
-        const previewButton = screen.getByTestId('editor-preview-toggle')
-        fireEvent.click(previewButton)
-
-        const textarea = screen.getByRole('textbox', { name: /content/i })
+        const scroller = screen.getByTestId('mock-cm-scroller')
 
         // Fire multiple scroll events in the same frame
-        fireEvent.scroll(textarea)
-        fireEvent.scroll(textarea)
-        fireEvent.scroll(textarea)
+        fireEvent.scroll(scroller)
+        fireEvent.scroll(scroller)
+        fireEvent.scroll(scroller)
 
         // Only one RAF should be scheduled (subsequent events are blocked by the ref guard)
         expect(mockRaf).toHaveBeenCalledTimes(1)
@@ -744,13 +749,10 @@ describe('EditorPanel', () => {
 
         render(<EditorPanel {...defaultProps} />)
 
-        const previewButton = screen.getByTestId('editor-preview-toggle')
-        fireEvent.click(previewButton)
-
-        const textarea = screen.getByRole('textbox', { name: /content/i })
+        const scroller = screen.getByTestId('mock-cm-scroller')
 
         // First scroll — schedules RAF
-        fireEvent.scroll(textarea)
+        fireEvent.scroll(scroller)
         expect(mockRaf).toHaveBeenCalledTimes(1)
 
         // Execute the RAF callback — clears scrollRafRef.current and sets isScrollingRef.current = true
@@ -762,7 +764,7 @@ describe('EditorPanel', () => {
         vi.advanceTimersByTime(50)
 
         // Second scroll after frame + cooldown — should schedule a new RAF
-        fireEvent.scroll(textarea)
+        fireEvent.scroll(scroller)
         expect(mockRaf).toHaveBeenCalledTimes(2)
 
         vi.useRealTimers()
@@ -777,12 +779,8 @@ describe('EditorPanel', () => {
 
         const { unmount } = render(<EditorPanel {...defaultProps} />)
 
-        // Open preview and trigger a scroll to schedule a RAF
-        const previewButton = screen.getByTestId('editor-preview-toggle')
-        fireEvent.click(previewButton)
-
-        const textarea = screen.getByRole('textbox', { name: /content/i })
-        fireEvent.scroll(textarea)
+        const scroller = screen.getByTestId('mock-cm-scroller')
+        fireEvent.scroll(scroller)
 
         // RAF is pending (callback not yet executed)
         expect(mockRaf).toHaveBeenCalled()

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -102,6 +102,8 @@ export function EditorPanel({
   const editorRef = useRef<MarkdownEditorHandle>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
+  const scrollRafRef = useRef<number | null>(null);
+  const isScrollingRef = useRef(false);
   const editorPreviewLayoutRef = useRef<HTMLDivElement>(null);
   const editorPreviewWidthRef = useRef(editorPreviewWidth);
   const lastExpandedEditorPreviewWidthRef = useRef(lastExpandedEditorPreviewWidth);
@@ -124,6 +126,36 @@ export function EditorPanel({
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  const handleEditorScroll = useCallback(() => {
+    if (scrollRafRef.current !== null) return;
+    if (isScrollingRef.current) return;
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      const view = editorRef.current?.view();
+      const preview = previewContainerRef.current;
+      if (!view || !preview) return;
+      const src = view.scrollDOM;
+      const ratio = src.scrollTop / Math.max(1, src.scrollHeight - src.clientHeight);
+      preview.scrollTop = ratio * Math.max(0, preview.scrollHeight - preview.clientHeight);
+      isScrollingRef.current = true;
+      setTimeout(() => { isScrollingRef.current = false; }, 50);
+    });
+  }, []);
+
+  useEffect(() => {
+    const view = editorRef.current?.view();
+    if (!view) return;
+    const target = view.scrollDOM;
+    target.addEventListener("scroll", handleEditorScroll, { passive: true });
+    return () => {
+      target.removeEventListener("scroll", handleEditorScroll);
+      if (scrollRafRef.current !== null) {
+        cancelAnimationFrame(scrollRafRef.current);
+        scrollRafRef.current = null;
+      }
+    };
+  }, [note?.id, handleEditorScroll]);
 
   // Hash-based Verification Logic
   const [currentHash, setCurrentHash] = useState("");

--- a/frontend/tests/golden-path.spec.ts
+++ b/frontend/tests/golden-path.spec.ts
@@ -191,7 +191,7 @@ test.describe('Golden Path: Note Lifecycle', () => {
     const titleInput = layout.getByTestId('editor-title-input');
     const contentInput = layout.getByTestId('editor-content-input');
     await expect(titleInput).toHaveValue(noteTitle, { timeout: 30000 });
-    await expect(contentInput).toHaveValue(noteContent, { timeout: 30000 });
+    await expect(contentInput).toContainText(noteContent, { timeout: 30000 });
 
     console.log('[Golden Path] Editing note title and content');
     await titleInput.fill(updatedTitle);

--- a/frontend/tests/mobile.spec.ts
+++ b/frontend/tests/mobile.spec.ts
@@ -61,8 +61,8 @@ test.describe('Mobile Comprehensive Scenario', () => {
     await expect(titleInput).toBeVisible({ timeout: 20000 });
     await expect(titleInput).toHaveValue(createdNote.title, { timeout: 20000 });
     await expect(
-      layout.getByPlaceholder(/Start writing your note|Markdownでノートを書き始め/i).first()
-    ).toHaveValue(createdNote.content, { timeout: 20000 });
+      layout.getByTestId('editor-content-input')
+    ).toContainText(createdNote.content, { timeout: 20000 });
 
     // 4. Summarize -> Auto transition to Chat/Summary view
     console.log('[Mobile Test] Summarizing');

--- a/frontend/tests/notes.spec.ts
+++ b/frontend/tests/notes.spec.ts
@@ -71,7 +71,7 @@ test.describe('Notes Functionality', () => {
     await expect(noteItem).toBeVisible({ timeout: 30000 });
     await noteItem.click();
     await expect(layout.getByTestId('editor-title-input')).toHaveValue(noteTitle, { timeout: 30000 });
-    await expect(layout.getByTestId('editor-content-input')).toHaveValue(noteContent, { timeout: 30000 });
+    await expect(layout.getByTestId('editor-content-input')).toContainText(noteContent, { timeout: 30000 });
 
     // 4. Summarize
     console.log('[E2E] Requesting summary');
@@ -335,7 +335,7 @@ test.describe('Notes Functionality', () => {
     await expect(existingNoteItem).toBeVisible({ timeout: 30000 });
     await existingNoteItem.click();
     await expect(layout.getByTestId('editor-title-input')).toHaveValue(onlineNoteTitle, { timeout: 30000 });
-    await expect(contentInput).toHaveValue(initialContent, { timeout: 30000 });
+    await expect(contentInput).toContainText(initialContent, { timeout: 30000 });
 
 
     // 2. Go offline
@@ -417,6 +417,6 @@ test.describe('Notes Functionality', () => {
 
     const reloadedLayout = isMobile ? page.getByTestId('mobile-layout-editor') : page.getByTestId('desktop-layout');
     await expect(reloadedLayout.getByTestId('editor-title-input')).toHaveValue(onlineNoteTitle, { timeout: 20000 });
-    await expect(reloadedLayout.getByTestId('editor-content-input')).toHaveValue(offlineContent, { timeout: 20000 });
+    await expect(reloadedLayout.getByTestId('editor-content-input')).toContainText(offlineContent, { timeout: 20000 });
   });
 });

--- a/frontend/tests/share.spec.ts
+++ b/frontend/tests/share.spec.ts
@@ -74,7 +74,7 @@ test.describe('Sharing Functionality', () => {
       await expect(titleInput).toBeVisible({ timeout: 20000 });
     }
     await expect(titleInput).toHaveValue(noteTitle, { timeout: 30000 });
-    await expect(contentTextarea).toHaveValue(noteContent, { timeout: 30000 });
+    await expect(contentTextarea).toContainText(noteContent, { timeout: 30000 });
 
     // Click the Share button
     console.log('[Share E2E] Opening share dialog');


### PR DESCRIPTION
## 概要

CM6 移行（PR-A: #73, PR-B: #74, カーソル修正: #75）の仕上げ。エディタ→プレビューのスクロール同期復活、Markdown シンタックスハイライト追加、ユニットテスト skip 0 件達成、E2E アサーション修正の 4 点をまとめて対応。

## 変更内容

- **スクロール同期** (`EditorPanel.tsx`): CM6 `view.scrollDOM` に scroll リスナーを登録し、RAF スロットル + 50ms クールダウンでエディタ → プレビューの比率ベース同期を復活（PR-A で外れていた旧実装の CM6 置き換え）
- **シンタックスハイライト** (`MarkdownEditor.tsx`): `syntaxHighlighting(defaultHighlightStyle)` を追加。見出し・太字・コードなどの Markdown トークンに色が付くようになった
- **テスト復活** (`EditorPanel.test.tsx`): `describe.skip('Scroll RAF throttling')` を解除。`MarkdownEditor` モックに `scrollDOM` を露出させ、scroll イベントターゲットを `mock-cm-scroller` に変更。テストスイート **258 passed / skip 0**
- **E2E 修正** (`notes.spec.ts`, `golden-path.spec.ts`, `share.spec.ts`, `mobile.spec.ts`): CM6 の contenteditable は `.value` を持たないため、`.toHaveValue()` を `.toContainText()` に置換。mobile テストはさらに `getByPlaceholder()` → `getByTestId('editor-content-input')` に修正

## テスト方法

- [ ] `make test-frontend` → 258 passed, skip 0
- [ ] `make dev-frontend` → 長文ノートでエディタをスクロールしてプレビューが追従する
- [ ] `make dev-frontend` → `# Heading`, `**bold**`, `code` にシンタックスハイライトが適用される
- [ ] `make dev-frontend` → Tab/Shift+Tab、Enter リスト継続、キャレット表示が PR-B 時点と同等

## チェックリスト

- [x] テストを追加・更新した（`Scroll RAF throttling` 4 ケース復活、E2E アサーション修正）
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）