### PR TITLE
fix: bidirectional scroll sync, AI edit content, and search store fallback

### DIFF
--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -102,7 +102,8 @@ export function EditorPanel({
   const editorRef = useRef<MarkdownEditorHandle>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
-  const scrollRafRef = useRef<number | null>(null);
+  const editorScrollRafRef = useRef<number | null>(null);
+  const previewScrollRafRef = useRef<number | null>(null);
   const isScrollingRef = useRef(false);
   const editorPreviewLayoutRef = useRef<HTMLDivElement>(null);
   const editorPreviewWidthRef = useRef(editorPreviewWidth);
@@ -128,17 +129,33 @@ export function EditorPanel({
   }, []);
 
   const handleEditorScroll = useCallback(() => {
-    if (scrollRafRef.current !== null) return;
+    if (editorScrollRafRef.current !== null) return;
     if (isScrollingRef.current) return;
-    scrollRafRef.current = requestAnimationFrame(() => {
-      scrollRafRef.current = null;
+    editorScrollRafRef.current = requestAnimationFrame(() => {
+      editorScrollRafRef.current = null;
       const view = editorRef.current?.view();
       const preview = previewContainerRef.current;
       if (!view || !preview) return;
       const src = view.scrollDOM;
       const ratio = src.scrollTop / Math.max(1, src.scrollHeight - src.clientHeight);
-      preview.scrollTop = ratio * Math.max(0, preview.scrollHeight - preview.clientHeight);
       isScrollingRef.current = true;
+      preview.scrollTop = ratio * Math.max(0, preview.scrollHeight - preview.clientHeight);
+      setTimeout(() => { isScrollingRef.current = false; }, 50);
+    });
+  }, []);
+
+  const handlePreviewScroll = useCallback(() => {
+    if (previewScrollRafRef.current !== null) return;
+    if (isScrollingRef.current) return;
+    previewScrollRafRef.current = requestAnimationFrame(() => {
+      previewScrollRafRef.current = null;
+      const view = editorRef.current?.view();
+      const preview = previewContainerRef.current;
+      if (!view || !preview) return;
+      const dst = view.scrollDOM;
+      const ratio = preview.scrollTop / Math.max(1, preview.scrollHeight - preview.clientHeight);
+      isScrollingRef.current = true;
+      dst.scrollTop = ratio * Math.max(0, dst.scrollHeight - dst.clientHeight);
       setTimeout(() => { isScrollingRef.current = false; }, 50);
     });
   }, []);
@@ -150,9 +167,13 @@ export function EditorPanel({
     target.addEventListener("scroll", handleEditorScroll, { passive: true });
     return () => {
       target.removeEventListener("scroll", handleEditorScroll);
-      if (scrollRafRef.current !== null) {
-        cancelAnimationFrame(scrollRafRef.current);
-        scrollRafRef.current = null;
+      if (editorScrollRafRef.current !== null) {
+        cancelAnimationFrame(editorScrollRafRef.current);
+        editorScrollRafRef.current = null;
+      }
+      if (previewScrollRafRef.current !== null) {
+        cancelAnimationFrame(previewScrollRafRef.current);
+        previewScrollRafRef.current = null;
       }
     };
   }, [note?.id, handleEditorScroll]);
@@ -806,7 +827,7 @@ export function EditorPanel({
                         deferredContent={deferredContent}
                         markdownComponents={markdownComponents}
                         previewContainerRef={previewContainerRef}
-                        onPreviewScroll={undefined}
+                        onPreviewScroll={handlePreviewScroll}
                         isDesktopViewport={isDesktopViewport}
                         previewPlaceholder={t("editor.previewPlaceholder")}
                       />

--- a/frontend/src/hooks/useNoteFilter.test.ts
+++ b/frontend/src/hooks/useNoteFilter.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { useNoteFilter } from "./useNoteFilter";
 import { noteBodyStore } from "@/lib/sync/noteBodyStore";
@@ -96,5 +96,29 @@ describe("useNoteFilter", () => {
     noteBodyStore.set("1", "completely different text");
     const { result } = renderHook(() => useNoteFilter(notes, null, "completely different"));
     expect(result.current.map((n) => n.id)).toEqual(["1"]);
+  });
+
+  it("does not fall back to n.content when store has empty string for that note", () => {
+    // n.content="hello world" for note "1", but user deleted all content → store has ""
+    noteBodyStore.set("1", "");
+    const { result } = renderHook(() => useNoteFilter(notes, null, "hello"));
+    // Note "1" should NOT appear (store empty string wins over stale n.content)
+    // Note "4" has n.content="hello again" and is not in store, so it still matches
+    expect(result.current.map((n) => n.id)).toEqual(["4"]);
+  });
+
+  it("updates search results reactively when noteBodyStore changes", () => {
+    const { result } = renderHook(() => useNoteFilter(notes, null, "reactive"));
+    expect(result.current).toHaveLength(0);
+
+    act(() => {
+      noteBodyStore.set("2", "reactive keyword added");
+    });
+    expect(result.current.map((n) => n.id)).toEqual(["2"]);
+
+    act(() => {
+      noteBodyStore.delete("2");
+    });
+    expect(result.current).toHaveLength(0);
   });
 });

--- a/frontend/src/hooks/useNoteFilter.ts
+++ b/frontend/src/hooks/useNoteFilter.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { Note } from "@/types";
 import { noteBodyStore } from "@/lib/sync/noteBodyStore";
 
@@ -7,6 +7,13 @@ export function useNoteFilter(
   selectedFolderId: string | null,
   searchQuery: string
 ) {
+  // Subscribe to noteBodyStore so search results refresh when note bodies change.
+  const bodyVersion = useSyncExternalStore(
+    noteBodyStore.subscribe,
+    () => noteBodyStore.version(),
+    () => 0
+  );
+
   // Fingerprint tracks only folder membership changes (id + folder_id), not snippet/updated_at.
   // This prevents folderFiltered from re-running on every auto-save that doesn't move notes.
   const folderFingerprint = useMemo(
@@ -29,13 +36,14 @@ export function useNoteFilter(
     const query = searchQuery.toLowerCase();
     return folderFiltered.filter((n) => {
       if (n.title?.toLowerCase().includes(query)) return true;
-      // Prefer noteBodyStore for latest content (n.content is stale after content-only edits).
-      // Falls back to n.content for notes not yet loaded into the store.
-      // TODO: replace with IndexedDB full-text index to cover notes not in store.
-      const body = noteBodyStore.get(n.id) || n.content;
+      // Use noteBodyStore when available (has() distinguishes "empty" from "not loaded").
+      // Fall back to n.content (snapshot value) only for notes not yet opened in this session.
+      const body = noteBodyStore.has(n.id) ? noteBodyStore.get(n.id) : (n.content ?? "");
       return body.toLowerCase().includes(query);
     });
-  }, [folderFiltered, searchQuery]);
+    // bodyVersion ensures re-evaluation when note bodies change in the store.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderFiltered, searchQuery, bodyVersion]);
 
   return filteredNotes;
 }

--- a/frontend/src/hooks/workspace/useWorkspaceState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.ts
@@ -185,10 +185,10 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   const handleSendEditRequestFromPanel = useCallback(
     (
       instruction: string,
-      _content: string,
+      content: string,
       noteId?: string,
       selectionRange?: { start: number; end: number }
-    ) => handleSendEditRequest(instruction, editorContentRef.current, noteId, selectionRange),
+    ) => handleSendEditRequest(instruction, content, noteId, selectionRange),
     [handleSendEditRequest]
   );
 

--- a/frontend/src/lib/sync/noteBodyStore.test.ts
+++ b/frontend/src/lib/sync/noteBodyStore.test.ts
@@ -43,6 +43,56 @@ describe("noteBodyStore", () => {
     });
   });
 
+  describe("has", () => {
+    it("returns false for unknown id", () => {
+      expect(noteBodyStore.has("unknown")).toBe(false);
+    });
+
+    it("returns true after set", () => {
+      noteBodyStore.set("a", "data");
+      expect(noteBodyStore.has("a")).toBe(true);
+    });
+
+    it("returns false after delete", () => {
+      noteBodyStore.set("a", "data");
+      noteBodyStore.delete("a");
+      expect(noteBodyStore.has("a")).toBe(false);
+    });
+
+    it("returns true even when value is empty string", () => {
+      noteBodyStore.set("a", "");
+      expect(noteBodyStore.has("a")).toBe(true);
+    });
+  });
+
+  describe("version", () => {
+    it("increments on set with new value", () => {
+      const before = noteBodyStore.version();
+      noteBodyStore.set("a", "v1");
+      expect(noteBodyStore.version()).toBe(before + 1);
+    });
+
+    it("does not increment when setting the same value", () => {
+      noteBodyStore.set("a", "same");
+      const before = noteBodyStore.version();
+      noteBodyStore.set("a", "same");
+      expect(noteBodyStore.version()).toBe(before);
+    });
+
+    it("increments on delete", () => {
+      noteBodyStore.set("a", "data");
+      const before = noteBodyStore.version();
+      noteBodyStore.delete("a");
+      expect(noteBodyStore.version()).toBe(before + 1);
+    });
+
+    it("does not increment when deleting nonexistent id", () => {
+      const before = noteBodyStore.version();
+      noteBodyStore.delete("nonexistent");
+      expect(noteBodyStore.version()).toBe(before);
+    });
+  });
+
   describe("delete", () => {
     it("removes a stored value", () => {
       noteBodyStore.set("a", "data");

--- a/frontend/src/lib/sync/noteBodyStore.ts
+++ b/frontend/src/lib/sync/noteBodyStore.ts
@@ -4,6 +4,7 @@ type Listener = () => void;
 
 const bodies = new Map<string, string>();
 const listeners = new Set<Listener>();
+let storeVersion = 0;
 
 function subscribe(listener: Listener): () => void {
   listeners.add(listener);
@@ -21,9 +22,14 @@ export const noteBodyStore = {
     return bodies.get(id) ?? "";
   },
 
+  has(id: string): boolean {
+    return bodies.has(id);
+  },
+
   set(id: string, content: string): void {
     if (bodies.get(id) !== content) {
       bodies.set(id, content);
+      storeVersion++;
       notify();
     }
   },
@@ -31,8 +37,13 @@ export const noteBodyStore = {
   delete(id: string): void {
     if (bodies.has(id)) {
       bodies.delete(id);
+      storeVersion++;
       notify();
     }
+  },
+
+  version(): number {
+    return storeVersion;
   },
 
   subscribe,


### PR DESCRIPTION
## 概要

CM6 移行（PR #73〜#76）完了後に報告された 3 件のバグを修正します。

## 変更内容

### Bug 1: プレビュー→エディタのスクロール同期を追加
- `EditorPanel.tsx`: `handlePreviewScroll` を追加（既存の `isScrollingRef` クールダウンを共有してフィードバックループを防止）
- `scrollRafRef` を `editorScrollRafRef` / `previewScrollRafRef` に分割
- `<EditorMarkdownPreview onPreviewScroll={handlePreviewScroll} />` に差し替え

### Bug 2: AI Edit モードが空 content でリクエストを送る問題を修正
- `useWorkspaceState.ts`: `handleSendEditRequestFromPanel` が `_content` 引数を無視して `editorContentRef.current`（CM6 初回マウント時は `""`）を使っていた
- AIChatPanel 側は `getCurrentEditorContent()` で正しい値を渡しているので、アダプタ層で透過するように修正

### Bug 3: 検索が壊れている問題を修正
- `noteBodyStore.ts`: `has(id)` と `version()` を追加。`set`/`delete` で単調増加するバージョンカウンタを管理
- `useNoteFilter.ts`: `useSyncExternalStore` で `noteBodyStore` を購読し、本文編集後に検索結果を即時更新。`||` フォールバックを `has()` 三項演算に置換し、「全削除後に古い n.content にフォールバックしてしまう」バグを解消

## テスト方法

- [ ] `make test-frontend` — 268 テスト全通過、skip 0
- [ ] 長文ノートでエディタ/プレビューを交互にスクロール → 双方向で追従しループしない
- [ ] ノートを開いた直後（未編集）で AI Edit に指示を送る → "Failed to edit content" が出ず diff が表示される
- [ ] ノート本文を全削除 → 旧キーワードで検索 → 結果に出ない
- [ ] ノートにキーワードを追加 → 検索バーが開いたまま編集 → 即座に検索結果に反映される

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当なし）