### PR TITLE
fix: eliminate cross-note noteBodyStore corruption on note switch

### DIFF
--- a/frontend/src/hooks/workspace/useWorkspaceState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import type { MobileView } from "@/components/layout";
 import { useAIChat } from "@/hooks/useAIChat";
@@ -30,10 +30,6 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   const editorContentRef = useRef("");
   const editorSelectedTextRef = useRef("");
   const selectionSubscribersRef = useRef(new Set<() => void>());
-  const selectedNoteIdRef = useRef<string | null>(null);
-  useEffect(() => {
-    selectedNoteIdRef.current = selectedNoteId;
-  }, [selectedNoteId]);
 
   const {
     folders,
@@ -101,8 +97,8 @@ export function useWorkspaceState(isAuthenticated: boolean) {
 
   const handleEditorContentChange = useCallback((content: string) => {
     editorContentRef.current = content;
-    if (selectedNoteIdRef.current) noteBodyStore.set(selectedNoteIdRef.current, content);
-  }, []);
+    if (selectedNoteId) noteBodyStore.set(selectedNoteId, content);
+  }, [selectedNoteId]);
 
   const handleEditorSelectionChange = useCallback((selectedText: string) => {
     editorSelectedTextRef.current = selectedText;
@@ -209,9 +205,8 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   );
 
   const getCurrentEditorContent = useCallback((): string => {
-    const id = selectedNoteIdRef.current;
-    return (id && noteBodyStore.get(id)) || editorContentRef.current;
-  }, []);
+    return (selectedNoteId && noteBodyStore.get(selectedNoteId)) || editorContentRef.current;
+  }, [selectedNoteId]);
 
   return {
     selectedFolderId,


### PR DESCRIPTION
## 概要

ノートを切り替えるたびに `noteBodyStore` のスロットが別ノートの内容で上書きされるレース条件を修正する。

React は子コンポーネントの `useEffect` を親の `useEffect` より先に実行する。従来のコードでは「選択中ノート id を ref に追跡する親の effect」より前に「EditorPanel のマウント effect から `onContentChange` 経由で noteBodyStore を更新する」処理が走るため、常に**直前に選択していたノートのスロット**に現在ノートの内容が書き込まれていた。

## 変更内容

- `useWorkspaceState.ts` のみ 1 ファイル変更
- `selectedNoteIdRef`（useEffect で更新していた ref）を完全に削除
- `handleEditorContentChange` と `getCurrentEditorContent` の `useCallback` deps に `selectedNoteId` state を直接追加
  - React state はレンダー時点で最新値に確定しているため、子の mount effect が実行される前に正しい id がクロージャに取り込まれる
  - EditorPanel / MarkdownEditor への変更なし → 前回 revert（IME 入力不能）のリスクを排除

## テスト方法

- [ ] `make test-frontend` — 268/268 通過済み
- [ ] 手動: ノート A（"アルファ専用"）、B（"ベータ専用"）を作成し A→B→A→B と切り替え後、"アルファ" で A だけ、"ベータ" で B だけがヒットすること
- [ ] 手動: 検索結果のノートをクリックしても結果が消えないこと
- [ ] 手動: AI Edit が cycling 後も正常に動作すること
- [ ] 手動: 日本語の連続入力が引き続き正常に動作すること

## チェックリスト

- [x] テストを追加・更新した（既存テスト 268/268 が無変更で通過）
- [ ] ドキュメントを更新した