### PR TITLE
fix: prevent AI Edit from overwriting wrong note after note switch

### DIFF
--- a/frontend/src/components/layout/EditorPanel.test.tsx
+++ b/frontend/src/components/layout/EditorPanel.test.tsx
@@ -874,4 +874,79 @@ describe('EditorPanel', () => {
     })
   })
 
+  describe('contentOverride is scoped to its source note', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('does not apply note A accepted edit to note B after key-switch remount', () => {
+      vi.useFakeTimers()
+      const onUpdateNote = vi.fn()
+
+      const noteA = { ...mockNote, id: 'A', content: 'A original' }
+      const noteB = { ...mockNote, id: 'B', content: 'B original' }
+      const overrideForA = { noteId: 'A', content: 'A edited', version: 1 }
+
+      // Render EditorPanel for note A with the override — the editor should show "A edited"
+      const { rerender } = render(
+        <EditorPanel
+          {...defaultProps}
+          key={noteA.id}
+          note={noteA}
+          contentOverride={overrideForA}
+          onUpdateNote={onUpdateNote}
+        />
+      )
+      expect(
+        (screen.getByRole('textbox', { name: /content/i }) as HTMLTextAreaElement).value
+      ).toBe('A edited')
+
+      // Simulate switching to note B while parent has not yet cleared contentOverride
+      // (worst case: the note switch arrives before the parent's setContentOverride(null))
+      rerender(
+        <EditorPanel
+          {...defaultProps}
+          key={noteB.id}
+          note={noteB}
+          contentOverride={overrideForA}  // still A's override
+          onUpdateNote={onUpdateNote}
+        />
+      )
+
+      // B's editor must show B's own content, not A's edited content
+      expect(
+        (screen.getByRole('textbox', { name: /content/i }) as HTMLTextAreaElement).value
+      ).toBe('B original')
+
+      // Auto-save must NOT write "A edited" into note B
+      act(() => { vi.advanceTimersByTime(600) })
+      expect(onUpdateNote).not.toHaveBeenCalledWith(
+        'B',
+        expect.objectContaining({ content: 'A edited' })
+      )
+    })
+
+    it('applies contentOverride only when noteId matches the current note', () => {
+      const noteB = { ...mockNote, id: 'B', content: 'B original' }
+      const overrideForA = { noteId: 'A', content: 'A edited', version: 1 }
+      const overrideForB = { noteId: 'B', content: 'B edited', version: 2 }
+
+      const { rerender } = render(
+        <EditorPanel {...defaultProps} note={noteB} contentOverride={overrideForA} />
+      )
+      // Override is for A, not B — B shows its own content
+      expect(
+        (screen.getByRole('textbox', { name: /content/i }) as HTMLTextAreaElement).value
+      ).toBe('B original')
+
+      // Now supply override for B — it should be applied
+      rerender(
+        <EditorPanel {...defaultProps} note={noteB} contentOverride={overrideForB} />
+      )
+      expect(
+        (screen.getByRole('textbox', { name: /content/i }) as HTMLTextAreaElement).value
+      ).toBe('B edited')
+    })
+  })
+
 })

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -53,7 +53,7 @@ interface EditorPanelProps {
   tokenUsage?: TokenUsageRead | null;
   onContentChange?: (content: string) => void;
   onSelectionChange?: (selectedText: string) => void;
-  contentOverride?: { content: string; version: number } | null;
+  contentOverride?: { noteId: string; content: string; version: number } | null;
   pendingEditProposal?: EditProposal | null;
   onAcceptEdit?: () => void;
   onRejectEdit?: () => void;
@@ -219,14 +219,18 @@ export function EditorPanel({
     onContentChange?.(content);
   }, [note?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Apply content override from AI edit accept
+  // Apply content override from AI edit accept — only for the note it was created for
   const contentOverrideVersionRef = useRef<number>(-1);
   useEffect(() => {
-    if (contentOverride && contentOverride.version !== contentOverrideVersionRef.current) {
+    if (
+      contentOverride &&
+      contentOverride.noteId === note?.id &&
+      contentOverride.version !== contentOverrideVersionRef.current
+    ) {
       contentOverrideVersionRef.current = contentOverride.version;
       editorRef.current?.setValue(contentOverride.content);
     }
-  }, [contentOverride]);
+  }, [contentOverride, note?.id]);
 
   // Trigger server sync on unmount or when switching notes
   // Store note.id in a ref so cleanup function has access to the current value

--- a/frontend/src/hooks/workspace/useWorkspaceState.test.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.test.ts
@@ -171,9 +171,68 @@ describe("useWorkspaceState", () => {
       content: "Edited content",
     });
     expect(result.current.contentOverride).toEqual({
+      noteId: "note-1",
       content: "Edited content",
       version: 1,
     });
+  });
+
+  it("scopes contentOverride to the note it was created for and clears it on note switch", () => {
+    const handleAcceptEdit = vi.fn().mockReturnValue("Edited content");
+
+    useNotesMock.mockReturnValue({
+      syncStatus: { local: "saved", remote: "synced", isSaving: false },
+      handleCreateNote: vi.fn(),
+      handleUpdateNote: vi.fn(),
+      handleDeleteNote: vi.fn(),
+      triggerServerSync: vi.fn(),
+      savedHashes: {},
+    });
+    useAIChatMock.mockReturnValue({
+      chatMessages: [
+        {
+          role: "assistant",
+          content: "",
+          editProposal: {
+            originalContent: "Original content",
+            editedContent: "Edited content",
+            status: "pending",
+          },
+        },
+      ],
+      isAILoading: false,
+      isEditMode: true,
+      setIsEditMode: vi.fn(),
+      handleSummarize: vi.fn(),
+      handleSendMessage: vi.fn(),
+      handleSendEditRequest: vi.fn(),
+      handleAcceptEdit,
+      handleRejectEdit: vi.fn(),
+      clearChat: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useWorkspaceState(true));
+
+    act(() => {
+      result.current.handleSelectNote("note-1");
+    });
+    act(() => {
+      result.current.handleAcceptEditAndApply(0);
+    });
+
+    // contentOverride is tagged with the source note id
+    expect(result.current.contentOverride).toEqual({
+      noteId: "note-1",
+      content: "Edited content",
+      version: 1,
+    });
+
+    // Switching to a different note clears contentOverride
+    act(() => {
+      result.current.handleSelectNote("note-2");
+    });
+
+    expect(result.current.contentOverride).toBeNull();
   });
 
   it("tracks editor selected text via handleEditorSelectionChange", () => {

--- a/frontend/src/hooks/workspace/useWorkspaceState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.ts
@@ -23,6 +23,7 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [mobileView, setMobileView] = useState<MobileView>("folders");
   const [contentOverride, setContentOverride] = useState<{
+    noteId: string;
     content: string;
     version: number;
   } | null>(null);
@@ -60,6 +61,7 @@ export function useWorkspaceState(isAuthenticated: boolean) {
 
   const handleSelectNote = useCallback((id: string | null) => {
     setSelectedNoteId(id);
+    setContentOverride(null);
     if (id) {
       setMobileView("editor");
     }
@@ -118,6 +120,7 @@ export function useWorkspaceState(isAuthenticated: boolean) {
       const editedContent = handleAcceptEdit(messageIndex);
       if (editedContent && selectedNoteId) {
         setContentOverride((prev) => ({
+          noteId: selectedNoteId,
           content: editedContent,
           version: (prev?.version ?? 0) + 1,
         }));


### PR DESCRIPTION
## 概要

AI Edit で変更を accept した後に別のノートに切り替えると、切替先のノートが accept したノートの内容で上書き保存される実データ汚染バグを修正する。auto-save (500ms) と triggerServerSync を経由してバックエンドに永続化されるため、transient な UI バグではなく**本番データの破壊**につながっていた。

## 変更内容

- `contentOverride` の型に `noteId: string` フィールドを追加し、どのノート向けの override かを明示
- `handleAcceptEditAndApply` で `setContentOverride` に `noteId: selectedNoteId` を付与
- `handleSelectNote` でノート切替時に `setContentOverride(null)` をクリア（防御の二段目）
- `EditorPanel.tsx` の contentOverride 適用 effect に `contentOverride.noteId === note?.id` のガードを追加 — noteId が一致した場合のみ `setValue` を呼ぶ
- `useWorkspaceState.test.ts` の既存アサーションを新しい型（`noteId` 含む）に更新
- `useWorkspaceState.test.ts` に回帰テスト追加（accept 後のノート切替で `contentOverride` が null になること）
- `EditorPanel.test.tsx` に回帰テスト 2 件追加（key-switch remount 後に A の override が B に適用されないこと、noteId 一致時のみ適用されること）

## テスト方法

- [x] `make test-frontend` — 271/271 通過
- [ ] dev 手動: ノート A で AI Edit を accept → B、C と切替 → 各ノートが自分の正しい内容を表示すること
- [ ] dev 手動: 数秒後にリロードしてもノート B/C の内容が改ざんされていないこと
- [ ] 通常の AI Edit accept がノート A 自身には正しく反映されること

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）