### PR TITLE
fix: エディタのマークダウン記号の色を見やすくする (#84)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright-cli
+.playwright/

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
@@ -70,8 +70,14 @@ describe("buildBlockquoteDecorations — basic", () => {
     const state = makeState(doc, 5); // cursor inside "quoted text" on blockquote line
     const decs = buildBlockquoteDecorations(state, makeFakeView(state));
     const replaces = getReplaceDecs(decs);
-    // No replace decoration should start at position 0
     expect(replaces.some((d) => d.from === 0)).toBe(false);
+  });
+
+  it("emits cm-md-marker on QuoteMark when cursor IS on blockquote line", () => {
+    const state = makeState(doc, 5); // cursor inside "quoted text"
+    const decs = buildBlockquoteDecorations(state, makeFakeView(state));
+    const markers = getLineDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 0)).toBe(true);
   });
 });
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
@@ -126,11 +126,25 @@ describe("buildCodeBlockDecorations — fence-line hiding", () => {
     expect(replaceDecs.some((d) => d.from === openFenceFrom)).toBe(false);
   });
 
+  it("emits cm-md-marker on opening fence line when cursor is on that line", () => {
+    const state = makeState(doc, 8); // cursor on "```js" line
+    const decs = buildCodeBlockDecorations(state, makeFakeView(state));
+    const markers = getLineDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === openFenceFrom && d.to === openFenceTo)).toBe(true);
+  });
+
   it("does NOT hide closing fence when cursor is on that line", () => {
     const state = makeState(doc, closeFenceFrom); // cursor on closing "```" line
     const decs = buildCodeBlockDecorations(state, makeFakeView(state));
     const replaceDecs = getReplaceDecs(decs);
     expect(replaceDecs.some((d) => d.from === closeFenceFrom)).toBe(false);
+  });
+
+  it("emits cm-md-marker on closing fence line when cursor is on that line", () => {
+    const state = makeState(doc, closeFenceFrom); // cursor on closing "```" line
+    const decs = buildCodeBlockDecorations(state, makeFakeView(state));
+    const markers = getLineDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === closeFenceFrom && d.to === closeFenceTo)).toBe(true);
   });
 
   it("still emits cm-md-fenced line decorations for all lines even when cursor is inside", () => {

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
@@ -74,6 +74,13 @@ describe("buildHeadingDecorations — ATXHeading1", () => {
     // Should NOT have a replace at [0, 1] (the "#" HeaderMark)
     expect(replaces.some((d) => d.from === 0 && d.to === 1)).toBe(false);
   });
+
+  it("emits cm-md-marker decoration on HeaderMark when cursor IS on heading line", () => {
+    const state = makeState(doc, 4); // cursor inside "Hello" on heading line
+    const decs = buildHeadingDecorations(state, makeFakeView(state));
+    const markers = getLineDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 0 && d.to === 1)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
@@ -165,6 +165,46 @@ describe("buildInlineDecorations — InlineCode", () => {
 });
 
 // ---------------------------------------------------------------
+// cm-md-marker — delimiter color when cursor is inside
+// ---------------------------------------------------------------
+describe("buildInlineDecorations — cm-md-marker on delimiters", () => {
+  it("emits cm-md-marker on ** markers when cursor is inside StrongEmphasis", () => {
+    const doc = "hello **world** end";
+    const state = makeState(doc, 10); // cursor inside "world"
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 6 && d.to === 8)).toBe(true);
+    expect(markers.some((d) => d.from === 13 && d.to === 15)).toBe(true);
+  });
+
+  it("emits cm-md-marker on * markers when cursor is inside Emphasis", () => {
+    const doc = "hello *italic* end";
+    const state = makeState(doc, 9); // cursor inside "italic"
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 6 && d.to === 7)).toBe(true);
+    expect(markers.some((d) => d.from === 13 && d.to === 14)).toBe(true);
+  });
+
+  it("emits cm-md-marker on backtick markers when cursor is inside InlineCode", () => {
+    const doc = "hello `code` end";
+    const state = makeState(doc, 8); // cursor inside "code"
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 6 && d.to === 7)).toBe(true);
+    expect(markers.some((d) => d.from === 11 && d.to === 12)).toBe(true);
+  });
+
+  it("does NOT emit cm-md-marker when cursor is outside the range", () => {
+    const doc = "hello **world** end";
+    const state = makeState(doc, 0); // cursor outside
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------
 // Multiple inline elements on the same line
 // ---------------------------------------------------------------
 describe("buildInlineDecorations — multiple elements", () => {

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
@@ -65,15 +65,18 @@ describe("buildListDecorations — BulletList", () => {
   });
 
   it("does NOT emit replace on line 1 mark when cursor is on line 1, still emits on line 2", () => {
-    // cursor on line 1 (pos 5 = inside "item one")
-    // Note: this uses the same extended doc
     const state = makeState(doc, 5);
     const decs = buildListDecorations(state, makeFakeView(state));
     const widgets = getWidgetDecs(decs);
-    // Line 1 mark should NOT be replaced
     expect(widgets.some((d) => d.from === 0 && d.to === 1)).toBe(false);
-    // Line 2 mark should still be replaced
     expect(widgets.some((d) => d.from === 11 && d.to === 12)).toBe(true);
+  });
+
+  it("emits cm-md-marker on ListMark when cursor is on the same line", () => {
+    const state = makeState(doc, 5); // cursor inside "item one"
+    const decs = buildListDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 0 && d.to === 1)).toBe(true);
   });
 });
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
@@ -1,6 +1,6 @@
 /**
  * buildListDecorations のユニットテスト。
- * BulletList の ListMark 置換と OrderedList の cm-md-ol-mark マーク付与を検証する。
+ * BulletList / OrderedList の ListMark ウィジェット置換とマーカー色付与を検証する。
  */
 import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
@@ -84,32 +84,33 @@ describe("buildListDecorations — BulletList", () => {
 // OrderedList
 // ---------------------------------------------------------------
 describe("buildListDecorations — OrderedList", () => {
-  const doc = "1. first\n2. second";
+  const doc = "1. first\n2. second\n\nsome text";
   // line 1: "1. first"   from=0   to=8   ListMark at [0, 2]
   // line 2: "2. second"  from=9  to=18  ListMark at [9, 11]
+  // line 4: "some text"  from=20 to=29
 
-  it("always emits cm-md-ol-mark on both ListMarks (cursor-independent)", () => {
-    // cursor on line 1
-    const stateOnLine1 = makeState(doc, 4);
-    const decs1 = buildListDecorations(stateOnLine1, makeFakeView(stateOnLine1));
-    const marks1 = getMarkDecs(decs1, "cm-md-ol-mark");
-    expect(marks1.some((d) => d.from === 0 && d.to === 2)).toBe(true);
-    expect(marks1.some((d) => d.from === 9 && d.to === 11)).toBe(true);
-  });
-
-  it("cursor on line 2 still emits ol-mark on both lines", () => {
-    const state = makeState(doc, 12);
-    const decs = buildListDecorations(state, makeFakeView(state));
-    const marks = getMarkDecs(decs, "cm-md-ol-mark");
-    expect(marks.some((d) => d.from === 0 && d.to === 2)).toBe(true);
-    expect(marks.some((d) => d.from === 9 && d.to === 11)).toBe(true);
-  });
-
-  it("emits no widget replace decorations for ordered lists", () => {
-    const state = makeState(doc, doc.length);
+  it("emits widget replace on both ListMarks when cursor is elsewhere", () => {
+    const state = makeState(doc, 22); // cursor on "some text"
     const decs = buildListDecorations(state, makeFakeView(state));
     const widgets = getWidgetDecs(decs);
-    expect(widgets.length).toBe(0);
+    expect(widgets.some((d) => d.from === 0 && d.to === 2)).toBe(true);
+    expect(widgets.some((d) => d.from === 9 && d.to === 11)).toBe(true);
+  });
+
+  it("does NOT emit widget on line 1 mark when cursor is on line 1", () => {
+    const state = makeState(doc, 4); // cursor inside "first"
+    const decs = buildListDecorations(state, makeFakeView(state));
+    const widgets = getWidgetDecs(decs);
+    expect(widgets.some((d) => d.from === 0 && d.to === 2)).toBe(false);
+    // line 2 still gets widget
+    expect(widgets.some((d) => d.from === 9 && d.to === 11)).toBe(true);
+  });
+
+  it("emits cm-md-marker on line 1 ListMark when cursor is on line 1", () => {
+    const state = makeState(doc, 4);
+    const decs = buildListDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 0 && d.to === 2)).toBe(true);
   });
 });
 

--- a/frontend/src/components/editor/extensions/livePreview/blockquote.ts
+++ b/frontend/src/components/editor/extensions/livePreview/blockquote.ts
@@ -47,10 +47,15 @@ export function buildBlockquoteDecorations(
         let cursor = node.node.firstChild;
         while (cursor) {
           if (cursor.name === "QuoteMark") {
-            // カーソルが QuoteMark と同じ行にない場合は非表示
             if (!isCursorOnLine(state, cursor.from)) {
+              // カーソルが同じ行にない場合は非表示
               decorations.push(
                 Decoration.replace({}).range(cursor.from, cursor.to)
+              );
+            } else {
+              // カーソルが同じ行にある場合はマーカー色で表示
+              decorations.push(
+                Decoration.mark({ class: "cm-md-marker" }).range(cursor.from, cursor.to)
               );
             }
           }

--- a/frontend/src/components/editor/extensions/livePreview/codeBlocks.ts
+++ b/frontend/src/components/editor/extensions/livePreview/codeBlocks.ts
@@ -55,10 +55,18 @@ export function buildCodeBlockDecorations(
             decorations.push(
               Decoration.replace({}).range(openLine.from, openLine.to)
             );
+          } else {
+            decorations.push(
+              Decoration.mark({ class: "cm-md-marker" }).range(openLine.from, openLine.to)
+            );
           }
           if (!isCursorOnLine(state, closeLine.from)) {
             decorations.push(
               Decoration.replace({}).range(closeLine.from, closeLine.to)
+            );
+          } else {
+            decorations.push(
+              Decoration.mark({ class: "cm-md-marker" }).range(closeLine.from, closeLine.to)
             );
           }
         }

--- a/frontend/src/components/editor/extensions/livePreview/headings.ts
+++ b/frontend/src/components/editor/extensions/livePreview/headings.ts
@@ -71,10 +71,15 @@ export function buildHeadingDecorations(
           let cursor = node.node.firstChild;
           while (cursor) {
             if (cursor.name === "HeaderMark") {
-              // カーソルが HeaderMark と同じ行にない場合は非表示
               if (!isCursorOnLine(state, cursor.from)) {
+                // カーソルが同じ行にない場合は非表示
                 decorations.push(
                   Decoration.replace({}).range(cursor.from, cursor.to)
+                );
+              } else {
+                // カーソルが同じ行にある場合はマーカー色で表示
+                decorations.push(
+                  Decoration.mark({ class: "cm-md-marker" }).range(cursor.from, cursor.to)
                 );
               }
               break;

--- a/frontend/src/components/editor/extensions/livePreview/inlineStyles.ts
+++ b/frontend/src/components/editor/extensions/livePreview/inlineStyles.ts
@@ -37,45 +37,35 @@ export function buildInlineDecorations(
             Decoration.mark({ class: "cm-md-strong" }).range(nFrom, nTo)
           );
           if (!isCursorInRange(state, nFrom, nTo)) {
-            // Opening marker (**  or __)
-            decorations.push(
-              Decoration.replace({}).range(nFrom, nFrom + 2)
-            );
-            // Closing marker
-            decorations.push(
-              Decoration.replace({}).range(nTo - 2, nTo)
-            );
+            decorations.push(Decoration.replace({}).range(nFrom, nFrom + 2));
+            decorations.push(Decoration.replace({}).range(nTo - 2, nTo));
+          } else {
+            decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nFrom, nFrom + 2));
+            decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nTo - 2, nTo));
           }
         } else if (name === "Emphasis") {
           decorations.push(
             Decoration.mark({ class: "cm-md-em" }).range(nFrom, nTo)
           );
           if (!isCursorInRange(state, nFrom, nTo)) {
-            // Opening marker (* or _)
-            decorations.push(
-              Decoration.replace({}).range(nFrom, nFrom + 1)
-            );
-            // Closing marker
-            decorations.push(
-              Decoration.replace({}).range(nTo - 1, nTo)
-            );
+            decorations.push(Decoration.replace({}).range(nFrom, nFrom + 1));
+            decorations.push(Decoration.replace({}).range(nTo - 1, nTo));
+          } else {
+            decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nFrom, nFrom + 1));
+            decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nTo - 1, nTo));
           }
         } else if (name === "Strikethrough") {
           decorations.push(
             Decoration.mark({ class: "cm-md-strikethrough" }).range(nFrom, nTo)
           );
           if (!isCursorInRange(state, nFrom, nTo)) {
-            // Opening marker (~~)
-            decorations.push(
-              Decoration.replace({}).range(nFrom, nFrom + 2)
-            );
-            // Closing marker
-            decorations.push(
-              Decoration.replace({}).range(nTo - 2, nTo)
-            );
+            decorations.push(Decoration.replace({}).range(nFrom, nFrom + 2));
+            decorations.push(Decoration.replace({}).range(nTo - 2, nTo));
+          } else {
+            decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nFrom, nFrom + 2));
+            decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nTo - 2, nTo));
           }
         } else if (name === "InlineCode") {
-          // Determine backtick length from actual text
           const text = state.sliceDoc(nFrom, nTo);
           let tickLen = 0;
           while (tickLen < text.length && text[tickLen] === "`") {
@@ -92,12 +82,13 @@ export function buildInlineDecorations(
           }
           if (!isCursorInRange(state, nFrom, nTo)) {
             if (tickLen > 0) {
-              decorations.push(
-                Decoration.replace({}).range(nFrom, contentFrom)
-              );
-              decorations.push(
-                Decoration.replace({}).range(contentTo, nTo)
-              );
+              decorations.push(Decoration.replace({}).range(nFrom, contentFrom));
+              decorations.push(Decoration.replace({}).range(contentTo, nTo));
+            }
+          } else {
+            if (tickLen > 0) {
+              decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(nFrom, contentFrom));
+              decorations.push(Decoration.mark({ class: "cm-md-marker" }).range(contentTo, nTo));
             }
           }
         }

--- a/frontend/src/components/editor/extensions/livePreview/lists.ts
+++ b/frontend/src/components/editor/extensions/livePreview/lists.ts
@@ -3,7 +3,9 @@
  * CM6 デコレーションを生成する。
  *
  * BulletList: カーソルが ListMark と同じ行にない場合、ListMark を BulletWidget（•）で置換する。
- * OrderedList: 常に ListMark に cm-md-ol-mark クラスを付与する（番号は常に表示）。
+ * OrderedList: カーソルが同じ行にない場合は OrderedListMarkWidget でウィジェット置換する。
+ *              ウィジェットはシンタックスハイライトの影響を受けないため通常テキスト色で表示される。
+ *              カーソルが同じ行にある場合は cm-md-marker クラスを付与する。
  *
  * タスクリストマーカー（TaskMarker）はここでは扱わない。taskList.ts が担当する。
  *
@@ -30,6 +32,36 @@ class BulletWidget extends WidgetType {
 
   eq(other: BulletWidget): boolean {
     return other instanceof BulletWidget;
+  }
+
+  get estimatedHeight(): number {
+    return -1;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+/**
+ * 番号付きリストマーカー（1.、2. など）をウィジェットで置換するクラス。
+ * ウィジェットとして描画することでシンタックスハイライトの色の影響を受けず、
+ * 通常テキスト色で表示される。
+ */
+class OrderedListMarkWidget extends WidgetType {
+  constructor(private text: string) {
+    super();
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "cm-md-ol-mark";
+    span.textContent = this.text;
+    return span;
+  }
+
+  eq(other: OrderedListMarkWidget): boolean {
+    return other instanceof OrderedListMarkWidget && other.text === this.text;
   }
 
   get estimatedHeight(): number {
@@ -88,7 +120,7 @@ export function buildListDecorations(
           return false; // 子ノードの重複走査を避ける
         }
 
-        // OrderedList: ListItem の ListMark に cm-md-ol-mark クラスを付与（常時）
+        // OrderedList: カーソルが同じ行にない場合はウィジェット置換、ある場合はマーカー色で表示
         if (node.name === "OrderedList") {
           let item = node.node.firstChild;
           while (item) {
@@ -96,12 +128,20 @@ export function buildListDecorations(
               let child = item.firstChild;
               while (child) {
                 if (child.name === "ListMark") {
-                  decorations.push(
-                    Decoration.mark({ class: "cm-md-ol-mark" }).range(
-                      child.from,
-                      child.to
-                    )
-                  );
+                  if (!isCursorOnLine(state, child.from)) {
+                    // ウィジェット置換でシンタックスハイライトの影響を受けずに通常色で表示
+                    const markText = state.sliceDoc(child.from, child.to);
+                    decorations.push(
+                      Decoration.replace({
+                        widget: new OrderedListMarkWidget(markText),
+                      }).range(child.from, child.to)
+                    );
+                  } else {
+                    // カーソルが同じ行にある場合はマーカー色で表示
+                    decorations.push(
+                      Decoration.mark({ class: "cm-md-marker" }).range(child.from, child.to)
+                    );
+                  }
                   break;
                 }
                 child = child.nextSibling;

--- a/frontend/src/components/editor/extensions/livePreview/lists.ts
+++ b/frontend/src/components/editor/extensions/livePreview/lists.ts
@@ -65,12 +65,17 @@ export function buildListDecorations(
               let child = item.firstChild;
               while (child) {
                 if (child.name === "ListMark") {
-                  // カーソルが同じ行にない場合のみ置換
                   if (!isCursorOnLine(state, child.from)) {
+                    // カーソルが同じ行にない場合のみ bullet ウィジェットで置換
                     decorations.push(
                       Decoration.replace({
                         widget: new BulletWidget(),
                       }).range(child.from, child.to)
+                    );
+                  } else {
+                    // カーソルが同じ行にある場合はマーカー色で表示
+                    decorations.push(
+                      Decoration.mark({ class: "cm-md-marker" }).range(child.from, child.to)
                     );
                   }
                   break;

--- a/frontend/src/components/editor/extensions/livePreview/theme.ts
+++ b/frontend/src/components/editor/extensions/livePreview/theme.ts
@@ -81,7 +81,7 @@ export const livePreviewBaseTheme = EditorView.baseTheme({
     color: "var(--muted-foreground, #6b7280)",
   },
 
-  // 番号付きリストマーカー（色指定なし: デフォルトのテキスト色を継承）
+  // 番号付きリストマーカーウィジェット（色指定なし: 親から通常テキスト色を継承）
   ".cm-md-ol-mark": {},
 
   // タスクリストチェックボックス

--- a/frontend/src/components/editor/extensions/livePreview/theme.ts
+++ b/frontend/src/components/editor/extensions/livePreview/theme.ts
@@ -26,10 +26,9 @@ export const livePreviewBaseTheme = EditorView.baseTheme({
     borderRadius: "3px",
     padding: "0 3px",
   },
-  // カーソルが同一行にある場合のフォールバック: マーカーを薄く小さく表示する
+  // カーソルが同一行にある場合: マーカーを色付きで表示する
   ".cm-md-marker": {
-    opacity: "0.3",
-    fontSize: "0.85em",
+    color: "var(--muted-foreground, #6b7280)",
   },
 
   // 見出し (ATX: #〜######)
@@ -79,12 +78,12 @@ export const livePreviewBaseTheme = EditorView.baseTheme({
   ".cm-md-bullet": {
     display: "inline-block",
     width: "1em",
-    color: "#888",
+    color: "var(--muted-foreground, #6b7280)",
   },
 
   // 番号付きリストマーカー
   ".cm-md-ol-mark": {
-    color: "#888",
+    color: "var(--muted-foreground, #6b7280)",
   },
 
   // タスクリストチェックボックス

--- a/frontend/src/components/editor/extensions/livePreview/theme.ts
+++ b/frontend/src/components/editor/extensions/livePreview/theme.ts
@@ -81,10 +81,8 @@ export const livePreviewBaseTheme = EditorView.baseTheme({
     color: "var(--muted-foreground, #6b7280)",
   },
 
-  // 番号付きリストマーカー
-  ".cm-md-ol-mark": {
-    color: "var(--muted-foreground, #6b7280)",
-  },
+  // 番号付きリストマーカー（色指定なし: デフォルトのテキスト色を継承）
+  ".cm-md-ol-mark": {},
 
   // タスクリストチェックボックス
   ".cm-md-task-checkbox": {


### PR DESCRIPTION
## Summary

- カーソルが同じ行/範囲にあるとき、`#`・`**`・`*`・`` ` ``・`~~`・`-`・`>` などのマークダウン記号に `cm-md-marker` クラスを付与し、`muted-foreground` 色で視認しやすく表示
- 番号付きリストマーカー（`1.` `2.` など）を `Decoration.mark()` からウィジェット置換方式（`OrderedListMarkWidget`）に変更し、シンタックスハイライトによるグレー化を解消
- 各デコレーション関数のテストに `cm-md-marker` の検証ケースを追加

## 変更ファイル

- `theme.ts` — `.cm-md-marker` を opacity ベースから `muted-foreground` 色に変更
- `headings.ts` — `HeaderMark` にカーソル行でマーカー色を適用
- `inlineStyles.ts` — `**`/`*`/`~~`/バッククォートの区切り文字にカーソル内でマーカー色を適用
- `blockquote.ts` — `QuoteMark` にカーソル行でマーカー色を適用
- `codeBlocks.ts` — フェンス行にカーソル行でマーカー色を適用
- `lists.ts` — BulletList と同様に OrderedList もウィジェット置換方式に変更

## Test plan

- [ ] 各マークダウン要素の行にカーソルを移動し、記号が `muted-foreground` 色で表示されることを確認
- [ ] カーソルが離れた行の番号（`1.` `2.`）が通常テキスト色（白）で表示されることを確認
- [ ] ユニットテスト 90件 全通過

Closes #84

---
_Generated by [Claude Code](https://claude.ai/code/session_011dTMiczoxkfkzAVFzxZ9Sd)_