### PR TITLE
fix: Tab/Shift+Tab で番号付きリストをインデントするとき番号をレベルごとに振り直す

### DIFF
--- a/frontend/src/components/editor/extensions/__tests__/markdownIndent.test.ts
+++ b/frontend/src/components/editor/extensions/__tests__/markdownIndent.test.ts
@@ -52,6 +52,21 @@ describe("markdownIndent — Tab", () => {
     view = makeView("hello", 0);
     expect(tabRun(view)).toBe(true);
   });
+
+  it("resets ordered list number to 1 when no items at new indent level", () => {
+    view = makeView("2. item", 7); // cursor at end
+    tabRun(view);
+    expect(view.state.doc.toString()).toBe("  1. item");
+    expect(view.state.selection.main.from).toBe(9); // 7 + (4 - 2)
+  });
+
+  it("continues ordered list number from previous item at same indent level", () => {
+    const doc = "  1. nested\n2. other";
+    view = makeView(doc, doc.length); // cursor at end of "2. other"
+    tabRun(view);
+    expect(view.state.doc.toString()).toBe("  1. nested\n  2. other");
+    expect(view.state.selection.main.from).toBe(22); // 20 + 2
+  });
 });
 
 describe("markdownIndent — Shift+Tab", () => {
@@ -90,5 +105,19 @@ describe("markdownIndent — Shift+Tab", () => {
   it("returns true to consume the event", () => {
     view = makeView("  hello", 0);
     expect(shiftTabRun(view)).toBe(true);
+  });
+
+  it("corrects ordered list number at parent level on unindent", () => {
+    const doc = "1. parent\n  1. nested";
+    view = makeView(doc, doc.length); // cursor at end of "  1. nested"
+    shiftTabRun(view);
+    expect(view.state.doc.toString()).toBe("1. parent\n2. nested");
+    expect(view.state.selection.main.from).toBe(19); // 21 + (2 - 4)
+  });
+
+  it("is a no-op for top-level ordered list item", () => {
+    view = makeView("1. item", 7);
+    expect(shiftTabRun(view)).toBe(true);
+    expect(view.state.doc.toString()).toBe("1. item");
   });
 });

--- a/frontend/src/components/editor/extensions/markdownIndent.ts
+++ b/frontend/src/components/editor/extensions/markdownIndent.ts
@@ -9,13 +9,34 @@
  *
  * 呼び出し関係: MarkdownEditor.tsx の extensions 配列で使用される。
  */
-import { EditorSelection } from "@codemirror/state";
+import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView, type KeyBinding } from "@codemirror/view";
 
 const INDENT = "  ";
 const LIST_LINE_RE = /^(\s*)([-*+]|\d+\.)\s/;
 const INDENTED_LINE_RE = /^\s+/;
 const LEADING_INDENT_RE = /^(\s{1,2})/;
+const OL_MARK_RE = /^(\s*)(\d+)(\.)\s/;
+
+/**
+ * targetIndent のインデントを持つ ordered list アイテムのうち、
+ * currentLineNum より前の最後のものを探し、その番号 +1 を返す。
+ * 見つからなければ 1 を返す。
+ */
+function getNextOrderedNumber(
+  state: EditorState,
+  currentLineNum: number,
+  targetIndent: string
+): number {
+  for (let n = currentLineNum - 1; n >= 1; n--) {
+    const line = state.doc.line(n);
+    const m = line.text.match(OL_MARK_RE);
+    if (m && m[1] === targetIndent) {
+      return parseInt(m[2], 10) + 1;
+    }
+  }
+  return 1;
+}
 
 /**
  * Tab キーに対応するインデントコマンド。
@@ -51,6 +72,24 @@ function indentCommand(view: EditorView): boolean {
 
   // Single line
   const line = state.doc.lineAt(from);
+
+  // Ordered list: renumber based on the new (deeper) indent level
+  const olMatch = line.text.match(OL_MARK_RE);
+  if (olMatch) {
+    const currentIndent = olMatch[1];
+    const dot = olMatch[3];
+    const newIndent = currentIndent + INDENT;
+    const newNum = getNextOrderedNumber(state, line.number, newIndent);
+    const oldPrefix = currentIndent + olMatch[2] + dot;
+    const newPrefix = newIndent + String(newNum) + dot;
+    view.dispatch(state.update({
+      changes: { from: line.from, to: line.from + oldPrefix.length, insert: newPrefix },
+      selection: EditorSelection.cursor(from + (newPrefix.length - oldPrefix.length)),
+      userEvent: "input.indent",
+    }));
+    return true;
+  }
+
   const isListLine = LIST_LINE_RE.test(line.text);
   const isIndentedLine = INDENTED_LINE_RE.test(line.text);
 
@@ -112,8 +151,30 @@ function unindentCommand(view: EditorView): boolean {
     }
   }
 
-  // Single line: remove 1–2 leading spaces
+  // Single line
   const line = state.doc.lineAt(from);
+
+  // Ordered list: renumber based on the new (shallower) indent level
+  const olMatch = line.text.match(OL_MARK_RE);
+  if (olMatch) {
+    const currentIndent = olMatch[1];
+    if (currentIndent.length === 0) return true; // already at top level
+    const indentMatch = currentIndent.match(LEADING_INDENT_RE);
+    if (!indentMatch) return true;
+    const removedSpaces = indentMatch[1].length;
+    const newIndent = currentIndent.slice(removedSpaces);
+    const dot = olMatch[3];
+    const newNum = getNextOrderedNumber(state, line.number, newIndent);
+    const oldPrefix = currentIndent + olMatch[2] + dot;
+    const newPrefix = newIndent + String(newNum) + dot;
+    view.dispatch(state.update({
+      changes: { from: line.from, to: line.from + oldPrefix.length, insert: newPrefix },
+      selection: EditorSelection.cursor(Math.max(line.from, from + (newPrefix.length - oldPrefix.length))),
+      userEvent: "delete.dedent",
+    }));
+    return true;
+  }
+
   const m = line.text.match(LEADING_INDENT_RE);
   if (!m) return true;
   const len = m[1].length;


### PR DESCRIPTION
## Summary

Closes #85

- `markdownIndent.ts` に `getNextOrderedNumber()` ヘルパーを追加。Tab/Shift+Tab で番号付きリスト行のインデントレベルを変更した際、移動先レベルで直前に存在するアイテムの番号 +1（存在しなければ 1）を自動計算して番号を振り直す
- `indentCommand`（Tab）: 番号付きリスト行を深いレベルへ移動するとき、新インデントレベルの番号に更新
- `unindentCommand`（Shift+Tab）: 番号付きリスト行を浅いレベルへ戻すとき、新インデントレベルの番号に更新

## Before / After

**修正前 (バグ):**
```
1. First
  2.   ← Tab 後も連番のまま（本来は 1. であるべき）
```

**修正後:**
```
1. First
  1.   ← ネストの最初は 1. にリセット ✅
```

## Test plan

- [x] 単体テスト 14/14 PASS（新規テスト4件含む）
- [x] 全フロントエンドテスト 371/371 PASS
- [x] Playwright による修正ロジックの動作確認（5ケース全 PASS）
  - Tab: ネスト最初のアイテムは 1. にリセット
  - Tab: 既存ネストアイテムがある場合はその次番号
  - Shift+Tab: 親レベルの次番号に更新
  - Shift+Tab: トップレベルは no-op
  - 3段ネストの正しい番号計算

https://claude.ai/code/session_01SepKRRXWYdqxGi4LjNBXR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SepKRRXWYdqxGi4LjNBXR9)_