### PR TITLE
fix: prevent JWT internal error details from leaking to clients (High)

### DIFF
--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -58,10 +58,11 @@ async def _verify_bearer_token(token: str) -> dict:
             "security.auth.failed",
             outcome="failure",
             reason=exc.__class__.__name__,
+            exc_info=exc,
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(exc),
+            detail="Invalid or expired token",
             headers={"WWW-Authenticate": "Bearer"},
         )
 


### PR DESCRIPTION
## Summary

- JWT verification failures were returning the raw library exception message in HTTP 401 `detail` (e.g. `"Signature has expired"`, `"Unable to find signing key"`)
- These messages reveal information about the JWT validation pipeline, aiding token-forgery attacks
- Fix: replace verbatim exception string with generic message; preserve full exception in server-side logs

## Changes

`backend/app/auth/dependencies.py`:
- `detail=str(exc)` → `detail="Invalid or expired token"`
- Added `exc_info=exc` to `log_event()` so stack traces remain visible in CloudWatch

## Test plan
- [ ] Invalid token returns `{"detail": "Invalid or expired token"}` (not library internals)
- [ ] Server logs still contain full `JWTError` stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)