### PR TITLE
fix: prevent "Bearer null" being sent when token is null in exportNotes (High)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -312,10 +312,12 @@ class ApiClient {
   }
 
   async exportNotes(): Promise<Blob> {
+    const headers: Record<string, string> = {};
+    if (this.token) {
+      headers["Authorization"] = `Bearer ${this.token}`;
+    }
     const response = await fetch(`${API_BASE_URL}/api/notes/export/all`, {
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-      },
+      headers,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- `exportNotes()` was constructing `Authorization: Bearer null` literally when `this.token` is null
- Other methods (`request()`, `uploadImage()`) correctly guard with `if (this.token)` before setting the header
- This inconsistency caused a malformed Authorization header on unauthenticated export requests

## Changes

`frontend/src/lib/api.ts`:
- Build `headers` as a `Record<string, string>` object
- Only add `Authorization` header when `this.token` is non-null (same pattern as `uploadImage()`)

## Test plan
- [ ] Calling `exportNotes()` while unauthenticated does not send `Authorization: Bearer null`
- [ ] Calling `exportNotes()` while authenticated sends correct `Authorization: Bearer <token>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)