### PR TITLE
fix: prevent ReDoS in note search highlight (Critical)

### DIFF
--- a/frontend/src/components/layout/NoteList.tsx
+++ b/frontend/src/components/layout/NoteList.tsx
@@ -115,7 +115,8 @@ export const NoteList = memo(function NoteList({
   const HighlightedText = ({ text, highlight }: { text: string; highlight: string }) => {
     if (!highlight.trim()) return <>{text}</>;
 
-    const parts = text.split(new RegExp(`(${highlight})`, "gi"));
+    const escaped = highlight.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const parts = text.split(new RegExp(`(${escaped})`, "gi"));
     return (
       <>
         {parts.map((part, i) => 


### PR DESCRIPTION
## Summary

- The `HighlightedText` component in `NoteList.tsx` passed raw user search input directly into `new RegExp()` without escaping
- Typing `(` or `[` in the search box caused `SyntaxError`, blanking out the entire note list
- Patterns like `(((((a+)+)+)+)+` triggered catastrophic backtracking, freezing the browser tab (ReDoS)

## Changes

`frontend/src/components/layout/NoteList.tsx`:
- Escape regex metacharacters before constructing the RegExp

## Test plan
- [ ] Search for `(`, `[`, `*` in the note list — list must not go blank
- [ ] Normal search highlighting continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)