### PR TITLE
fix: enable optional TOTP MFA on Cognito User Pool (High)

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -56,8 +56,12 @@ resource "aws_cognito_user_pool" "main" {
     }
   }
 
-  # MFA configuration (optional)
-  mfa_configuration = "OFF"
+  # MFA configuration
+  mfa_configuration = "OPTIONAL"
+
+  software_token_mfa_configuration {
+    enabled = true
+  }
 
   tags = {
     Name = "${var.project_name}-user-pool-${terraform.workspace}"


### PR DESCRIPTION
## Summary

- **Security fix (High):** Cognito User Pool MFA was set to `OFF`, leaving accounts unprotected by multi-factor authentication.
- Changed `mfa_configuration` from `"OFF"` to `"OPTIONAL"` so users can enroll in MFA without being forced to.
- Added `software_token_mfa_configuration { enabled = true }` block to enable TOTP-based MFA (authenticator apps such as Google Authenticator, Authy, etc.).

## Impact

Users can now opt in to TOTP MFA for their accounts. No breaking change — existing users without MFA configured are unaffected, and new users can enroll at their discretion.

## Test plan

- [ ] `terraform plan` in dev workspace shows only the Cognito User Pool MFA change
- [ ] `terraform apply` succeeds in dev without recreation of the user pool
- [ ] Verify in AWS Console that the Cognito User Pool shows MFA as "Optional" with software token MFA enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)