### PR TITLE
fix: add explicit SSE-S3 encryption to all S3 buckets

### DIFF
--- a/terraform/s3_cache.tf
+++ b/terraform/s3_cache.tf
@@ -31,3 +31,14 @@ resource "aws_s3_bucket_public_access_block" "cache" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cache" {
+  bucket = aws_s3_bucket.cache.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}

--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -23,6 +23,17 @@ resource "aws_s3_bucket_public_access_block" "frontend" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
 # S3 bucket policy for CloudFront OAC
 resource "aws_s3_bucket_policy" "frontend" {
   bucket = aws_s3_bucket.frontend.id

--- a/terraform/s3_images.tf
+++ b/terraform/s3_images.tf
@@ -15,6 +15,17 @@ resource "aws_s3_bucket_public_access_block" "images" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "images" {
+  bucket = aws_s3_bucket.images.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
 # CloudFront OAC for images bucket
 resource "aws_cloudfront_origin_access_control" "images" {
   name                              = "${var.project_name}-images-oac-${terraform.workspace}"


### PR DESCRIPTION
## 概要

S3バケット（images、cache、frontend）に明示的なSSE-S3暗号化設定が存在しないというセキュリティ上の問題を修正します。`aws_s3_bucket_server_side_encryption_configuration` リソースをすべてのバケットに追加し、AES256によるサーバーサイド暗号化とバケットキーを有効にします。

## 変更内容

- `terraform/s3_images.tf`: `aws_s3_bucket_server_side_encryption_configuration.images` リソースを追加
- `terraform/s3_cache.tf`: `aws_s3_bucket_server_side_encryption_configuration.cache` リソースを追加
- `terraform/s3_cloudfront.tf`: `aws_s3_bucket_server_side_encryption_configuration.frontend` リソースを追加
- すべてのバケットでSSEアルゴリズム `AES256` と `bucket_key_enabled = true` を設定

## テスト方法

- [ ] `terraform plan` を実行して、各バケットに暗号化設定が追加されることを確認
- [ ] `terraform apply` 後、AWSコンソールでS3バケットの暗号化タブを確認

## チェックリスト

- [x] テストを追加・更新した（Terraformリソースの追加のみ、アプリコードの変更なし）
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当なし）