### PR TITLE
fix: use commit_with_error_handling in EditJobUseCases.create_job (High)

### DIFF
--- a/backend/app/features/assistant/use_cases/edit_jobs.py
+++ b/backend/app/features/assistant/use_cases/edit_jobs.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from sqlmodel import Session
 
+from app.db_commit import commit_with_error_handling
 from app.features.assistant.use_cases.common import (
     ensure_token_limit,
     require_non_empty,
@@ -50,7 +51,7 @@ class EditJobUseCases:
             status="pending",
         )
         self.session.add(job)
-        self.session.commit()
+        commit_with_error_handling(self.session, "AIEditJob")
         self.session.refresh(job)
         return job
 


### PR DESCRIPTION
## Summary
- Replaced raw `self.session.commit()` with `commit_with_error_handling(self.session, "AIEditJob")` in `backend/app/features/assistant/use_cases/edit_jobs.py`
- Added `from app.db_commit import commit_with_error_handling` import

## Why
Raw `session.commit()` bypasses the project's shared error-handling layer that translates SQLAlchemy exceptions (retryable conflicts, integrity errors) into domain exceptions. Without this, DSQL optimistic-lock conflicts surface as unhandled 500 errors instead of retriable domain errors.

## Test plan
- [x] `make format-check` — passes
- [x] `make lint` — passes
- [x] Existing `test_edit_jobs.py` integration tests cover the create path

🤖 Generated with [Claude Code](https://claude.com/claude-code)