### PR TITLE
fix: reduce Cognito refresh token validity from 30 to 14 days (High)

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -72,7 +72,7 @@ resource "aws_cognito_user_pool_client" "main" {
   # Token validity
   access_token_validity  = 1
   id_token_validity      = 1
-  refresh_token_validity = 30
+  refresh_token_validity = 14
 
   token_validity_units {
     access_token  = "hours"


### PR DESCRIPTION
## Summary
Refresh token validity was 30 days, giving attackers a large window to use stolen refresh tokens. 14 days is a better balance between security and user convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)