### PR TITLE
fix: set ECR image_tag_mutability to IMMUTABLE (High)

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_log_group" "api_gateway" {
 # ECR Repository for Lambda container image
 resource "aws_ecr_repository" "api" {
   name                 = "${var.project_name}-api-${terraform.workspace}"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
   force_delete         = terraform.workspace != "prd"
 
   image_scanning_configuration {


### PR DESCRIPTION
## Summary

- **Security severity:** High
- Changed `image_tag_mutability` from `MUTABLE` to `IMMUTABLE` in the `aws_ecr_repository "api"` resource (`terraform/lambda.tf` line 111)
- Prevents attackers from overwriting existing image tags in ECR, closing a supply-chain attack vector where a pushed image could silently replace a previously deployed one

## Why this matters

With mutable tags, any principal that has ECR push access could overwrite (e.g.) the `latest` or a versioned tag already running in production. Immutable tags make each tag a permanent pointer to a single image digest, ensuring auditability and preventing silent replacement.

## Test plan

- [ ] Confirm `terraform plan` shows only the `image_tag_mutability` attribute changing (no destructive replacement of the repository)
- [ ] Apply in `dev` workspace and verify pushes of new unique tags still succeed
- [ ] Verify that attempting to re-push an existing tag is rejected by ECR with a 400 error (expected behavior for IMMUTABLE repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)