### PR TITLE
fix: remove duplicate API_BASE_URL constant (Medium)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -351,14 +351,11 @@ export function createApiClient(token: string | null): ApiClient {
   return new ApiClient(token);
 }
 
-// 認証不要のパブリック API
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-
 /**
  * 共有トークンを使って公開ノートを取得する。認証不要のパブリックエンドポイント。
  */
 export async function getSharedNote(token: string): Promise<SharedNote> {
-  const response = await fetch(`${API_BASE}/api/shared/${token}`);
+  const response = await fetch(`${API_BASE_URL}/api/shared/${token}`);
 
   if (!response.ok) {
     throw new ApiError(response.status, response.statusText, await response.json().catch(() => ({})));


### PR DESCRIPTION
## Summary
Removed the redundant `API_BASE` constant at the bottom of `api.ts` (line 355) that duplicated `API_BASE_URL` defined at line 47. Updated `getSharedNote()` to use the existing `API_BASE_URL`.

## Why
Duplicate constants for the same value are a maintenance hazard — a developer updating the base URL must change it in two places or risk a subtle divergence in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)