### PR TITLE
fix: add CloudFront security response headers policy (High)

### DIFF
--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -119,6 +119,36 @@ function handler(event) {
 EOF
 }
 
+# CloudFront Response Headers Policy (security headers)
+resource "aws_cloudfront_response_headers_policy" "security" {
+  name = "${var.project_name}-security-headers-${terraform.workspace}"
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+  }
+}
+
 # CloudFront Distribution
 resource "aws_cloudfront_distribution" "main" {
   enabled             = true
@@ -152,11 +182,12 @@ resource "aws_cloudfront_distribution" "main" {
       }
     }
 
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
-    compress               = true
+    viewer_protocol_policy      = "redirect-to-https"
+    min_ttl                     = 0
+    default_ttl                 = 86400
+    max_ttl                     = 31536000
+    compress                    = true
+    response_headers_policy_id  = aws_cloudfront_response_headers_policy.security.id
   }
 
   default_cache_behavior {
@@ -171,11 +202,12 @@ resource "aws_cloudfront_distribution" "main" {
       }
     }
 
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-    compress               = true
+    viewer_protocol_policy      = "redirect-to-https"
+    min_ttl                     = 0
+    default_ttl                 = 3600
+    max_ttl                     = 86400
+    compress                    = true
+    response_headers_policy_id  = aws_cloudfront_response_headers_policy.security.id
 
     function_association {
       event_type   = "viewer-request"


### PR DESCRIPTION
## Summary

- Adds `aws_cloudfront_response_headers_policy` resource with HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, and XSS-Protection headers
- Attaches the policy to both `ordered_cache_behavior` (images) and `default_cache_behavior` in the CloudFront distribution
- Resolves a High security finding: responses previously lacked standard security headers

## Security headers added

| Header | Value |
|--------|-------|
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` |
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `X-XSS-Protection` | `1; mode=block` |

## Test plan

- [ ] Run `terraform plan` in dev workspace and confirm the new `aws_cloudfront_response_headers_policy` resource appears as an addition
- [ ] Confirm both cache behavior blocks show `response_headers_policy_id` set to the new policy
- [ ] After apply, verify headers are present using `curl -I https://<domain>` or browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)