### PR TITLE
fix: remove aws-marketplace:Subscribe from Lambda IAM policy (High)

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -46,11 +46,9 @@ resource "aws_iam_role_policy" "bedrock_access" {
         ]
       },
       {
-        # Required for Bedrock to auto-subscribe to models on first access
         Effect = "Allow"
         Action = [
-          "aws-marketplace:ViewSubscriptions",
-          "aws-marketplace:Subscribe"
+          "aws-marketplace:ViewSubscriptions"
         ]
         Resource = "*"
       }


### PR DESCRIPTION
## Summary
Removed `aws-marketplace:Subscribe` from the Bedrock IAM policy attached to the Lambda execution role. Kept `aws-marketplace:ViewSubscriptions` (read-only).

## Why
`aws-marketplace:Subscribe` allows the Lambda function (and any code running in it) to subscribe to paid AWS Marketplace products, potentially incurring unexpected charges or subscribing to malicious third-party software. Bedrock model subscriptions should be done through the AWS Console by an administrator, not automatically by the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)