### PR TITLE
fix: scope CloudWatch Logs IAM resource to project log groups (High)

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -95,7 +95,12 @@ resource "aws_iam_role_policy" "logs" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:*:*:*"
+        Resource = [
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.project_name}-*",
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.project_name}-*:log-stream:*",
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/api-gateway/${var.project_name}-*",
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/api-gateway/${var.project_name}-*:log-stream:*"
+        ]
       }
     ]
   })


### PR DESCRIPTION
## Summary
Changed the CloudWatch Logs IAM resource from the wildcard `"arn:aws:logs:*:*:*"` to explicit ARN patterns scoped to the project's own log groups in the correct region and account.

## Why
The previous wildcard resource granted the Lambda execution role permission to write to **any** CloudWatch log group in the account, including log groups owned by other services. A compromised Lambda could exfiltrate or tamper with logs from other services. The fix uses ARN patterns with `${var.aws_region}` and `${data.aws_caller_identity.current.account_id}` to enforce account/region boundary, and `${var.project_name}-*` to enforce project namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)