### PR TITLE
fix: add CloudTrail for API audit logging (High)

### DIFF
--- a/terraform/cloudtrail.tf
+++ b/terraform/cloudtrail.tf
@@ -1,0 +1,105 @@
+resource "aws_cloudtrail" "main" {
+  name                          = "${var.project_name}-trail-${terraform.workspace}"
+  s3_bucket_name                = aws_s3_bucket.cloudtrail.bucket
+  include_global_service_events = true
+  is_multi_region_trail         = false
+  enable_log_file_validation    = true
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::Lambda::Function"
+      values = ["arn:aws:lambda"]
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-trail-${terraform.workspace}"
+  }
+}
+
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket        = "${var.project_name}-cloudtrail-${terraform.workspace}"
+  force_destroy = terraform.workspace != "prd"
+
+  tags = {
+    Name = "${var.project_name}-cloudtrail-${terraform.workspace}"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AWSCloudTrailAclCheck"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.cloudtrail.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceArn" = "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-trail-${terraform.workspace}"
+          }
+        }
+      },
+      {
+        Sid    = "AWSCloudTrailWrite"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+            "aws:SourceArn" = "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-trail-${terraform.workspace}"
+          }
+        }
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## Summary

- Add `terraform/cloudtrail.tf` to enable AWS CloudTrail for management event logging
- CloudTrail trail logs all read/write management events and Lambda data events
- S3 bucket for trail logs is configured with: public access block, AES256 server-side encryption, 365-day lifecycle expiration, and a bucket policy that restricts writes to CloudTrail only (with SourceArn condition)

## Security Fix

This addresses a High-severity compliance gap: without CloudTrail, AWS API calls were not audited, making it impossible to detect unauthorized access or changes to AWS resources.

## Test plan

- [ ] Run `terraform plan` in dev workspace and confirm no unexpected changes
- [ ] Run `terraform apply` and verify CloudTrail trail appears in the AWS console
- [ ] Confirm S3 bucket is created with correct name, encryption, and lifecycle policy
- [ ] Verify CloudTrail is delivering log files to the S3 bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)