### PR TITLE
fix: add reserved_concurrent_executions to Lambda functions (High)

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -36,8 +36,9 @@ resource "aws_lambda_function" "api" {
   role          = aws_iam_role.backend.arn
   package_type  = "Image"
   image_uri     = length(regexall("@?sha256:", var.lambda_image_tag)) > 0 ? "${aws_ecr_repository.api.repository_url}@${var.lambda_image_tag}" : "${aws_ecr_repository.api.repository_url}:${var.lambda_image_tag}"
-  timeout       = 60
-  memory_size   = 512
+  timeout                        = 60
+  memory_size                    = 512
+  reserved_concurrent_executions = 50
 
   environment {
     variables = local.backend_lambda_environment
@@ -59,8 +60,9 @@ resource "aws_lambda_function" "ai_edit_worker" {
   role          = aws_iam_role.backend.arn
   package_type  = "Image"
   image_uri     = length(regexall("@?sha256:", var.lambda_image_tag)) > 0 ? "${aws_ecr_repository.api.repository_url}@${var.lambda_image_tag}" : "${aws_ecr_repository.api.repository_url}:${var.lambda_image_tag}"
-  timeout       = 180
-  memory_size   = 1024
+  timeout                        = 180
+  memory_size                    = 1024
+  reserved_concurrent_executions = 10
 
   environment {
     variables = local.backend_lambda_environment


### PR DESCRIPTION
## Summary

- Without `reserved_concurrent_executions`, a burst of requests to either Lambda function can exhaust the AWS account's shared concurrency pool (default 1000), starving all other Lambda-based services and causing a denial-of-service condition.
- `aws_lambda_function.api` is now capped at **50** concurrent executions.
- `aws_lambda_function.ai_edit_worker` is now capped at **10** concurrent executions.

## Details

AWS Lambda concurrency is a shared account-level resource. If no reserved limit is set, a single function can consume the entire pool during a traffic spike, blocking every other Lambda function in the account from executing. Setting `reserved_concurrent_executions` both caps the blast radius of any single function and guarantees that capacity is reserved for it.

## Test plan

- [ ] Run `terraform plan` in dev workspace and confirm the two Lambda resources show a `reserved_concurrent_executions` update (no unexpected destroy/recreate).
- [ ] Apply to dev, verify both functions show the concurrency limit in the AWS Console → Lambda → Configuration → Concurrency.
- [ ] Confirm other Lambda functions in the account still operate normally after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)