### PR TITLE
fix: replace window.confirm() with non-blocking ConfirmDialog (High)

### DIFF
--- a/frontend/src/components/layout/EditorToolbar.tsx
+++ b/frontend/src/components/layout/EditorToolbar.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { useApi, useTranslation } from "@/hooks";
 import { ShareDialog } from "@/components/ui/ShareDialog";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import type { EditorDisplayMode } from "@/hooks/useEditorDisplayMode";
 
 interface EditorToolbarProps {
@@ -113,6 +114,7 @@ export const EditorToolbar = memo(function EditorToolbar({
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isShareLoading, setIsShareLoading] = useState(false);
   const [currentShare, setCurrentShare] = useState<NoteShare | null>(null);
+  const [confirmDeleteNoteOpen, setConfirmDeleteNoteOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const exportDropdownRef = useRef<HTMLDivElement>(null);
 
@@ -379,9 +381,7 @@ export const EditorToolbar = memo(function EditorToolbar({
             size="icon"
             className="text-destructive hover:text-destructive"
             onClick={() => {
-              if (confirm(t("noteList.deleteConfirm"))) {
-                onDeleteNote(noteId);
-              }
+              setConfirmDeleteNoteOpen(true);
             }}
             data-testid="editor-delete-note-button"
           >
@@ -389,6 +389,14 @@ export const EditorToolbar = memo(function EditorToolbar({
           </Button>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmDeleteNoteOpen}
+        onOpenChange={setConfirmDeleteNoteOpen}
+        title={t("noteList.deleteConfirm")}
+        description={t("noteList.deleteConfirm")}
+        onConfirm={() => onDeleteNote(noteId)}
+      />
 
       <ShareDialog
         isOpen={isShareDialogOpen}

--- a/frontend/src/components/layout/EditorToolbar.tsx
+++ b/frontend/src/components/layout/EditorToolbar.tsx
@@ -393,7 +393,7 @@ export const EditorToolbar = memo(function EditorToolbar({
       <ConfirmDialog
         open={confirmDeleteNoteOpen}
         onOpenChange={setConfirmDeleteNoteOpen}
-        title={t("noteList.deleteConfirm")}
+        title={t("noteList.deleteNote")}
         description={t("noteList.deleteConfirm")}
         onConfirm={() => onDeleteNote(noteId)}
       />

--- a/frontend/src/components/layout/NoteList.tsx
+++ b/frontend/src/components/layout/NoteList.tsx
@@ -29,6 +29,7 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import { useState, useEffect, memo } from "react";
 import { useTranslation } from "@/hooks";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 interface NoteListProps {
   notes: Note[];
@@ -66,6 +67,7 @@ export const NoteList = memo(function NoteList({
   const [isEditing, setIsEditing] = useState(false);
   const [editingName, setEditingName] = useState("");
   const [isCreating, setIsCreating] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const handleCreate = async () => {
     setIsCreating(true);
@@ -105,9 +107,7 @@ export const NoteList = memo(function NoteList({
 
   const handleDelete = () => {
     if (folderId && onDeleteFolder) {
-      if (confirm(t("sidebar.deleteConfirm"))) {
-        onDeleteFolder(folderId);
-      }
+      setConfirmDeleteOpen(true);
     }
   };
 
@@ -253,6 +253,14 @@ export const NoteList = memo(function NoteList({
             : t("noteList.noteCount").replace("{{count}}", String(notes.length))}
         </p>
       </div>
+
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title={t("noteList.deleteFolder")}
+        description={t("sidebar.deleteConfirm")}
+        onConfirm={() => { if (folderId && onDeleteFolder) onDeleteFolder(folderId); }}
+      />
 
       {/* Note list */}
       <ScrollArea className="flex-1 min-h-0">

--- a/frontend/src/components/layout/SettingsDialog.test.tsx
+++ b/frontend/src/components/layout/SettingsDialog.test.tsx
@@ -25,6 +25,7 @@ const mockT = vi.fn((key: string) => {
     "common.save": "Save",
     "common.saved": "Saved",
     "common.cancel": "Cancel",
+    "common.confirm": "Confirm",
     "common.error": "Error",
     "settings.title": "Settings",
     "settings.description": "Manage your settings",
@@ -135,7 +136,6 @@ describe("SettingsDialog", () => {
     currentTranslationFn = mockT;
     window.URL.createObjectURL = createObjectURLMock;
     window.URL.revokeObjectURL = revokeObjectURLMock;
-    vi.stubGlobal("confirm", vi.fn(() => true));
     Object.defineProperty(window.navigator, "clipboard", {
       configurable: true,
       value: {
@@ -244,6 +244,9 @@ describe("SettingsDialog", () => {
     });
 
     fireEvent.click(screen.getByText("Revoke"));
+
+    const confirmButton = await screen.findByRole("button", { name: "Confirm" });
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(mockApi.revokeApiKey).toHaveBeenCalledWith("key-1");

--- a/frontend/src/components/layout/SettingsDialog.tsx
+++ b/frontend/src/components/layout/SettingsDialog.tsx
@@ -9,6 +9,7 @@
  */
 import { useEffect, useState } from "react";
 import Image from "next/image";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
   Dialog,
   DialogContent,
@@ -75,6 +76,7 @@ export function SettingsDialog({
   const [isExporting, setIsExporting] = useState(false);
   const [isCreatingApiKey, setIsCreatingApiKey] = useState(false);
   const [revokingApiKeyId, setRevokingApiKeyId] = useState<string | null>(null);
+  const [confirmRevokeKeyId, setConfirmRevokeKeyId] = useState<string | null>(null);
   const [secretCopied, setSecretCopied] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [errorKey, setErrorKey] = useState<SettingsErrorKey | null>(null);
@@ -263,10 +265,6 @@ export function SettingsDialog({
   };
 
   const handleRevokeApiKey = async (keyId: string) => {
-    if (!confirm(t("settings.apiKeysRevokeConfirm"))) {
-      return;
-    }
-
     setRevokingApiKeyId(keyId);
     setApiKeysErrorKey(null);
 
@@ -291,6 +289,14 @@ export function SettingsDialog({
   };
 
   return (
+    <>
+    <ConfirmDialog
+      open={confirmRevokeKeyId !== null}
+      onOpenChange={(isOpen) => { if (!isOpen) setConfirmRevokeKeyId(null); }}
+      title={t("settings.apiKeysRevokeButton")}
+      description={t("settings.apiKeysRevokeConfirm")}
+      onConfirm={() => { if (confirmRevokeKeyId) void handleRevokeApiKey(confirmRevokeKeyId); }}
+    />
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
@@ -473,7 +479,7 @@ export function SettingsDialog({
                         </div>
                         <Button
                           variant="outline"
-                          onClick={() => handleRevokeApiKey(key.id)}
+                          onClick={() => setConfirmRevokeKeyId(key.id)}
                           disabled={revokingApiKeyId === key.id}
                         >
                           {revokingApiKeyId === key.id ? (
@@ -552,5 +558,6 @@ export function SettingsDialog({
         )}
       </DialogContent>
     </Dialog>
+    </>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import { logger } from "@/lib/logger";
 import { FolderIcon, FolderPlusIcon, TrashIcon, PencilIcon, PanelLeftCloseIcon, CheckIcon, XIcon, Loader2Icon } from "lucide-react";
 import { useState, memo } from "react";
 import { useTranslation } from "@/hooks";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 interface SidebarProps {
   folders: Folder[];
@@ -49,6 +50,7 @@ export const Sidebar = memo(function Sidebar({
   const [newFolderName, setNewFolderName] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
+  const [confirmDeleteFolderId, setConfirmDeleteFolderId] = useState<string | null>(null);
 
   const handleCreateFolder = async () => {
     if (newFolderName.trim()) {
@@ -110,6 +112,14 @@ export const Sidebar = memo(function Sidebar({
           </Button>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmDeleteFolderId !== null}
+        onOpenChange={(open) => { if (!open) setConfirmDeleteFolderId(null); }}
+        title={t("noteList.deleteFolder")}
+        description={t("sidebar.deleteConfirm")}
+        onConfirm={() => { if (confirmDeleteFolderId) onDeleteFolder(confirmDeleteFolderId); }}
+      />
 
       {/* Folder list */}
       <ScrollArea className="flex-1 min-h-0">
@@ -232,9 +242,7 @@ export const Sidebar = memo(function Sidebar({
                       className="h-6 w-6 text-destructive hover:text-destructive"
                       onClick={(e) => {
                         e.stopPropagation();
-                        if (confirm(t("sidebar.deleteConfirm"))) {
-                          onDeleteFolder(folder.id);
-                        }
+                        setConfirmDeleteFolderId(folder.id);
                       }}
                       data-testid="sidebar-folder-delete-button"
                     >

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+}: ConfirmDialogProps) {
+  const handleConfirm = () => {
+    onOpenChange(false);
+    onConfirm();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {cancelLabel}
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { useTranslation } from "@/hooks";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -26,9 +27,12 @@ export function ConfirmDialog({
   title,
   description,
   onConfirm,
-  confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
+  confirmLabel,
+  cancelLabel,
 }: ConfirmDialogProps) {
+  const { t } = useTranslation();
+  const resolvedConfirmLabel = confirmLabel ?? t("common.confirm");
+  const resolvedCancelLabel = cancelLabel ?? t("common.cancel");
   const handleConfirm = () => {
     onOpenChange(false);
     onConfirm();
@@ -43,10 +47,10 @@ export function ConfirmDialog({
         </DialogHeader>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {cancelLabel}
+            {resolvedCancelLabel}
           </Button>
           <Button variant="destructive" onClick={handleConfirm}>
-            {confirmLabel}
+            {resolvedConfirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/ui/ShareDialog.test.tsx
+++ b/frontend/src/components/ui/ShareDialog.test.tsx
@@ -5,6 +5,8 @@ import { ShareDialog } from "./ShareDialog";
 // Mock useTranslation
 const mockT = vi.fn((key: string) => {
   const translations: Record<string, string> = {
+    "common.confirm": "Confirm",
+    "common.cancel": "Cancel",
     "share.title": "Share Note",
     "share.description": "Anyone with the link can view this note",
     "share.copied": "Link copied to clipboard!",
@@ -33,9 +35,6 @@ Object.defineProperty(navigator, "clipboard", {
   writable: true,
 });
 
-// Mock window.confirm
-const mockConfirm = vi.fn();
-window.confirm = mockConfirm;
 
 describe("ShareDialog", () => {
   const defaultProps = {
@@ -123,24 +122,24 @@ describe("ShareDialog", () => {
     });
 
     it("calls onRevokeShare when revoke is confirmed", () => {
-      mockConfirm.mockReturnValue(true);
       render(<ShareDialog {...propsWithUrl} />);
-      
+
       fireEvent.click(screen.getByTestId("share-revoke-button"));
-      
-      expect(mockConfirm).toHaveBeenCalledWith(
-        "Are you sure you want to revoke this share link?"
-      );
+
+      const confirmButton = screen.getByRole("button", { name: "Confirm" });
+      fireEvent.click(confirmButton);
+
       expect(propsWithUrl.onRevokeShare).toHaveBeenCalledTimes(1);
     });
 
     it("does not call onRevokeShare when revoke is cancelled", () => {
-      mockConfirm.mockReturnValue(false);
       render(<ShareDialog {...propsWithUrl} />);
-      
+
       fireEvent.click(screen.getByTestId("share-revoke-button"));
-      
-      expect(mockConfirm).toHaveBeenCalled();
+
+      const cancelButton = screen.getByRole("button", { name: "Cancel" });
+      fireEvent.click(cancelButton);
+
       expect(propsWithUrl.onRevokeShare).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/components/ui/ShareDialog.tsx
+++ b/frontend/src/components/ui/ShareDialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { CopyIcon, CheckIcon, Trash2Icon, Loader2Icon, LinkIcon } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 interface ShareDialogProps {
   isOpen: boolean;
@@ -46,6 +47,7 @@ export function ShareDialog({
 }: ShareDialogProps) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
+  const [confirmRevokeOpen, setConfirmRevokeOpen] = useState(false);
 
   /** 共有 URL をクリップボードにコピーし、2 秒間コピー完了フィードバックを表示する。 */
   const handleCopy = async () => {
@@ -58,12 +60,18 @@ export function ShareDialog({
 
   /** 確認ダイアログを表示し、ユーザーが承認した場合のみ共有リンクを削除する。 */
   const handleRevoke = () => {
-    if (confirm(t("share.revokeConfirm"))) {
-      onRevokeShare();
-    }
+    setConfirmRevokeOpen(true);
   };
 
   return (
+    <>
+    <ConfirmDialog
+      open={confirmRevokeOpen}
+      onOpenChange={setConfirmRevokeOpen}
+      title={t("share.revokeShare")}
+      description={t("share.revokeConfirm")}
+      onConfirm={onRevokeShare}
+    />
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md" data-testid="share-dialog">
         <DialogHeader>
@@ -129,5 +137,6 @@ export function ShareDialog({
         )}
       </DialogContent>
     </Dialog>
+    </>
   );
 }

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -16,6 +16,7 @@ export const en = {
   common: {
     save: "Save",
     cancel: "Cancel",
+    confirm: "Confirm",
     delete: "Delete",
     edit: "Edit",
     create: "Create",
@@ -87,6 +88,7 @@ export const en = {
     noNotes: "No notes",
     searchPlaceholder: "Search notes...",
     untitled: "Untitled",
+    deleteNote: "Delete note",
     deleteConfirm: "Delete this note?",
     noContent: "No content",
     createOne: "Create one",
@@ -290,6 +292,7 @@ export type TranslationKeys = {
   common: {
     save: string;
     cancel: string;
+    confirm: string;
     delete: string;
     edit: string;
     create: string;
@@ -355,6 +358,7 @@ export type TranslationKeys = {
     noNotes: string;
     searchPlaceholder: string;
     untitled: string;
+    deleteNote: string;
     deleteConfirm: string;
     noContent: string;
     createOne: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -16,6 +16,7 @@ export const ja = {
   common: {
     save: "保存",
     cancel: "キャンセル",
+    confirm: "確認",
     delete: "削除",
     edit: "編集",
     create: "作成",
@@ -87,6 +88,7 @@ export const ja = {
     noNotes: "ノートがありません",
     searchPlaceholder: "ノートを検索...",
     untitled: "無題",
+    deleteNote: "ノートを削除",
     deleteConfirm: "このノートを削除しますか？",
     noContent: "内容なし",
     createOne: "作成する",


### PR DESCRIPTION
## Summary
- Created reusable ConfirmDialog component using existing Dialog primitive
- Replaced all 5 window.confirm() calls in NoteList, Sidebar, ShareDialog, SettingsDialog, and EditorToolbar with non-blocking React dialog state

## Why
window.confirm() is a blocking browser dialog that freezes the event loop, breaks browser extensions, and is inaccessible to screen readers. React state-based dialogs are non-blocking and accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)