### PR TITLE
fix: enable S3 bucket versioning on frontend and images buckets (High)

### DIFF
--- a/terraform/s3_cache.tf
+++ b/terraform/s3_cache.tf
@@ -32,6 +32,14 @@ resource "aws_s3_bucket_public_access_block" "cache" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_versioning" "cache" {
+  bucket = aws_s3_bucket.cache.id
+
+  versioning_configuration {
+    status = "Suspended"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "cache" {
   bucket = aws_s3_bucket.cache.id
 

--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -23,6 +23,14 @@ resource "aws_s3_bucket_public_access_block" "frontend" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
   bucket = aws_s3_bucket.frontend.id
 

--- a/terraform/s3_images.tf
+++ b/terraform/s3_images.tf
@@ -15,6 +15,14 @@ resource "aws_s3_bucket_public_access_block" "images" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_versioning" "images" {
+  bucket = aws_s3_bucket.images.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "images" {
   bucket = aws_s3_bucket.images.id
 


### PR DESCRIPTION
## Summary
- Enabled versioning (`Enabled`) on `s3_images` and `s3_cloudfront` (frontend) buckets
- Added versioning with `Suspended` status on `s3_cache` bucket (ephemeral cache data — full versioning would multiply storage cost unnecessarily)

## Why
Without versioning, accidental or malicious object deletion/overwriting cannot be recovered. Versioned buckets enable point-in-time recovery and provide an audit trail of object changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)