### PR TITLE
fix: enable DSQL deletion protection in all environments (Medium)

### DIFF
--- a/terraform/dsql.tf
+++ b/terraform/dsql.tf
@@ -1,6 +1,6 @@
 # Aurora DSQL Cluster
 resource "aws_dsql_cluster" "main" {
-  deletion_protection_enabled = terraform.workspace == "prd" ? true : false
+  deletion_protection_enabled = true
 
   tags = {
     Name = "${var.project_name}-dsql-${terraform.workspace}"


### PR DESCRIPTION
## Summary
Changed `deletion_protection_enabled` from a `prd`-only conditional to `true` unconditionally across all workspaces (dev, prd).

## Why
The dev environment contains real user data used for integration testing. Accidental `terraform destroy` or a misconfigured deployment pipeline could irreversibly delete the DSQL cluster and all data. Deletion protection adds a manual override requirement before destruction is possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)