### PR TITLE
fix: add explicit KMS key to AWS Backup vault (Medium)

### DIFF
--- a/terraform/backup.tf
+++ b/terraform/backup.tf
@@ -1,6 +1,7 @@
 # AWS Backup Vault
 resource "aws_backup_vault" "main" {
-  name = "${var.project_name}-backup-vault-${terraform.workspace}"
+  name        = "${var.project_name}-backup-vault-${terraform.workspace}"
+  kms_key_arn = "arn:aws:kms:${var.aws_region}:${data.aws_caller_identity.current.account_id}:alias/aws/backup"
 }
 
 # AWS Backup Plan（日次バックアップ）


### PR DESCRIPTION
## Summary
Added `kms_key_arn` using the AWS-managed backup key (`alias/aws/backup`) to the `aws_backup_vault` resource.

## Why
Without an explicit KMS key, backups may use an unmanaged default key that cannot be rotated, audited, or revoked independently. Using `alias/aws/backup` (AWS-managed) provides encryption without requiring custom key management overhead, while making the encryption intent explicit in the configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)