### PR TITLE
fix: validate image MIME type from file magic bytes, not just Content-Type header

### DIFF
--- a/backend/app/features/images/use_cases.py
+++ b/backend/app/features/images/use_cases.py
@@ -28,6 +28,28 @@ MIME_TO_EXT = {
 }
 
 
+def _detect_mime_from_bytes(content: bytes) -> str | None:
+    """ファイルのマジックバイトから実際の MIME タイプを判定する。
+
+    Content-Type ヘッダーは攻撃者が自由に設定できるため、
+    ファイルの先頭バイト列（マジックバイト）を直接検査して
+    実際のフォーマットを確認する。
+
+    Returns:
+        検出された MIME タイプ文字列、またはサポート外フォーマットの場合 None。
+    """
+    if content[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if content[:8] == b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a":
+        return "image/png"
+    if content[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    # WebP: "RIFF" + 4-byte size + "WEBP"
+    if len(content) >= 12 and content[:4] == b"RIFF" and content[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
 class ImageUploadUseCases:
     """画像アップロードのアプリケーションユースケース。"""
 
@@ -35,12 +57,24 @@ class ImageUploadUseCases:
         """ファイルを検証して S3 に保存し、CDN URL を返す。"""
         settings = get_settings()
 
+        # 早期リターン: Content-Type ヘッダーが許可リスト外なら即拒否
         if file.content_type not in ALLOWED_MIME_TYPES:
             raise ValidationFailed(
                 f"Unsupported file type: {file.content_type}. Allowed: {', '.join(sorted(ALLOWED_MIME_TYPES))}"
             )
 
         content = await file.read()
+
+        # マジックバイト検証: ヘッダーではなく実際のバイト列でフォーマットを確認する
+        detected_mime = _detect_mime_from_bytes(content)
+        if detected_mime is None:
+            raise ValidationFailed(
+                "File content does not match any supported image format"
+            )
+        if detected_mime != file.content_type:
+            raise ValidationFailed(
+                f"File content type mismatch: header says {file.content_type} but content is {detected_mime}"
+            )
 
         if len(content) > MAX_FILE_SIZE:
             raise ValidationFailed(


### PR DESCRIPTION
## Summary

- **Security fix**: Image uploads previously trusted the `Content-Type` HTTP header, which is fully attacker-controlled. A malicious actor could upload arbitrary file content (e.g. an executable or HTML) while declaring `Content-Type: image/jpeg`, bypassing the MIME type check entirely.
- Added `_detect_mime_from_bytes(content: bytes) -> str | None` helper that inspects actual file magic bytes for JPEG, PNG, GIF, and WebP — no new dependencies required.
- Validation now has two gates:
  1. **Early exit** on disallowed `Content-Type` header (existing check, kept as-is).
  2. **Magic byte check** after reading content: raises `ValidationFailed` if the bytes don't match a known format, or if the detected format disagrees with the declared `Content-Type`.

## Magic byte signatures used

| Format | Signature |
|--------|-----------|
| JPEG   | `\xff\xd8\xff` (first 3 bytes) |
| PNG    | `\x89PNG\r\n\x1a\n` (first 8 bytes) |
| GIF    | `GIF87a` or `GIF89a` (first 6 bytes) |
| WebP   | `RIFF` + 4-byte size + `WEBP` (bytes 0–3 and 8–11) |

## Test plan

- [ ] Upload a valid JPEG — should succeed
- [ ] Upload a valid PNG — should succeed
- [ ] Upload a valid GIF — should succeed
- [ ] Upload a valid WebP — should succeed
- [ ] Upload a file with `Content-Type: image/jpeg` but PNG bytes — expect 422 `File content type mismatch`
- [ ] Upload a text file with `Content-Type: image/png` — expect 422 `File content does not match any supported image format`
- [ ] Upload a file with an unsupported `Content-Type` (e.g. `application/pdf`) — expect early 422 `Unsupported file type` (existing behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)