### PR TITLE
fix: require user consent before accessing geolocation in WeatherWidget

### DIFF
--- a/frontend/src/components/WeatherWidget.test.tsx
+++ b/frontend/src/components/WeatherWidget.test.tsx
@@ -61,13 +61,22 @@ const setupFetchFailure = (status = 500) => {
   });
 };
 
+const CONSENT_KEY = "weather-geolocation-consent";
+
 describe("WeatherWidget", () => {
   const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    // Simulate already-granted consent so existing geolocation/fetch tests run
+    // without hitting the consent-needed gate introduced by PR #119.
+    localStorage.setItem(CONSENT_KEY, "granted");
+  });
 
   afterEach(() => {
     global.fetch = originalFetch;
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    localStorage.removeItem(CONSENT_KEY);
   });
 
   // -------------------------
@@ -146,6 +155,20 @@ describe("WeatherWidget", () => {
   it("React.memo でラップされている", () => {
     const widgetType = (WeatherWidget as unknown as { $$typeof?: symbol })?.$$typeof;
     expect(widgetType).toBe(Symbol.for("react.memo"));
+  });
+
+  // -------------------------
+  // 同意フロー
+  // -------------------------
+
+  it("同意未設定時は consent chip を表示する", () => {
+    localStorage.removeItem(CONSENT_KEY);
+    mockGeolocationSuccess();
+    setupFetchMock();
+
+    const { getByTestId } = render(<WeatherWidget />);
+
+    expect(getByTestId("weather-consent-chip")).toBeInTheDocument();
   });
 
   // -------------------------

--- a/frontend/src/components/WeatherWidget.tsx
+++ b/frontend/src/components/WeatherWidget.tsx
@@ -17,9 +17,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+
+const CONSENT_KEY = "weather-geolocation-consent";
 
 type WeatherState =
-  | { status: "idle" | "loading" | "error" }
+  | { status: "idle" | "loading" | "error" | "consent-needed" }
   | { status: "success"; temperature: number; weatherCode: number; updatedAt: Date };
 
 type WeatherConditionKey =
@@ -68,16 +71,20 @@ function getWeatherInfo(code: number): { emoji: string; labelKey: WeatherConditi
 /**
  * 位置情報を取得して天気データを管理するカスタムフック。
  * 取得失敗・位置情報拒否・AbortError はすべて適切にハンドリングする。
+ * 初回マウント時にローカルストレージで同意確認を行い、未同意の場合は consent-needed 状態を返す。
  */
-function useWeather(): WeatherState {
+function useWeather(): { state: WeatherState; grantConsent: () => void } {
   const [state, setState] = useState<WeatherState>({ status: "idle" });
   const abortRef = useRef<AbortController | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startedRef = useRef(false);
 
-  useEffect(() => {
+  const startGeolocation = () => {
     if (typeof navigator === "undefined" || !navigator.geolocation) {
       return;
     }
+    if (startedRef.current) return;
+    startedRef.current = true;
 
     const fetchWeather = (lat: number, lon: number) => {
       abortRef.current?.abort();
@@ -123,23 +130,78 @@ function useWeather(): WeatherState {
       },
       { timeout: 10_000 }
     );
+  };
+
+  useEffect(() => {
+    const alreadyGranted =
+      typeof localStorage !== "undefined" &&
+      localStorage.getItem(CONSENT_KEY) === "granted";
+
+    if (alreadyGranted) {
+      startGeolocation();
+    } else {
+      setState({ status: "consent-needed" });
+    }
 
     return () => {
       abortRef.current?.abort();
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
+     
   }, []);
 
-  return state;
+  const grantConsent = () => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(CONSENT_KEY, "granted");
+    }
+    startGeolocation();
+  };
+
+  return { state, grantConsent };
 }
 
 /**
  * 天気情報をコンパクトに表示するウィジェット。
- * 取得成功時のみ描画し、ホバーでツールチップに詳細（気温・天気状況・最終更新時刻）を表示する。
+ * 未同意の場合は位置情報の用途を説明するチップを表示し、同意後に天気データを取得・表示する。
+ * 取得成功時のみ気温を描画し、ホバーでツールチップに詳細（気温・天気状況・最終更新時刻）を表示する。
  */
 export const WeatherWidget = memo(function WeatherWidget() {
   const { t } = useTranslation();
-  const state = useWeather();
+  const { state, grantConsent } = useWeather();
+
+  if (state.status === "consent-needed") {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="flex items-center gap-1 text-xs font-mono cursor-pointer bg-accent/50 hover:bg-accent px-2 py-1 rounded-md transition-colors text-muted-foreground"
+              data-testid="weather-consent-chip"
+            >
+              <span>📍</span>
+              <span>?</span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent align="center" sideOffset={5} className="max-w-xs">
+            <div className="space-y-2 text-sm font-sans p-1">
+              {/* TODO: add i18n */}
+              <p className="font-semibold">Weather Widget</p>
+              <p>Location is used for weather data and never stored.</p>
+              <Button
+                size="sm"
+                className="w-full mt-1"
+                onClick={grantConsent}
+                data-testid="weather-consent-allow"
+              >
+                {/* TODO: add i18n */}
+                Allow
+              </Button>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   if (state.status !== "success") {
     return null;

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { buildBlockquoteDecorations } from "../blockquote";
 
 function makeFakeView(state: EditorState): EditorView {
@@ -18,11 +19,13 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos = 0): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 function getLineDecs(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { buildCodeBlockDecorations } from "../codeBlocks";
 
 function makeFakeView(state: EditorState): EditorView {
@@ -18,11 +19,13 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos = 0): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 function getLineDecs(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { buildHeadingDecorations } from "../headings";
 
 function makeFakeView(state: EditorState): EditorView {
@@ -18,11 +19,13 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos = 0): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 function getLineDecs(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/horizontalRule.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/horizontalRule.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { buildHorizontalRuleDecorations } from "../horizontalRule";
 
 function makeFakeView(state: EditorState): EditorView {
@@ -19,11 +20,14 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos = 0): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
+  // lezer-markdown は遅延パースするため強制フルパース（5000ms で JIT 未ウォームアップ時も対応）
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 function getLineDecs(decs: Range<Decoration>[]): Range<Decoration>[] {

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/images.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/images.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { GFM } from "@lezer/markdown";
 import { buildImageDecorations, ImageWidget } from "../images";
 
@@ -19,11 +20,13 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos: number): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 /** widget を持つ replace デコレーションを取得する */

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { buildInlineDecorations } from "../inlineStyles";
 
 /** DOM なしで動作する最小限の EditorView シム */
@@ -20,11 +21,13 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos = 0): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 // ---------------------------------------------------------------

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/links.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/links.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { GFM } from "@lezer/markdown";
 import { buildLinkDecorations } from "../links";
 
@@ -19,11 +20,13 @@ function makeFakeView(state: EditorState): EditorView {
 }
 
 function makeState(doc: string, cursorPos: number): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 /** cm-md-link マークデコレーションを抽出する */

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import { markdown } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { buildListDecorations } from "../lists";
 
 function makeFakeView(state: EditorState, composing = false): EditorView {
@@ -21,11 +22,13 @@ function makeFakeView(state: EditorState, composing = false): EditorView {
 }
 
 function makeState(doc: string, cursorPos = 0): EditorState {
-  return EditorState.create({
+  const state = EditorState.create({
     doc,
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
 }
 
 /** 指定クラスの mark デコレーションを取得する */

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/taskList.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/taskList.test.ts
@@ -28,7 +28,8 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
   // lezer-markdown は遅延パースするため、テストでは強制的にフルパースしておく
-  ensureSyntaxTree(state, state.doc.length, 100);
+  // 5000ms に設定: JIT未ウォームアップ時でも確実にパースが完了する余裕を持たせる
+  ensureSyntaxTree(state, state.doc.length, 5000);
   return state;
 }
 

--- a/frontend/tests/regression/weather-widget.spec.ts
+++ b/frontend/tests/regression/weather-widget.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+import { waitForWorkspaceSnapshotReady } from '../helpers/apiFixtures';
+
+const CONSENT_KEY = 'weather-geolocation-consent';
+const SNAPSHOT_WARMUP = { attempts: 12, delayMs: 5000, timeoutMs: 30000 };
+
+async function openFirstNote(page: Parameters<typeof waitForWorkspaceSnapshotReady>[0]) {
+  const desktopLayout = page.getByTestId('desktop-layout');
+  const firstNote = desktopLayout.locator('[data-testid^="note-list-item-"]').first();
+  await expect(firstNote).toBeVisible({ timeout: 30000 });
+  await firstNote.click();
+  await expect(desktopLayout.getByTestId('editor-title-input')).toBeVisible({ timeout: 15000 });
+}
+
+test.describe('Regression: WeatherWidget geolocation consent', () => {
+  test('shows consent chip on first load and grants consent on Allow click', async ({ page, isMobile, browserName }) => {
+    test.skip(isMobile, 'Desktop only — WeatherWidget lives in the editor status bar');
+    test.skip(browserName === 'webkit', 'Flaky on WebKit');
+    test.setTimeout(120000);
+
+    await page.goto('/');
+    await waitForWorkspaceSnapshotReady(page, SNAPSHOT_WARMUP);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    // Ensure consent is not set, then reload so the component sees the cleared state
+    await page.evaluate((key) => localStorage.removeItem(key), CONSENT_KEY);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    // Open a note so the EditorStatusBar (which hosts WeatherWidget) is visible
+    await openFirstNote(page);
+
+    // Scope to desktop layout to avoid strict mode violation (mobile layout renders the same widget)
+    const desktopLayout = page.getByTestId('desktop-layout');
+
+    // Consent chip should appear in the status bar
+    const chip = desktopLayout.getByTestId('weather-consent-chip');
+    await expect(chip).toBeVisible({ timeout: 15000 });
+
+    // Hover chip to open tooltip (Radix Tooltip opens on mouseenter)
+    await chip.hover();
+
+    // Allow button should appear inside tooltip
+    const allowButton = page.getByTestId('weather-consent-allow').first();
+    await expect(allowButton).toBeVisible({ timeout: 10000 });
+
+    // Tooltip should show privacy explanation
+    await expect(page.getByText('Location is used for weather data and never stored.').first()).toBeVisible({ timeout: 5000 });
+
+    // Click Allow — consent is stored and geolocation starts
+    await allowButton.click();
+
+    // Consent should be persisted in localStorage
+    const stored = await page.evaluate((key) => localStorage.getItem(key), CONSENT_KEY);
+    expect(stored).toBe('granted');
+
+    // Consent chip should disappear after granting
+    await expect(chip).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('skips consent UI on reload when consent already stored', async ({ page, isMobile, browserName }) => {
+    test.skip(isMobile, 'Desktop only — WeatherWidget lives in the editor status bar');
+    test.skip(browserName === 'webkit', 'Flaky on WebKit');
+    test.setTimeout(120000);
+
+    await page.goto('/');
+    await waitForWorkspaceSnapshotReady(page, SNAPSHOT_WARMUP);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    // Pre-set consent, then reload
+    await page.evaluate((key) => localStorage.setItem(key, 'granted'), CONSENT_KEY);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    // Open a note so the EditorStatusBar is rendered
+    await openFirstNote(page);
+
+    // Scope to desktop layout to avoid strict mode violation
+    const desktopLayout = page.getByTestId('desktop-layout');
+
+    // Consent chip must NOT appear
+    const chip = desktopLayout.getByTestId('weather-consent-chip');
+    await expect(chip).not.toBeVisible({ timeout: 10000 });
+
+    // Cleanup: remove consent so other test runs start fresh
+    await page.evaluate((key) => localStorage.removeItem(key), CONSENT_KEY);
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
-    exclude: ['tests/**', 'node_modules/**'],
+    exclude: ['tests/**', 'node_modules/**', '../.claude/**'],
   },
 })


### PR DESCRIPTION
## 概要

位置情報を取得する前にユーザーの同意を求める UI を WeatherWidget に追加する。ブラウザの権限プロンプトだけでは「なぜ・どのように位置情報を使うか」が伝わらないため、アプリ側で明示的な開示とオプトインを実装する。

## 変更内容

- **`WeatherWidget.tsx`**: `useWeather` フックに `consent-needed` 状態を追加。初回マウント時に `localStorage("weather-geolocation-consent")` を確認し、未同意なら位置情報取得をスキップして同意 UI を表示する。同意後は `localStorage` に `"granted"` を保存し、以降のロードでは即座に位置情報取得を開始する。
- **同意 UI**: `📍?` チップを EditorStatusBar に表示し、ホバーで Tooltip を開いて「Location is used for weather data and never stored.」と **Allow** ボタンを提示する（`data-testid="weather-consent-chip"` / `"weather-consent-allow"` でテスト可能）。

### テスト関連（動作確認時に追加）

- **`WeatherWidget.test.tsx`**: 既存テストに `localStorage` consent 設定を追加（`beforeEach`/`afterEach`）、consent-chip の表示確認テストを追加
- **`tests/regression/weather-widget.spec.ts`**: 新規 Playwright E2E テスト（dev 環境で動作確認済み）
  - 初回ロード（未同意）: チップ表示 → Allow クリック → localStorage 保存 → チップ消滅
  - 同意済みリロード: チップ非表示
- **`livePreview/__tests__` 9 件**: `makeState()` に `ensureSyntaxTree(state, doc.length, 5000)` を追加。lezer-markdown の遅延パースが並列ワーカー初回起動時にフレーキー失敗を引き起こしていた問題を修正
- **`vitest.config.ts`**: `../.claude/**` を exclude 追加（worktree のテストが混入する問題を解消）

## テスト方法

- [ ] 初回ロード（localStorage に consent なし）: `📍?` チップが表示されることを確認
- [ ] チップにホバー → Tooltip が開き「Location is used for weather data and never stored.」と **Allow** ボタンが表示されること
- [ ] **Allow** クリック → `localStorage.getItem("weather-geolocation-consent") === "granted"` になりチップが消えること
- [ ] ページリロード（consent 済み）→ チップが表示されず位置情報取得が始まること

## チェックリスト

- [x] テストを追加・更新した（ユニット + E2E）
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（TODO が 2 箇所残存: 「Weather Widget」と「Allow」）

> **Note**: i18n TODO が 2 箇所残っています。マージ前に対応推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)