### PR TITLE
fix: prevent note content from appearing in Sentry Replay via block selectors

### DIFF
--- a/frontend/src/components/ai/AIChatPanel.tsx
+++ b/frontend/src/components/ai/AIChatPanel.tsx
@@ -212,6 +212,7 @@ export const AIChatPanel = memo(function AIChatPanel({
           "fixed md:relative inset-0 md:inset-auto w-full z-40 md:z-auto bg-background md:bg-transparent pb-14 md:pb-0"
         )}
         style={width ? { width: `${width}px` } : { width: '320px' }}
+        data-sentry-block
       >
       {/* Header */}
       <div className="p-4 border-b border-border/50">

--- a/frontend/src/components/layout/EditorPanel.tsx
+++ b/frontend/src/components/layout/EditorPanel.tsx
@@ -731,7 +731,7 @@ export function EditorPanel({
           />
 
           {/* Editor */}
-          <div className="flex-1 flex flex-col overflow-hidden" role="main">
+          <div className="flex-1 flex flex-col overflow-hidden" role="main" data-sentry-block>
             {/* Fixed Title Area */}
             <div className="p-4 md:p-6 pb-0 flex-none bg-background z-10">
               <div className="relative mb-4">

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -56,6 +56,7 @@ export function getSentryBrowserConfig() {
       Sentry.replayIntegration({
         maskAllText: true,
         blockAllMedia: true,
+        block: [".cm-content", ".cm-editor", "[data-sentry-block]"],
       }),
     ],
   };


### PR DESCRIPTION
## Summary

- Added `block` option to `replayIntegration` in `sentry.ts` with CSS selectors `[".cm-content", ".cm-editor", "[data-sentry-block]"]` to fully block (not just mask) CodeMirror editor DOM nodes from session recordings
- Added `data-sentry-block` attribute to the `role="main"` editor container div in `EditorPanel.tsx` so the entire note title + content area is blocked
- Added `data-sentry-block` attribute to the main panel div in `AIChatPanel.tsx` so AI chat responses (which may reflect note content) are also blocked

## Why

`maskAllText: true` only replaces visible text with placeholder characters, but the structural shape of the DOM (and CodeMirror's internal nodes) can still be recorded. Blocking these elements removes them entirely from the Replay recording, preventing any note content from leaking via session recordings.

## Test plan

- [ ] Confirm Sentry Replay sessions no longer capture content inside `.cm-editor` / `.cm-content`
- [ ] Confirm the AI chat panel content is absent from Replay recordings
- [ ] Verify that non-editor UI (toolbar, sidebar, navigation) still appears in recordings as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)