### PR TITLE
fix: restrict frontend dev auth bypass to local environment only

### DIFF
--- a/frontend/src/lib/dev-bypass.ts
+++ b/frontend/src/lib/dev-bypass.ts
@@ -1,7 +1,7 @@
 /**
  * ローカル開発・AI エージェント検証用の認証バイパス定数。
- * NEXT_PUBLIC_DEV_AUTH_BYPASS=true かつ NEXT_PUBLIC_ENVIRONMENT !== "prd" のときのみ有効。
- * 本番ビルドでは絶対に true にならない (二段ガード)。
+ * NEXT_PUBLIC_DEV_AUTH_BYPASS=true かつ NEXT_PUBLIC_ENVIRONMENT === "local" のときのみ有効。
+ * ローカル環境以外では絶対に true にならない (二段ガード)。
  */
 
 export const BYPASS_TOKEN = "local-dev-token";
@@ -14,4 +14,4 @@ export const BYPASS_USER = {
 
 export const isDevAuthBypass =
   process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS === "true" &&
-  process.env.NEXT_PUBLIC_ENVIRONMENT !== "prd";
+  process.env.NEXT_PUBLIC_ENVIRONMENT === "local";


### PR DESCRIPTION
## Summary
- Align frontend auth bypass guard with backend fix (PR #97)
- Changed `NEXT_PUBLIC_ENVIRONMENT !== "prd"` to `=== "local"` so the bypass can never activate in the live AWS dev environment
- Previously, deploying with `NEXT_PUBLIC_DEV_AUTH_BYPASS=true` to dev AWS would have enabled the bypass

## Test plan
- [ ] Verify `isDevAuthBypass` is false when `NEXT_PUBLIC_ENVIRONMENT=dev`
- [ ] Verify `isDevAuthBypass` is true only when `NEXT_PUBLIC_ENVIRONMENT=local` AND `NEXT_PUBLIC_DEV_AUTH_BYPASS=true`

🤖 Generated with Claude Code