### PR TITLE
fix: type chat history with BedrockMessage Pydantic model instead of list[dict]

### DIFF
--- a/backend/app/features/assistant/gateway.py
+++ b/backend/app/features/assistant/gateway.py
@@ -55,7 +55,7 @@ class AIGateway(ABC):
         self,
         content: str,
         question: str,
-        history: list[dict] | None = None,
+        history: list[BedrockMessage] | None = None,
         model_id: str | None = None,
         language: str = "auto",
     ) -> tuple[str, int]:
@@ -174,7 +174,7 @@ class BedrockGateway(AIGateway):
         self,
         content: str,
         question: str,
-        history: list[dict] | None = None,
+        history: list[BedrockMessage] | None = None,
         model_id: str | None = None,
         language: str = "auto",
     ) -> tuple[str, int]:
@@ -191,13 +191,7 @@ class BedrockGateway(AIGateway):
         messages = []
         if history:
             # 過去の会話履歴をメッセージリストに展開する
-            for item in history:
-                messages.append(
-                    {
-                        "role": item.get("role", "user"),
-                        "content": item.get("content", ""),
-                    }
-                )
+            messages.extend([msg.model_dump() for msg in history])
 
         messages.append(
             {

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -6,12 +6,20 @@
 呼び出し関係: router.py のエンドポイント関数から参照される。
 """
 
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from app.models import AIEditJobRead
 from app.models.enums import ChatScope
+
+
+class BedrockMessage(BaseModel):
+    """Bedrockへ送信する単一の会話ターンを表すモデル。"""
+
+    role: Literal["user", "assistant"]
+    content: str
 
 
 class SummarizeRequest(BaseModel):
@@ -39,7 +47,7 @@ class ChatRequest(BaseModel):
     note_id: UUID | None = None
     folder_id: UUID | None = None
     question: str
-    history: list[dict] | None = None
+    history: list[BedrockMessage] | None = None
     selected_content: str | None = None
 
 

--- a/backend/app/features/assistant/use_cases/ai_interactions.py
+++ b/backend/app/features/assistant/use_cases/ai_interactions.py
@@ -58,7 +58,7 @@ class AIInteractionUseCases:
         *,
         scope: ChatScope,
         question: str,
-        history: list[dict] | None = None,
+        history: list[BedrockMessage] | None = None,
         note_id: UUID | None = None,
         folder_id: UUID | None = None,
         selected_content: str | None = None,


### PR DESCRIPTION
## Summary

- Add `BedrockMessage` Pydantic model (`role: Literal["user", "assistant"]`, `content: str`) to `schemas.py`
- Replace all `history: list[dict] | None` annotations in `ChatRequest`, `AIGateway.chat`, `BedrockGateway.chat`, and `chat_with_context` with `list[BedrockMessage] | None`
- Convert typed history to dicts for the Bedrock API using `[msg.model_dump() for msg in history]`, removing the previous unsafe `.get()` fallbacks

## Test plan

- [ ] Confirm existing chat endpoint tests pass (`make test-backend`)
- [ ] Send a chat request with a multi-turn `history` payload and verify the correct `role`/`content` values reach Bedrock
- [ ] Confirm that an invalid `role` value (e.g. `"system"`) in `history` is rejected at the schema layer with a 422 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)