### PR TITLE
fix: cap admin user search query length to prevent oversized DB queries

### DIFF
--- a/backend/app/features/admin/router.py
+++ b/backend/app/features/admin/router.py
@@ -32,7 +32,7 @@ def get_admin_me(admin_user: AdminUser):
 def list_admin_users(
     admin_user: AdminUser,
     use_cases: Annotated[AdminUseCases, Depends(get_admin_use_cases)],
-    q: str | None = Query(default=None, min_length=1),
+    q: str | None = Query(default=None, min_length=1, max_length=200),
     admin_only: bool | None = Query(default=None),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),


### PR DESCRIPTION
## Summary
- Added `max_length=200` to the `q` query parameter in the admin users list endpoint
- Without this limit, an attacker could send arbitrarily long search strings, causing expensive LIKE queries on the database

## Test plan
- [ ] Verify requests with q longer than 200 chars return 422
- [ ] Verify normal searches still work

🤖 Generated with Claude Code