### PR TITLE
fix: replace error.detail with generic message in unhandled DomainError 500 handler

### DIFF
--- a/backend/app/http_errors.py
+++ b/backend/app/http_errors.py
@@ -6,7 +6,11 @@
     app.shared のドメインエラー群を参照する。
 """
 
+import logging
+
 from fastapi import HTTPException, status
+
+logger = logging.getLogger(__name__)
 
 from app.shared import (
     ConflictDetected,
@@ -39,7 +43,8 @@ def to_http_exception(error: DomainError) -> HTTPException:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=error.detail,
         )
+    logger.error("Unhandled DomainError type %s: %s", type(error).__name__, error.detail)
     return HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=error.detail,
+        detail="An internal error occurred.",
     )


### PR DESCRIPTION
## Summary

- Unknown `DomainError` subclasses previously fell through to a 500 handler that exposed `error.detail` directly to the client, potentially leaking sensitive internal information.
- The fallback now logs the error type and detail server-side via `logger.error(...)` and returns a generic `"An internal error occurred."` message to the client instead.
- Added `import logging` and `logger = logging.getLogger(__name__)` to `backend/app/http_errors.py`.

## Security impact

Before: any unhandled `DomainError` subclass would send its raw `.detail` string in the HTTP 500 response body — visible to API consumers.  
After: the detail is logged internally only; the client receives a non-descriptive generic message.

## Test plan

- [ ] Confirm existing tests still pass: `make test-backend`
- [ ] Add a unit test that raises an unknown `DomainError` subclass through `to_http_exception` and asserts the response `detail` is `"An internal error occurred."` and does not contain the original detail string
- [ ] Verify the error is still logged at `ERROR` level by inspecting log output in a local run

🤖 Generated with [Claude Code](https://claude.com/claude-code)