### PR TITLE
fix: support SES email sending in Cognito user pool to lift 50/day limit

### DIFF
--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -26,7 +26,9 @@ resource "aws_cognito_user_pool" "main" {
 
   # Email configuration
   email_configuration {
-    email_sending_account = "COGNITO_DEFAULT"
+    email_sending_account = var.ses_email_identity_arn != "" ? "DEVELOPER" : "COGNITO_DEFAULT"
+    source_arn            = var.ses_email_identity_arn != "" ? var.ses_email_identity_arn : null
+    from_email_address    = var.cognito_from_email != "" ? var.cognito_from_email : null
   }
 
   # Schema attributes

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,6 +63,18 @@ variable "bootstrap_admin_user_ids" {
   default     = ""
 }
 
+variable "ses_email_identity_arn" {
+  description = "ARN of the SES verified email identity for Cognito user pool emails"
+  type        = string
+  default     = ""
+}
+
+variable "cognito_from_email" {
+  description = "From email address for Cognito user pool emails (must be verified in SES)"
+  type        = string
+  default     = ""
+}
+
 variable "sentry_traces_sample_rate" {
   description = "Optional backend Sentry trace sample rate override"
   type        = number


### PR DESCRIPTION
## Summary
- Added `ses_email_identity_arn` and `cognito_from_email` Terraform variables
- When `ses_email_identity_arn` is set, Cognito switches to SES (`DEVELOPER` mode) with no daily limit
- Falls back to `COGNITO_DEFAULT` when variable is empty, so existing deployments are unaffected

## Test plan
- [ ] Verify plan applies cleanly without `ses_email_identity_arn` (backward compatible)
- [ ] Verify SES mode activates when variables are set in `terraform.tfvars`

🤖 Generated with Claude Code