### PR TITLE
fix: allow Sentry CORS headers and migrate delete dialogs to modal confirm

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,14 @@ app.add_middleware(
     allow_origins=settings_app.cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Request-ID"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "X-API-Key",
+        "X-Request-ID",
+        "baggage",
+        "sentry-trace",
+    ],
 )
 
 # 各機能ルーターをAPIパスプレフィックスに紐付けて登録

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig, devices } from '@playwright/test';
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -9,26 +9,27 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-dotenv.config({ path: path.resolve(__dirname, '.env.local') });
+dotenv.config({ path: path.resolve(__dirname, ".env.local") });
 
 /**
  * environment URL mapping
  */
 const ENV_URLS = {
-  local: 'http://localhost:3000',
-  dev: 'https://notes.dev.devtools.site',
-  prd: 'https://notes.devtools.site',
+  local: "http://localhost:3000",
+  dev: "https://notes.dev.devtools.site",
+  prd: "https://notes.devtools.site",
 };
 
-const targetEnv = (process.env.E2E_TARGET || 'local') as keyof typeof ENV_URLS;
+const targetEnv = (process.env.E2E_TARGET || "local") as keyof typeof ENV_URLS;
 const baseURL = ENV_URLS[targetEnv] || targetEnv; // Allow passing a raw URL
 
 // In local mode, inject bypass flag so the frontend skips Cognito login
-const isLocalBypass = targetEnv === 'local' || baseURL.includes('localhost');
+const isLocalBypass = targetEnv === "local" || baseURL.includes("localhost");
 if (isLocalBypass) {
-  process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS = 'true';
-  process.env.NEXT_PUBLIC_ENVIRONMENT = process.env.NEXT_PUBLIC_ENVIRONMENT || 'local';
-  process.env.NEXT_PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS = "true";
+  process.env.NEXT_PUBLIC_ENVIRONMENT =
+    process.env.NEXT_PUBLIC_ENVIRONMENT || "local";
+  process.env.NEXT_PUBLIC_API_URL = "http://localhost:8000";
 }
 
 console.log(`[E2E] Target Environment: ${targetEnv}`);
@@ -39,8 +40,8 @@ console.log(`[E2E] Auth bypass: ${isLocalBypass}`);
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './tests',
-  timeout: targetEnv !== 'local' ? 60000 : 30000,
+  testDir: "./tests",
+  timeout: targetEnv !== "local" ? 60000 : 30000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -50,15 +51,15 @@ export default defineConfig({
   /* Limit workers to avoid overwhelming the dev API under concurrent browser projects */
   workers: process.env.CI ? 1 : 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-    
+    trace: "on-first-retry",
+
     /* Accessibility-first best practice: headless is true by default */
     headless: true,
   },
@@ -70,55 +71,66 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     // In local bypass mode, skip the auth setup project — no login needed
-    ...(isLocalBypass ? [] : [{ name: 'setup', testMatch: /.*\.setup\.ts/ }]),
+    ...(isLocalBypass ? [] : [{ name: "setup", testMatch: /.*\.setup\.ts/ }]),
 
     {
-      name: 'chromium',
+      name: "chromium",
       use: {
-        ...devices['Desktop Chrome'],
-        ...(isLocalBypass ? {} : { storageState: 'playwright/.auth/user.json' }),
+        ...devices["Desktop Chrome"],
+        ...(isLocalBypass
+          ? {}
+          : { storageState: "playwright/.auth/user.json" }),
       },
-      ...(isLocalBypass ? {} : { dependencies: ['setup'] }),
+      ...(isLocalBypass ? {} : { dependencies: ["setup"] }),
     },
 
     {
-      name: 'webkit',
+      name: "webkit",
       use: {
-        ...devices['Desktop Safari'],
-        ...(isLocalBypass ? {} : { storageState: 'playwright/.auth/user.json' }),
+        ...devices["Desktop Safari"],
+        ...(isLocalBypass
+          ? {}
+          : { storageState: "playwright/.auth/user.json" }),
       },
-      ...(isLocalBypass ? {} : { dependencies: ['setup'] }),
+      ...(isLocalBypass ? {} : { dependencies: ["setup"] }),
     },
 
     /* Test against mobile viewports. */
     {
-      name: 'Mobile Chrome',
+      name: "Mobile Chrome",
       use: {
-        ...devices['Pixel 5'],
-        ...(isLocalBypass ? {} : { storageState: 'playwright/.auth/user.json' }),
+        ...devices["Pixel 5"],
+        ...(isLocalBypass
+          ? {}
+          : { storageState: "playwright/.auth/user.json" }),
       },
-      ...(isLocalBypass ? {} : { dependencies: ['setup'] }),
+      ...(isLocalBypass ? {} : { dependencies: ["setup"] }),
     },
     {
-      name: 'Mobile Safari',
+      name: "Mobile Safari",
       use: {
-        ...devices['iPhone 12'],
-        ...(isLocalBypass ? {} : { storageState: 'playwright/.auth/user.json' }),
+        ...devices["iPhone 12"],
+        ...(isLocalBypass
+          ? {}
+          : { storageState: "playwright/.auth/user.json" }),
       },
-      ...(isLocalBypass ? {} : { dependencies: ['setup'] }),
+      ...(isLocalBypass ? {} : { dependencies: ["setup"] }),
     },
   ],
 
   /* Run your local dev server before starting the tests ONLY if targeting local */
   /* Note: in local mode the backend must already be running via `make dev-stack-backend` */
-  webServer: isLocalBypass ? {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    env: {
-      NEXT_PUBLIC_DEV_AUTH_BYPASS: 'true',
-      NEXT_PUBLIC_ENVIRONMENT: 'local',
-      NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
-    },
-  } : undefined,
+  webServer: isLocalBypass
+    ? {
+        command: "npm run dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: !process.env.CI,
+        env: {
+          NEXT_PUBLIC_DEV_AUTH_BYPASS: "true",
+          NEXT_PUBLIC_ENVIRONMENT: "local",
+          NEXT_PUBLIC_API_URL:
+            process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+        },
+      }
+    : undefined,
 });

--- a/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
@@ -105,6 +105,7 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
 
     return () => {
       isActive = false;
+      hasFetchedRef.current = false;
     };
   }, [authLoading, getApi, isAuthenticated]);
 

--- a/frontend/tests/golden-path.spec.ts
+++ b/frontend/tests/golden-path.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect, type Locator, type Page, type Response } from '@playwright/test';
+import {
+  test,
+  expect,
+  type Locator,
+  type Page,
+  type Response,
+} from "@playwright/test";
 
 import {
   createFolderFixture,
@@ -8,10 +14,13 @@ import {
   getNoteFixture,
   waitForNoteContentFixture,
   waitForWorkspaceSnapshotReady,
-} from './helpers/apiFixtures';
-import { getAppliedEntityId, waitForWorkspaceChange } from './helpers/workspaceSync';
+} from "./helpers/apiFixtures";
+import {
+  getAppliedEntityId,
+  waitForWorkspaceChange,
+} from "./helpers/workspaceSync";
 
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: "serial" });
 
 const SNAPSHOT_RESPONSE_TIMEOUT_MS = 45000;
 const SNAPSHOT_WARMUP_OPTIONS = {
@@ -33,7 +42,7 @@ function createCleanupState(): CleanupState {
 }
 
 async function getSnapshotFailureDetails(response: Response): Promise<string> {
-  const body = await response.text().catch(() => '');
+  const body = await response.text().catch(() => "");
   return `${response.status()} ${body}`;
 }
 
@@ -43,27 +52,30 @@ async function reloadAndWaitForSnapshot(page: Page): Promise<void> {
   for (let attempt = 1; attempt <= 3; attempt++) {
     const snapshotPromise = page.waitForResponse(
       (response) =>
-        response.url().includes('/api/workspace/snapshot') &&
-        response.request().method() === 'GET',
-      { timeout: SNAPSHOT_RESPONSE_TIMEOUT_MS }
+        response.url().includes("/api/workspace/snapshot") &&
+        response.request().method() === "GET",
+      { timeout: SNAPSHOT_RESPONSE_TIMEOUT_MS },
     );
 
-    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.reload({ waitUntil: "domcontentloaded" });
 
     try {
       const response = await snapshotPromise;
       if (response.status() === 200) {
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState("networkidle");
         return;
       }
 
       const details = await getSnapshotFailureDetails(response);
-      lastError = new Error(`Snapshot reload attempt ${attempt} failed: ${details}`);
+      lastError = new Error(
+        `Snapshot reload attempt ${attempt} failed: ${details}`,
+      );
       console.log(`[Golden Path] ${lastError.message}`);
     } catch (error) {
-      lastError = error instanceof Error
-        ? error
-        : new Error(`Snapshot reload attempt ${attempt} timed out`);
+      lastError =
+        error instanceof Error
+          ? error
+          : new Error(`Snapshot reload attempt ${attempt} timed out`);
       console.log(`[Golden Path] ${lastError.message}`);
     }
 
@@ -78,7 +90,7 @@ async function reloadAndWaitForSnapshot(page: Page): Promise<void> {
     }
   }
 
-  throw lastError ?? new Error('Workspace snapshot never became ready');
+  throw lastError ?? new Error("Workspace snapshot never became ready");
 }
 
 async function prepareWorkspaceUi(page: Page): Promise<void> {
@@ -90,13 +102,15 @@ async function waitForVisibleWithReload(
   page: Page,
   locator: Locator,
   label: string,
-  afterReload?: () => Promise<void>
+  afterReload?: () => Promise<void>,
 ): Promise<void> {
   try {
     await expect(locator).toBeVisible({ timeout: 20000 });
     return;
   } catch {
-    console.log(`[Golden Path] ${label} not visible, retrying after snapshot warmup`);
+    console.log(
+      `[Golden Path] ${label} not visible, retrying after snapshot warmup`,
+    );
     await prepareWorkspaceUi(page);
     if (afterReload) {
       await afterReload();
@@ -106,34 +120,40 @@ async function waitForVisibleWithReload(
 }
 
 async function expectVisibleSyncStatus(layout: Locator): Promise<void> {
-  const syncStatus = layout.getByTestId('sync-status');
+  const syncStatus = layout.getByTestId("sync-status");
   await expect(syncStatus).toBeVisible({ timeout: 60000 });
-  await expect(syncStatus).toHaveText(/Saved|保存しました|Saved locally|ローカルに保存/i, {
-    timeout: 60000,
-  });
+  await expect(syncStatus).toHaveText(
+    /Saved|保存しました|Saved locally|ローカルに保存/i,
+    {
+      timeout: 60000,
+    },
+  );
 }
 
-test.describe('Golden Path: Note Lifecycle', () => {
-  test.skip(({ isMobile }) => isMobile, 'Desktop-only golden-path tests');
+test.describe("Golden Path: Note Lifecycle", () => {
+  test.skip(({ isMobile }) => isMobile, "Desktop-only golden-path tests");
 
   let cleanupState: CleanupState = createCleanupState();
 
-  const trackFolder = (folderId: string) => cleanupState.folderIds.add(folderId);
+  const trackFolder = (folderId: string) =>
+    cleanupState.folderIds.add(folderId);
   const trackNote = (noteId: string) => cleanupState.noteIds.add(noteId);
-  const markFolderDeleted = (folderId: string) => cleanupState.folderIds.delete(folderId);
-  const markNoteDeleted = (noteId: string) => cleanupState.noteIds.delete(noteId);
+  const markFolderDeleted = (folderId: string) =>
+    cleanupState.folderIds.delete(folderId);
+  const markNoteDeleted = (noteId: string) =>
+    cleanupState.noteIds.delete(noteId);
 
   test.beforeAll(async ({ browser, baseURL }) => {
     test.setTimeout(120000);
     const context = await browser.newContext(
-      process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS === 'true'
+      process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS === "true"
         ? {}
-        : { storageState: 'playwright/.auth/user.json' }
+        : { storageState: "playwright/.auth/user.json" },
     );
     const page = await context.newPage();
 
     try {
-      await page.goto(baseURL ?? '/');
+      await page.goto(baseURL ?? "/");
       await waitForWorkspaceSnapshotReady(page, SNAPSHOT_WARMUP_OPTIONS);
     } finally {
       await context.close();
@@ -153,7 +173,9 @@ test.describe('Golden Path: Note Lifecycle', () => {
       try {
         await deleteNoteFixture(page, noteId);
       } catch (error) {
-        console.log(`[Golden Path] Cleanup note ${noteId} failed: ${String(error)}`);
+        console.log(
+          `[Golden Path] Cleanup note ${noteId} failed: ${String(error)}`,
+        );
       }
     }
 
@@ -161,132 +183,185 @@ test.describe('Golden Path: Note Lifecycle', () => {
       try {
         await deleteFolderFixture(page, folderId);
       } catch (error) {
-        console.log(`[Golden Path] Cleanup folder ${folderId} failed: ${String(error)}`);
+        console.log(
+          `[Golden Path] Cleanup folder ${folderId} failed: ${String(error)}`,
+        );
       }
     }
   });
 
-  test('should edit note content and delete it via editor toolbar', async ({ page, browserName }) => {
-    if (browserName === 'webkit') test.skip();
+  test("should edit note content and delete it via editor toolbar", async ({
+    page,
+    browserName,
+  }) => {
+    if (browserName === "webkit") test.skip();
     test.setTimeout(300000);
 
     const noteTitle = `Golden Path Note ${Date.now()}`;
-    const noteContent = 'Initial content for golden path test.';
+    const noteContent = "Initial content for golden path test.";
     const updatedTitle = `${noteTitle} (edited)`;
-    const updatedContent = 'Updated content - verified by golden path test.';
+    const updatedContent = "Updated content - verified by golden path test.";
 
-    await page.goto('/');
-    const note = await createNoteFixture(page, { title: noteTitle, content: noteContent });
+    await page.goto("/");
+    const note = await createNoteFixture(page, {
+      title: noteTitle,
+      content: noteContent,
+    });
     trackNote(note.id);
 
     await prepareWorkspaceUi(page);
 
-    const layout = page.getByTestId('desktop-layout');
-    await layout.getByTestId('sidebar-nav-all-notes').click();
+    const layout = page.getByTestId("desktop-layout");
+    await layout.getByTestId("sidebar-nav-all-notes").click();
 
-    const noteItem = layout.locator('[data-testid^="note-list-item-"]').filter({ hasText: noteTitle }).first();
-    await waitForVisibleWithReload(page, noteItem, 'note in All Notes', async () => {
-      await layout.getByTestId('sidebar-nav-all-notes').click();
-    });
+    const noteItem = layout
+      .locator('[data-testid^="note-list-item-"]')
+      .filter({ hasText: noteTitle })
+      .first();
+    await waitForVisibleWithReload(
+      page,
+      noteItem,
+      "note in All Notes",
+      async () => {
+        await layout.getByTestId("sidebar-nav-all-notes").click();
+      },
+    );
     await noteItem.click();
 
-    const titleInput = layout.getByTestId('editor-title-input');
-    const contentInput = layout.getByTestId('editor-content-input');
+    const titleInput = layout.getByTestId("editor-title-input");
+    const contentInput = layout.getByTestId("editor-content-input");
     await expect(titleInput).toHaveValue(noteTitle, { timeout: 30000 });
     await expect(contentInput).toContainText(noteContent, { timeout: 30000 });
 
-    console.log('[Golden Path] Editing note title and content');
+    console.log("[Golden Path] Editing note title and content");
     await titleInput.fill(updatedTitle);
     // CodeMirror 6 ignores fill()/keyboard.type() — it manages content via transactions.
     // Access CM6's EditorView via the internal .cmTile.view DOM property and dispatch a
     // replace-all transaction so the change propagates through React state → API sync.
     await page.evaluate((content) => {
       const el = document.querySelector('[data-testid="editor-content-input"]');
-      const tile = (el as unknown as Record<string, unknown>)?.['cmTile'] as Record<string, unknown> | undefined;
-      const view = tile?.['view'] as { dispatch: (t: unknown) => void; state: { doc: { length: number } } } | undefined;
+      const tile = (el as unknown as Record<string, unknown>)?.["cmTile"] as
+        | Record<string, unknown>
+        | undefined;
+      const view = tile?.["view"] as
+        | { dispatch: (t: unknown) => void; state: { doc: { length: number } } }
+        | undefined;
       if (!view) return;
-      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: content } });
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: content },
+      });
     }, updatedContent);
-    const updateResponse = waitForWorkspaceChange(page, 'note', 'update', 60000);
+    const updateResponse = waitForWorkspaceChange(
+      page,
+      "note",
+      "update",
+      60000,
+    );
     await contentInput.blur();
     await updateResponse;
 
     await expectVisibleSyncStatus(layout);
 
-    console.log('[Golden Path] Verifying API persistence');
+    console.log("[Golden Path] Verifying API persistence");
     await waitForNoteContentFixture(page, note.id, updatedContent, 30000);
     const persisted = await getNoteFixture(page, note.id);
     expect(persisted.title).toBe(updatedTitle);
 
-    console.log('[Golden Path] Deleting note via editor toolbar');
-    page.once('dialog', (dialog) => dialog.accept());
-    const deleteButton = layout.getByTestId('editor-delete-note-button');
+    console.log("[Golden Path] Deleting note via editor toolbar");
+    const deleteButton = layout.getByTestId("editor-delete-note-button");
     await expect(deleteButton).toBeVisible({ timeout: 10000 });
 
-    const deleteResponse = waitForWorkspaceChange(page, 'note', 'delete', 60000);
+    const deleteResponse = waitForWorkspaceChange(
+      page,
+      "note",
+      "delete",
+      60000,
+    );
     await deleteButton.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
     await deleteResponse;
     markNoteDeleted(note.id);
 
     await expect(noteItem).not.toBeVisible({ timeout: 15000 });
   });
 
-  test('should rename and delete a folder via sidebar', async ({ page, browserName }) => {
-    if (browserName === 'webkit') test.skip();
+  test("should rename and delete a folder via sidebar", async ({
+    page,
+    browserName,
+  }) => {
+    if (browserName === "webkit") test.skip();
     test.setTimeout(300000);
 
     const folderName = `Rename Me ${Date.now()}`;
     const renamedFolderName = `Renamed Folder ${Date.now()}`;
 
-    await page.goto('/');
+    await page.goto("/");
     const folder = await createFolderFixture(page, folderName);
     trackFolder(folder.id);
 
     await prepareWorkspaceUi(page);
 
-    const layout = page.getByTestId('desktop-layout');
+    const layout = page.getByTestId("desktop-layout");
     const folderItem = layout.getByTestId(`sidebar-folder-item-${folder.id}`);
-    await waitForVisibleWithReload(page, folderItem, `folder ${folder.id} in sidebar`);
+    await waitForVisibleWithReload(
+      page,
+      folderItem,
+      `folder ${folder.id} in sidebar`,
+    );
 
-    console.log('[Golden Path] Renaming folder');
+    console.log("[Golden Path] Renaming folder");
     await folderItem.hover();
-    const renameButton = folderItem.getByTestId('sidebar-folder-rename-button');
+    const renameButton = folderItem.getByTestId("sidebar-folder-rename-button");
     await expect(renameButton).toBeVisible({ timeout: 5000 });
     await renameButton.click();
 
-    const editInput = layout.getByTestId('sidebar-folder-edit-input');
+    const editInput = layout.getByTestId("sidebar-folder-edit-input");
     await expect(editInput).toBeVisible({ timeout: 5000 });
     await editInput.fill(renamedFolderName);
 
-    const renameResponse = waitForWorkspaceChange(page, 'folder', 'update', 60000);
-    await editInput.press('Enter');
+    const renameResponse = waitForWorkspaceChange(
+      page,
+      "folder",
+      "update",
+      60000,
+    );
+    await editInput.press("Enter");
     await renameResponse;
 
-    await expect(folderItem).toContainText(renamedFolderName, { timeout: 15000 });
+    await expect(folderItem).toContainText(renamedFolderName, {
+      timeout: 15000,
+    });
 
-    console.log('[Golden Path] Deleting folder via sidebar');
+    console.log("[Golden Path] Deleting folder via sidebar");
     await folderItem.hover();
-    const deleteButton = folderItem.getByTestId('sidebar-folder-delete-button');
+    const deleteButton = folderItem.getByTestId("sidebar-folder-delete-button");
     await expect(deleteButton).toBeVisible({ timeout: 5000 });
 
-    page.once('dialog', (dialog) => dialog.accept());
-    const deleteResponse = waitForWorkspaceChange(page, 'folder', 'delete', 60000);
+    const deleteResponse = waitForWorkspaceChange(
+      page,
+      "folder",
+      "delete",
+      60000,
+    );
     await deleteButton.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
     await deleteResponse;
     markFolderDeleted(folder.id);
 
     await expect(folderItem).not.toBeVisible({ timeout: 15000 });
   });
 
-  test('should move a note between folders via editor dropdown', async ({ page }) => {
+  test("should move a note between folders via editor dropdown", async ({
+    page,
+  }) => {
     test.setTimeout(300000);
 
     const folderAName = `Folder A ${Date.now()}`;
     const folderBName = `Folder B ${Date.now()}`;
     const noteTitle = `Move Me ${Date.now()}`;
-    const noteContent = 'Note to be moved between folders.';
+    const noteContent = "Note to be moved between folders.";
 
-    await page.goto('/');
+    await page.goto("/");
     const folderA = await createFolderFixture(page, folderAName);
     const folderB = await createFolderFixture(page, folderBName);
     const note = await createNoteFixture(page, {
@@ -300,131 +375,196 @@ test.describe('Golden Path: Note Lifecycle', () => {
 
     await prepareWorkspaceUi(page);
 
-    const layout = page.getByTestId('desktop-layout');
+    const layout = page.getByTestId("desktop-layout");
     const folderAItem = layout.getByTestId(`sidebar-folder-item-${folderA.id}`);
-    await waitForVisibleWithReload(page, folderAItem, `folder A ${folderA.id} in sidebar`);
+    await waitForVisibleWithReload(
+      page,
+      folderAItem,
+      `folder A ${folderA.id} in sidebar`,
+    );
     await folderAItem.click();
 
-    const noteItem = layout.locator('[data-testid^="note-list-item-"]').filter({ hasText: noteTitle }).first();
+    const noteItem = layout
+      .locator('[data-testid^="note-list-item-"]')
+      .filter({ hasText: noteTitle })
+      .first();
     await expect(noteItem).toBeVisible({ timeout: 30000 });
     await noteItem.click();
 
-    await expect(layout.getByTestId('editor-title-input')).toHaveValue(noteTitle, { timeout: 30000 });
+    await expect(layout.getByTestId("editor-title-input")).toHaveValue(
+      noteTitle,
+      { timeout: 30000 },
+    );
 
-    console.log('[Golden Path] Opening editor folder dropdown');
-    const folderDropdown = layout.getByTestId('editor-folder-dropdown');
+    console.log("[Golden Path] Opening editor folder dropdown");
+    const folderDropdown = layout.getByTestId("editor-folder-dropdown");
     await expect(folderDropdown).toBeVisible({ timeout: 10000 });
     await folderDropdown.click();
 
-    const updateResponse = waitForWorkspaceChange(page, 'note', 'update', 60000);
-    await page.getByRole('button', { name: folderBName, exact: true }).last().click();
+    const updateResponse = waitForWorkspaceChange(
+      page,
+      "note",
+      "update",
+      60000,
+    );
+    await page
+      .getByRole("button", { name: folderBName, exact: true })
+      .last()
+      .click();
     await updateResponse;
 
     const folderBItem = layout.getByTestId(`sidebar-folder-item-${folderB.id}`);
     await expect(folderBItem).toBeVisible({ timeout: 30000 });
     await folderBItem.click();
 
-    const noteInFolderB = layout.locator('[data-testid^="note-list-item-"]').filter({ hasText: noteTitle }).first();
+    const noteInFolderB = layout
+      .locator('[data-testid^="note-list-item-"]')
+      .filter({ hasText: noteTitle })
+      .first();
     await expect(noteInFolderB).toBeVisible({ timeout: 30000 });
 
     await folderAItem.click();
-    const noteInFolderA = layout.locator('[data-testid^="note-list-item-"]').filter({ hasText: noteTitle }).first();
+    const noteInFolderA = layout
+      .locator('[data-testid^="note-list-item-"]')
+      .filter({ hasText: noteTitle })
+      .first();
     await expect(noteInFolderA).not.toBeVisible({ timeout: 10000 });
   });
 
-  test('should export a note as markdown', async ({ page, browserName }) => {
-    if (browserName === 'webkit') test.skip();
+  test("should export a note as markdown", async ({ page, browserName }) => {
+    if (browserName === "webkit") test.skip();
     test.setTimeout(300000);
 
     const noteTitle = `Export Test ${Date.now()}`;
-    const noteContent = '# Export Me\n\nThis note should be downloadable as Markdown.';
+    const noteContent =
+      "# Export Me\n\nThis note should be downloadable as Markdown.";
 
-    await page.goto('/');
-    const note = await createNoteFixture(page, { title: noteTitle, content: noteContent });
+    await page.goto("/");
+    const note = await createNoteFixture(page, {
+      title: noteTitle,
+      content: noteContent,
+    });
     trackNote(note.id);
 
     await prepareWorkspaceUi(page);
 
-    const layout = page.getByTestId('desktop-layout');
-    await layout.getByTestId('sidebar-nav-all-notes').click();
+    const layout = page.getByTestId("desktop-layout");
+    await layout.getByTestId("sidebar-nav-all-notes").click();
 
-    const noteItem = layout.locator('[data-testid^="note-list-item-"]').filter({ hasText: noteTitle }).first();
-    await waitForVisibleWithReload(page, noteItem, 'export note in All Notes', async () => {
-      await layout.getByTestId('sidebar-nav-all-notes').click();
-    });
+    const noteItem = layout
+      .locator('[data-testid^="note-list-item-"]')
+      .filter({ hasText: noteTitle })
+      .first();
+    await waitForVisibleWithReload(
+      page,
+      noteItem,
+      "export note in All Notes",
+      async () => {
+        await layout.getByTestId("sidebar-nav-all-notes").click();
+      },
+    );
     await noteItem.click();
-    await expect(layout.getByTestId('editor-title-input')).toHaveValue(noteTitle, { timeout: 30000 });
+    await expect(layout.getByTestId("editor-title-input")).toHaveValue(
+      noteTitle,
+      { timeout: 30000 },
+    );
 
-    console.log('[Golden Path] Triggering markdown export');
-    const exportDropdown = layout.getByTestId('editor-export-dropdown');
+    console.log("[Golden Path] Triggering markdown export");
+    const exportDropdown = layout.getByTestId("editor-export-dropdown");
     await expect(exportDropdown).toBeVisible({ timeout: 10000 });
     await exportDropdown.click();
 
-    const downloadPromise = page.waitForEvent('download', { timeout: 15000 });
-    await layout.getByTestId('editor-export-markdown').click();
+    const downloadPromise = page.waitForEvent("download", { timeout: 15000 });
+    await layout.getByTestId("editor-export-markdown").click();
     const download = await downloadPromise;
 
     expect(download.suggestedFilename()).toMatch(/\.md$/i);
   });
 
-  test('should create a note in a new folder and delete the folder', async ({ page, browserName }) => {
-    if (browserName === 'webkit') test.skip();
+  test("should create a note in a new folder and delete the folder", async ({
+    page,
+    browserName,
+  }) => {
+    if (browserName === "webkit") test.skip();
     test.setTimeout(300000);
 
     const folderName = `New UI Folder ${Date.now()}`;
 
-    await page.goto('/');
+    await page.goto("/");
     await prepareWorkspaceUi(page);
 
-    const layout = page.getByTestId('desktop-layout');
+    const layout = page.getByTestId("desktop-layout");
 
-    console.log('[Golden Path] Creating folder via UI');
-    const addFolderButton = layout.getByTestId('sidebar-add-folder-button');
+    console.log("[Golden Path] Creating folder via UI");
+    const addFolderButton = layout.getByTestId("sidebar-add-folder-button");
     await expect(addFolderButton).toBeVisible({ timeout: 30000 });
     await addFolderButton.click();
 
-    const newFolderInput = layout.getByTestId('sidebar-new-folder-input');
+    const newFolderInput = layout.getByTestId("sidebar-new-folder-input");
     await expect(newFolderInput).toBeVisible({ timeout: 5000 });
     await newFolderInput.fill(folderName);
 
-    const createFolderResponse = waitForWorkspaceChange(page, 'folder', 'create', 60000);
-    await layout.getByTestId('sidebar-new-folder-confirm').click();
+    const createFolderResponse = waitForWorkspaceChange(
+      page,
+      "folder",
+      "create",
+      60000,
+    );
+    await layout.getByTestId("sidebar-new-folder-confirm").click();
     const createdFolderId = await createFolderResponse.then((response) =>
-      getAppliedEntityId(response, 'folder', 'create')
+      getAppliedEntityId(response, "folder", "create"),
     );
     trackFolder(createdFolderId);
 
-    const folderItem = layout.getByTestId(`sidebar-folder-item-${createdFolderId}`);
+    const folderItem = layout.getByTestId(
+      `sidebar-folder-item-${createdFolderId}`,
+    );
     await expect(folderItem).toBeVisible({ timeout: 30000 });
     await folderItem.click();
 
-    console.log('[Golden Path] Creating note in folder via UI');
-    const addNoteButton = layout.getByTestId('note-list-add-note-button');
+    console.log("[Golden Path] Creating note in folder via UI");
+    const addNoteButton = layout.getByTestId("note-list-add-note-button");
     await expect(addNoteButton).toBeVisible({ timeout: 15000 });
 
-    const createNoteResponse = waitForWorkspaceChange(page, 'note', 'create', 60000);
+    const createNoteResponse = waitForWorkspaceChange(
+      page,
+      "note",
+      "create",
+      60000,
+    );
     await addNoteButton.click();
     const createdNoteId = await createNoteResponse.then((response) =>
-      getAppliedEntityId(response, 'note', 'create')
+      getAppliedEntityId(response, "note", "create"),
     );
     trackNote(createdNoteId);
 
-    const titleInput = layout.getByTestId('editor-title-input');
+    const titleInput = layout.getByTestId("editor-title-input");
     await expect(titleInput).toBeVisible({ timeout: 30000 });
 
     const testNoteTitle = `Folder Note ${Date.now()}`;
     await titleInput.fill(testNoteTitle);
-    const contentInput = layout.getByTestId('editor-content-input');
+    const contentInput = layout.getByTestId("editor-content-input");
     // CodeMirror 6 ignores fill() — dispatch a transaction directly.
     await page.evaluate((content) => {
       const el = document.querySelector('[data-testid="editor-content-input"]');
-      const tile = (el as unknown as Record<string, unknown>)?.['cmTile'] as Record<string, unknown> | undefined;
-      const view = tile?.['view'] as { dispatch: (t: unknown) => void; state: { doc: { length: number } } } | undefined;
+      const tile = (el as unknown as Record<string, unknown>)?.["cmTile"] as
+        | Record<string, unknown>
+        | undefined;
+      const view = tile?.["view"] as
+        | { dispatch: (t: unknown) => void; state: { doc: { length: number } } }
+        | undefined;
       if (!view) return;
-      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: content } });
-    }, 'Content inside the new folder.');
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: content },
+      });
+    }, "Content inside the new folder.");
 
-    const updateResponse = waitForWorkspaceChange(page, 'note', 'update', 60000);
+    const updateResponse = waitForWorkspaceChange(
+      page,
+      "note",
+      "update",
+      60000,
+    );
     await contentInput.blur();
     await updateResponse;
 
@@ -435,13 +575,20 @@ test.describe('Golden Path: Note Lifecycle', () => {
     const noteItem = layout.getByTestId(`note-list-item-${createdNoteId}`);
     await expect(noteItem).toBeVisible({ timeout: 30000 });
 
-    console.log('[Golden Path] Deleting folder via NoteList header');
-    const deleteFolderButton = layout.getByTestId('note-list-delete-folder-button');
+    console.log("[Golden Path] Deleting folder via NoteList header");
+    const deleteFolderButton = layout.getByTestId(
+      "note-list-delete-folder-button",
+    );
     await expect(deleteFolderButton).toBeVisible({ timeout: 15000 });
 
-    page.once('dialog', (dialog) => dialog.accept());
-    const deleteFolderResponse = waitForWorkspaceChange(page, 'folder', 'delete', 60000);
+    const deleteFolderResponse = waitForWorkspaceChange(
+      page,
+      "folder",
+      "delete",
+      60000,
+    );
     await deleteFolderButton.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
     await deleteFolderResponse;
     markFolderDeleted(createdFolderId);
     markNoteDeleted(createdNoteId);

--- a/terraform/cloudtrail.tf
+++ b/terraform/cloudtrail.tf
@@ -95,7 +95,7 @@ resource "aws_s3_bucket_policy" "cloudtrail" {
         Resource = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
         Condition = {
           StringEquals = {
-            "s3:x-amz-acl" = "bucket-owner-full-control"
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
             "aws:SourceArn" = "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-trail-${terraform.workspace}"
           }
         }

--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -201,12 +201,12 @@ resource "aws_cloudfront_distribution" "main" {
       }
     }
 
-    viewer_protocol_policy      = "redirect-to-https"
-    min_ttl                     = 0
-    default_ttl                 = 86400
-    max_ttl                     = 31536000
-    compress                    = true
-    response_headers_policy_id  = aws_cloudfront_response_headers_policy.security.id
+    viewer_protocol_policy     = "redirect-to-https"
+    min_ttl                    = 0
+    default_ttl                = 86400
+    max_ttl                    = 31536000
+    compress                   = true
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
   }
 
   default_cache_behavior {
@@ -221,12 +221,12 @@ resource "aws_cloudfront_distribution" "main" {
       }
     }
 
-    viewer_protocol_policy      = "redirect-to-https"
-    min_ttl                     = 0
-    default_ttl                 = 3600
-    max_ttl                     = 86400
-    compress                    = true
-    response_headers_policy_id  = aws_cloudfront_response_headers_policy.security.id
+    viewer_protocol_policy     = "redirect-to-https"
+    min_ttl                    = 0
+    default_ttl                = 3600
+    max_ttl                    = 86400
+    compress                   = true
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
 
     function_association {
       event_type   = "viewer-request"


### PR DESCRIPTION
## 概要

Sentry が自動挿入する `baggage` / `sentry-trace` ヘッダーがバックエンドの CORS `allow_headers` に未登録だったため、ブラウザのプリフライト (OPTIONS) が HTTP 400 を返し、フロントエンドからのスナップショット API 呼び出しが全ブロックされていた。Playwright の `page.request.fetch`（CORS をバイパス）でのテストは通るが実ブラウザでは失敗するという、発見しにくい無音の障害。

## 変更内容

- `backend/app/main.py`: CORS `allow_headers` に `baggage` と `sentry-trace` を追加
- `frontend/tests/golden-path.spec.ts`: 削除確認を `page.once('dialog', accept)` からカスタムモーダルの `getByRole('button', { name: 'Confirm' })` クリックへ移行
- `frontend/playwright.config.ts`: ローカル E2E モード時に `NEXT_PUBLIC_API_URL` をホスト環境の変数で上書きされないよう固定
- `frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts`: エフェクトのクリーンアップ時に `hasFetchedRef.current` をリセットし、依存関係変更後の再フェッチを保証
- `terraform/cloudtrail.tf`, `terraform/s3_cloudfront.tf`: `terraform fmt` による整形

## テスト方法

- [ ] `make test-e2e-dev TEST_ARGS='tests/golden-path.spec.ts'` → 7 passed, 0 failed を確認（修正デプロイ済み）
- [ ] `curl -X OPTIONS https://api.notes.dev.devtools.site/api/workspace/snapshot -H "Access-Control-Request-Headers: baggage, sentry-trace" ...` → HTTP 200 を確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] ユーザー向けテキストの i18n 対応を行った（該当する場合）