### PR TITLE
fix: add sentry-trace and baggage to CORS allow_headers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,14 @@ app.add_middleware(
     allow_origins=settings_app.cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Request-ID"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "X-API-Key",
+        "X-Request-ID",
+        "sentry-trace",
+        "baggage",
+    ],
 )
 
 # 各機能ルーターをAPIパスプレフィックスに紐付けて登録

--- a/terraform/cloudtrail.tf
+++ b/terraform/cloudtrail.tf
@@ -95,7 +95,7 @@ resource "aws_s3_bucket_policy" "cloudtrail" {
         Resource = "${aws_s3_bucket.cloudtrail.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
         Condition = {
           StringEquals = {
-            "s3:x-amz-acl" = "bucket-owner-full-control"
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
             "aws:SourceArn" = "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-trail-${terraform.workspace}"
           }
         }

--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -201,12 +201,12 @@ resource "aws_cloudfront_distribution" "main" {
       }
     }
 
-    viewer_protocol_policy      = "redirect-to-https"
-    min_ttl                     = 0
-    default_ttl                 = 86400
-    max_ttl                     = 31536000
-    compress                    = true
-    response_headers_policy_id  = aws_cloudfront_response_headers_policy.security.id
+    viewer_protocol_policy     = "redirect-to-https"
+    min_ttl                    = 0
+    default_ttl                = 86400
+    max_ttl                    = 31536000
+    compress                   = true
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
   }
 
   default_cache_behavior {
@@ -221,12 +221,12 @@ resource "aws_cloudfront_distribution" "main" {
       }
     }
 
-    viewer_protocol_policy      = "redirect-to-https"
-    min_ttl                     = 0
-    default_ttl                 = 3600
-    max_ttl                     = 86400
-    compress                    = true
-    response_headers_policy_id  = aws_cloudfront_response_headers_policy.security.id
+    viewer_protocol_policy     = "redirect-to-https"
+    min_ttl                    = 0
+    default_ttl                = 3600
+    max_ttl                    = 86400
+    compress                   = true
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
 
     function_association {
       event_type   = "viewer-request"


### PR DESCRIPTION
## 概要

コミット #95（`fix: restrict CORS allow_methods and allow_headers from wildcard to explicit lists`）で FastAPI の `allow_headers` をワイルドカードから明示リストに変更した際、Sentry 分散トレーシングに必要な `sentry-trace` と `baggage` ヘッダーが漏れていた。その結果、本番環境でノートの同期が全件 CORS エラーで失敗するリグレッションが発生した。

## 変更内容

- `backend/app/main.py`: `CORSMiddleware` の `allow_headers` に `sentry-trace` と `baggage` を追加し、API Gateway Terraform の `cors_configuration` と整合させた
- `terraform/cloudtrail.tf`, `terraform/s3_cloudfront.tf`: pre-existing の Terraform フォーマット崩れを修正（`terraform fmt`）

## 障害の流れ

1. Sentry SDK の `browserTracingIntegration` が `tracePropagationTargets`（`api.notes.devtools.site` を含む）にマッチする全リクエストに `sentry-trace` / `baggage` ヘッダーを付加
2. ブラウザが OPTIONS preflight の `Access-Control-Request-Headers` にそれらを含めて送信
3. Starlette の `CORSMiddleware` が許可リストにないヘッダーを検出し **400 Bad Request** を返す
4. ブラウザが「It does not have HTTP ok status」と報告 → 全 API 通信がブロック

## テスト方法

- [ ] 本番 (`notes.devtools.site`) でノート編集 → コンソールに CORS エラーが出ないことを確認
- [ ] `OPTIONS https://api.notes.devtools.site/api/workspace/changes` が 200 を返すことを確認

## チェックリスト

- [ ] テストを追加・更新した
- [x] ドキュメントを更新した（不要）
- [x] ユーザー向けテキストの i18n 対応を行った（該当なし）

> **Note:** この修正は既に `prd` 環境にデプロイ済み（Lambda イメージ `sha256:c8ef460c...`）。