### PR TITLE
fix: persist folder and note-list panel open/close state across reloads

### DIFF
--- a/frontend/src/hooks/usePersistedBoolean.test.ts
+++ b/frontend/src/hooks/usePersistedBoolean.test.ts
@@ -1,0 +1,80 @@
+/**
+ * usePersistedBoolean のユニットテスト。
+ * localStorage の読み書き、デフォルト値、SSR 安全性、関数形セッタを検証する。
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePersistedBoolean } from "./usePersistedBoolean";
+
+const KEY = "test-bool-key";
+
+describe("usePersistedBoolean", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns defaultValue when localStorage is empty", () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY, true));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("returns false as defaultValue when specified", () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY, false));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("reads persisted 'true' from localStorage on mount", async () => {
+    localStorage.setItem(KEY, "true");
+    const { result } = renderHook(() => usePersistedBoolean(KEY, false));
+    await act(async () => {});
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("reads persisted 'false' from localStorage on mount", async () => {
+    localStorage.setItem(KEY, "false");
+    const { result } = renderHook(() => usePersistedBoolean(KEY, true));
+    await act(async () => {});
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("ignores unknown values in localStorage and keeps defaultValue", async () => {
+    localStorage.setItem(KEY, "unknown");
+    const { result } = renderHook(() => usePersistedBoolean(KEY, true));
+    await act(async () => {});
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("setter updates state and persists to localStorage", () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY, true));
+    act(() => {
+      result.current[1](false);
+    });
+    expect(result.current[0]).toBe(false);
+    expect(localStorage.getItem(KEY)).toBe("false");
+  });
+
+  it("setter accepts a function updater (toggle pattern)", () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY, true));
+    act(() => {
+      result.current[1]((v) => !v);
+    });
+    expect(result.current[0]).toBe(false);
+    expect(localStorage.getItem(KEY)).toBe("false");
+
+    act(() => {
+      result.current[1]((v) => !v);
+    });
+    expect(result.current[0]).toBe(true);
+    expect(localStorage.getItem(KEY)).toBe("true");
+  });
+
+  it("different storage keys are independent", async () => {
+    localStorage.setItem("key-a", "true");
+    localStorage.setItem("key-b", "false");
+    const { result: a } = renderHook(() => usePersistedBoolean("key-a", false));
+    const { result: b } = renderHook(() => usePersistedBoolean("key-b", true));
+    await act(async () => {});
+    expect(a.current[0]).toBe(true);
+    expect(b.current[0]).toBe(false);
+  });
+});

--- a/frontend/src/hooks/usePersistedBoolean.ts
+++ b/frontend/src/hooks/usePersistedBoolean.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * ブール値を localStorage に永続化するフック。
+ * SSR 安全: 初期値は defaultValue、マウント後に localStorage を読んで同期する。
+ */
+export function usePersistedBoolean(
+  storageKey: string,
+  defaultValue: boolean
+): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+  const [value, setValue] = useState<boolean>(defaultValue);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const saved = window.localStorage.getItem(storageKey);
+    if (saved === "true") setValue(true);
+    else if (saved === "false") setValue(false);
+  }, [storageKey]);
+
+  const set = useCallback(
+    (next: boolean | ((prev: boolean) => boolean)) => {
+      setValue((prev) => {
+        const resolved = typeof next === "function" ? next(prev) : next;
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(storageKey, String(resolved));
+        }
+        return resolved;
+      });
+    },
+    [storageKey]
+  );
+
+  return [value, set];
+}

--- a/frontend/src/hooks/workspace/useWorkspaceState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.ts
@@ -18,6 +18,7 @@ import { useAIChat } from "@/hooks/useAIChat";
 import { useFolders } from "@/hooks/useFolders";
 import { useNoteFilter } from "@/hooks/useNoteFilter";
 import { useNotes } from "@/hooks/useNotes";
+import { usePersistedBoolean } from "@/hooks/usePersistedBoolean";
 import { useResizable } from "@/hooks/useResizable";
 import { useTokenUsage } from "@/hooks/useTokenUsage";
 import { noteBodyStore } from "@/lib/sync/noteBodyStore";
@@ -35,8 +36,8 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [isChatOpen, setIsChatOpen] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-  const [isNoteListOpen, setIsNoteListOpen] = useState(true);
+  const [isSidebarOpen, setIsSidebarOpen] = usePersistedBoolean("notes-sidebar-open", true);
+  const [isNoteListOpen, setIsNoteListOpen] = usePersistedBoolean("notes-notelist-open", true);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [mobileView, setMobileView] = useState<MobileView>("folders");
   const [contentOverride, setContentOverride] = useState<{
@@ -205,8 +206,8 @@ export function useWorkspaceState(isAuthenticated: boolean) {
     direction: "right",
   });
 
-  const handleToggleSidebar = useCallback(() => setIsSidebarOpen((v) => !v), []);
-  const handleToggleNoteList = useCallback(() => setIsNoteListOpen((v) => !v), []);
+  const handleToggleSidebar = useCallback(() => setIsSidebarOpen((v) => !v), [setIsSidebarOpen]);
+  const handleToggleNoteList = useCallback(() => setIsNoteListOpen((v) => !v), [setIsNoteListOpen]);
   const handleToggleChat = useCallback(() => setIsChatOpen((v) => !v), []);
 
   const handleMobileViewChange = useCallback((view: MobileView) => {


### PR DESCRIPTION
## 概要

フォルダパネルまたはノートリストパネルを閉じた後にページをリロードすると、パネルが開いた状態に戻ってしまう問題を修正します。パネル幅はすでに `localStorage` に永続化されていましたが、開閉状態は揮発していました。

## 変更内容

- **新規**: `frontend/src/hooks/usePersistedBoolean.ts`
  - `useEditorDisplayMode` と同じ SSR セーフな `localStorage` 永続化パターンを持つ汎用フック
  - マウント後に `localStorage` を読み込み、セッタで書き込む
- **修正**: `frontend/src/hooks/workspace/useWorkspaceState.ts`
  - `isSidebarOpen` / `isNoteListOpen` の `useState(true)` を `usePersistedBoolean` に差し替え
  - ストレージキー: `notes-sidebar-open` / `notes-notelist-open`（既存の `notes-sidebar-width` / `notes-notelist-width` と命名規則を統一）
  - `handleToggleSidebar` / `handleToggleNoteList` の `useCallback` 依存配列を修正

## テスト方法

1. アプリにログインし、フォルダパネルを閉じる → リロード → 閉じたまま
2. ノートリストパネルを閉じる → リロード → 閉じたまま
3. DevTools → Application → Local Storage で `notes-sidebar-open` / `notes-notelist-open` の値がトグルに追随することを確認
4. パネル幅の永続化（`notes-sidebar-width` 等）が従来どおり動作することを確認

## チェックリスト

- [x] テストを追加・更新した（ユニットテスト 383件通過、devデプロイ後のバックエンド統合テスト 31件通過）
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当なし）