### PR TITLE
feat: retry autosave until success with exponential backoff (no upper limit)

### DIFF
--- a/frontend/src/lib/sync/syncConfig.ts
+++ b/frontend/src/lib/sync/syncConfig.ts
@@ -2,14 +2,14 @@
  * サーバー同期失敗時の指数バックオフリトライ設定。
  *
  * リトライ間隔は retryBaseDelayMs * 2^attempt で計算し、
- * retryMaxDelayMs を上限として打ち切る。
- * maxRetryAttempts を超えた場合はリトライを中止し、"failed" 状態のままにする。
+ * retryMaxDelayMs を上限として頭打ちにする。
+ * 一時的なエラー（ネットワーク障害など）は成功するまでリトライし続ける。
+ * 409 競合エラーのみリトライ対象外（スナップショット再取得で解決）。
+ * オフライン時は syncQueue に積み、再接続時にフラッシュする。
  */
 export const SYNC_RETRY_CONFIG = {
-  /** 最大リトライ回数。これを超えると自動リトライを諦める */
-  maxRetryAttempts: 3,
   /** リトライ間隔の基準値 (ms)。指数バックオフの底として使用 */
   retryBaseDelayMs: 2000,
-  /** リトライ間隔の上限 (ms)。バックオフが際限なく伸びないよう制限 */
+  /** リトライ間隔の上限 (ms)。バックオフが際限なく伸びないよう制限（例: 2s→4s→8s→16s→30s→30s…） */
   retryMaxDelayMs: 30000,
 } as const;

--- a/frontend/src/lib/sync/useNoteSyncEngine.test.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.test.ts
@@ -587,7 +587,75 @@ describe("useNoteSyncEngine", () => {
       vi.useRealTimers();
     });
 
-    it("exhausts after maxRetryAttempts and stays failed with no countdown", async () => {
+    it("keeps retrying beyond 3 attempts until success (no upper limit)", async () => {
+      vi.useFakeTimers();
+
+      const initialNote = buildNote();
+      const updatedServerNote = buildNote({ content: "Finally synced", version: 6 });
+      const snapshot = {
+        folders: [],
+        notes: [updatedServerNote],
+        cursor: "cursor-6",
+        server_time: "2024-01-06T00:00:00.000Z",
+      };
+      // Fail 5 times, then succeed on the 6th call
+      const applyWorkspaceChanges = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockRejectedValueOnce(new Error("Server error"))
+        .mockResolvedValueOnce({
+          applied: [{ entity: "note", operation: "update", entity_id: initialNote.id, client_mutation_id: null, folder: null, note: updatedServerNote }],
+          snapshot,
+        });
+      getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+      const { result } = renderHook(() =>
+        useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
+      });
+
+      // Initial call (via debounce) → fail → countdown 2s
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+        await result.current.triggerServerSync(initialNote.id);
+      });
+      expect(result.current.syncStatus.retryCountdown).toBe(2);
+
+      // Attempt 0 (2s delay) → fail → countdown 4s
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(4);
+
+      // Attempt 1 (4s delay) → fail → countdown 8s
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(8);
+
+      // Attempt 2 (8s delay) — would have been the last under old maxRetryAttempts=3, but now continues
+      await act(async () => { await vi.advanceTimersByTimeAsync(8000); });
+      expect(result.current.syncStatus.remote).toBe("failed");
+      expect(result.current.syncStatus.retryCountdown).toBe(16); // still retrying!
+
+      // Attempt 3 (16s delay) → fail → countdown 30s (clamped)
+      await act(async () => { await vi.advanceTimersByTimeAsync(16000); });
+      expect(result.current.syncStatus.retryCountdown).toBe(30);
+
+      // Attempt 4 (30s delay) → finally succeeds
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+      expect(result.current.syncStatus.remote).toBe("synced");
+      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
+
+      // 1 initial + 5 retries = 6 total calls
+      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(6);
+
+      vi.useRealTimers();
+    });
+
+    it("clamps backoff delay at retryMaxDelayMs (30s) and holds steady", async () => {
       vi.useFakeTimers();
 
       const initialNote = buildNote();
@@ -602,28 +670,23 @@ describe("useNoteSyncEngine", () => {
         await result.current.handleUpdateNote(initialNote.id, { content: "edit" });
       });
 
-      // Initial call
+      // Initial call → fail
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5000);
         await result.current.triggerServerSync(initialNote.id);
       });
-      expect(result.current.syncStatus.retryCountdown).toBe(2);
 
-      // Attempt 0 (2s delay)
-      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
-      expect(result.current.syncStatus.retryCountdown).toBe(4);
+      // Advance through 2s, 4s, 8s, 16s attempts
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });  // attempt 0
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });  // attempt 1
+      await act(async () => { await vi.advanceTimersByTimeAsync(8000); });  // attempt 2
+      await act(async () => { await vi.advanceTimersByTimeAsync(16000); }); // attempt 3 → countdown 30s
 
-      // Attempt 1 (4s delay)
-      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
-      expect(result.current.syncStatus.retryCountdown).toBe(8);
+      expect(result.current.syncStatus.retryCountdown).toBe(30);
 
-      // Attempt 2 (8s delay) — last attempt (maxRetryAttempts = 3)
-      await act(async () => { await vi.advanceTimersByTimeAsync(8000); });
-      expect(result.current.syncStatus.remote).toBe("failed");
-      expect(result.current.syncStatus.retryCountdown).toBeUndefined();
-
-      // 1 initial + 3 retries = 4 total calls
-      expect(applyWorkspaceChanges).toHaveBeenCalledTimes(4);
+      // attempt 4 also clamps to 30s (not 64s)
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000); }); // attempt 4 → countdown 30s
+      expect(result.current.syncStatus.retryCountdown).toBe(30);
 
       vi.useRealTimers();
     });

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -202,42 +202,39 @@ export function useNoteSyncEngine({
             setLastError(t("sync.serverSyncFailed"));
 
             const attempt = retryAttemptRef.current;
-            if (attempt < SYNC_RETRY_CONFIG.maxRetryAttempts) {
-              // 指数バックオフで次のリトライ遅延を計算し、最大値でクランプする
-              const delayMs = Math.min(
-                SYNC_RETRY_CONFIG.retryBaseDelayMs * Math.pow(2, attempt),
-                SYNC_RETRY_CONFIG.retryMaxDelayMs
-              );
-              const delaySec = Math.round(delayMs / 1000);
-              retryArgsRef.current = { id, updates, expectedVersion };
-              setRetryCountdown(delaySec);
+            // 指数バックオフで次のリトライ遅延を計算し、最大値でクランプする。
+            // 一時的な失敗は成功するまで無限にリトライし続ける（上限なし）。
+            const delayMs = Math.min(
+              SYNC_RETRY_CONFIG.retryBaseDelayMs * Math.pow(2, attempt),
+              SYNC_RETRY_CONFIG.retryMaxDelayMs
+            );
+            const delaySec = Math.round(delayMs / 1000);
+            retryArgsRef.current = { id, updates, expectedVersion };
+            setRetryCountdown(delaySec);
 
-              retryIntervalRef.current = setInterval(() => {
-                setRetryCountdown((prev) => {
-                  if (prev === undefined || prev <= 1) {
-                    clearInterval(retryIntervalRef.current!);
-                    retryIntervalRef.current = null;
-                    return 0;
-                  }
-                  return prev - 1;
-                });
-              }, 1000);
-
-              retryTimeoutRef.current = setTimeout(() => {
-                retryTimeoutRef.current = null;
-                clearInterval(retryIntervalRef.current!);
-                retryIntervalRef.current = null;
-                setRetryCountdown(undefined);
-                const args = retryArgsRef.current;
-                retryArgsRef.current = null;
-                if (args && syncNoteToServerRef.current) {
-                  retryAttemptRef.current += 1;
-                  void syncNoteToServerRef.current(args.id, args.updates, args.expectedVersion);
+            retryIntervalRef.current = setInterval(() => {
+              setRetryCountdown((prev) => {
+                if (prev === undefined || prev <= 1) {
+                  clearInterval(retryIntervalRef.current!);
+                  retryIntervalRef.current = null;
+                  return 0;
                 }
-              }, delayMs);
-            } else {
-              setRetryCountdown(undefined); // exhausted, stay failed
-            }
+                return prev - 1;
+              });
+            }, 1000);
+
+            retryTimeoutRef.current = setTimeout(() => {
+              retryTimeoutRef.current = null;
+              clearInterval(retryIntervalRef.current!);
+              retryIntervalRef.current = null;
+              setRetryCountdown(undefined);
+              const args = retryArgsRef.current;
+              retryArgsRef.current = null;
+              if (args && syncNoteToServerRef.current) {
+                retryAttemptRef.current += 1;
+                void syncNoteToServerRef.current(args.id, args.updates, args.expectedVersion);
+              }
+            }, delayMs);
           } finally {
             if (activeSavePromiseRef.current === currentPromise) {
               activeSavePromiseRef.current = null;


### PR DESCRIPTION
## 概要

エディタの自動保存が失敗した際、これまでは最大3回でリトライを諦め `failed` 状態のままになっていた。本PRでは上限を撤廃し、一時的なエラー（ネットワーク障害・サーバーエラー）は成功するまで無限にリトライし続けるよう変更する。遅延は指数バックオフ（2s→4s→8s→16s→30s→30s…）で伸び、30秒で頭打ちになる。

## 変更内容

- `syncConfig.ts`: `maxRetryAttempts` を撤廃。コメントを「成功するまでリトライ」の設計意図に更新
- `useNoteSyncEngine.ts`: `attempt < maxRetryAttempts` の上限ゲートを削除。一時的失敗時は常にリトライをスケジュール
- `useNoteSyncEngine.test.ts`:
  - 「3回で諦める」テストを「3回を超えても継続し最終的に成功する」テストに書き換え（5回失敗→6回目に成功）
  - `retryMaxDelayMs`（30s）でクランプされることを検証する新テストを追加

**変更なし:**
- 409 競合エラーはリトライしない（スナップショット再取得で解決）
- オフライン時は `syncQueue` に積んで再接続時にフラッシュ（既存動作を維持）
- UI（ステータスバーの「Retrying in Ns...」表示）は既存のまま流用

## テスト方法

- [ ] `make test-frontend` でユニットテスト全通過を確認
- [ ] ローカルでノートを編集し、DevTools でリクエストをブロック → ステータスバーに「Retrying in Ns...」表示 → ブロック解除 → `Saved` に戻ることを確認
- [ ] リトライが3回を超えても継続し、4回目以降も `retryCountdown` が設定され続けることを確認

## チェックリスト

- [x] テストを追加・更新した
- [x] ドキュメントを更新した（コメント・型定義）
- [ ] ユーザー向けテキストの i18n 対応を行った（該当なし）