### PR TITLE
fix: address security/bug/architecture review findings + verify on local & dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,9 @@ This repository is a Mac Notes app clone with AI-powered features built on a ser
 ## Common Commands
 
 ```bash
-make dev
+make dev          # prints local dev startup options
+make dev-stack    # one command: backend + frontend with auth bypass against dev DSQL
+                  # (requires the AWS dev profile and `make tf-init ENV=dev`)
 make test
 make install-hooks
 make deploy ENV=prd

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,16 @@ dev-frontend: ## Run frontend locally
 	cd frontend && npm run dev
 
 .PHONY: dev
-dev: ## Run both backend and frontend (requires tmux or run in separate terminals)
-	@echo "Run in separate terminals:"
-	@echo "  make dev-backend"
-	@echo "  make dev-frontend"
+dev: ## Show how to start the local dev environment (use `make dev-stack` for one-command startup)
+	@echo "Choose a local development mode:"
+	@echo ""
+	@echo "  make dev-stack        # RECOMMENDED: starts backend (8000) + frontend (3000)"
+	@echo "                        # together with auth bypass against the dev DSQL cluster."
+	@echo "                        # Requires: AWS '$(ENV)' profile + 'make tf-init ENV=$(ENV)'."
+	@echo ""
+	@echo "  Or run each process in its own terminal:"
+	@echo "    make dev-backend    # uvicorn on :8000 (needs a local Postgres / DATABASE_URL)"
+	@echo "    make dev-frontend   # next dev on :3000"
 
 # =============================================================================
 # Local Bypass Stack (auth bypass + dev DSQL)
@@ -260,7 +266,12 @@ ifeq ($(ENV),prd)
 	@echo "Skipping integration tests in prd (backdoor auth not available)"
 else
 	$(eval API_URL := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw api_url))
-	cd backend && API_URL=$(API_URL) uv run --extra dev python -m pytest tests/integration -v
+	$(eval BYPASS_TOKEN := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw integration_test_bypass_token))
+	$(eval BYPASS_TOKEN_2 := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw integration_test_bypass_token_2))
+	cd backend && API_URL=$(API_URL) \
+		INTEGRATION_TEST_BYPASS_TOKEN=$(BYPASS_TOKEN) \
+		INTEGRATION_TEST_BYPASS_TOKEN_2=$(BYPASS_TOKEN_2) \
+		uv run --extra dev python -m pytest tests/integration -v
 endif
 
 # =============================================================================
@@ -447,7 +458,12 @@ test-frontend: ## Run frontend Vitest unit tests
 .PHONY: test-integration
 test-integration: tf-switch ## Run backend integration tests against the deployed environment selected by ENV
 	$(eval API_URL := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw api_url))
-	cd backend && API_URL=$(API_URL) uv run --extra dev python -m pytest tests/integration -v
+	$(eval BYPASS_TOKEN := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw integration_test_bypass_token))
+	$(eval BYPASS_TOKEN_2 := $(shell cd terraform && AWS_PROFILE=$(AWS_PROFILE) terraform output -raw integration_test_bypass_token_2))
+	cd backend && API_URL=$(API_URL) \
+		INTEGRATION_TEST_BYPASS_TOKEN=$(BYPASS_TOKEN) \
+		INTEGRATION_TEST_BYPASS_TOKEN_2=$(BYPASS_TOKEN_2) \
+		uv run --extra dev python -m pytest tests/integration -v
 
 .PHONY: test-lint
 test-lint: lint-backend lint-frontend ## Run all linters

--- a/backend/app/auth/cognito.py
+++ b/backend/app/auth/cognito.py
@@ -76,9 +76,14 @@ class CognitoJWTVerifier:
         """
         # ----------------------------------------------------------------------
         # 開発環境での結合テスト用バイパス
+        #
+        # トークンはソースにハードコードせず、デプロイ時に環境変数
+        # (INTEGRATION_TEST_BYPASS_TOKEN) として注入された秘密値とのみ照合する。
+        # 環境変数が未設定（本番および注入されていない環境）の場合はバイパスを
+        # 一切行わず、通常の JWT 検証にフォールスルーする。
         # ----------------------------------------------------------------------
-        if settings.environment == "dev":
-            if token == "dev-integration-test-token":  # noqa: S105
+        if settings.environment == "dev" and settings.integration_test_bypass_token:
+            if token == settings.integration_test_bypass_token:
                 return {
                     "sub": "integration-test-user-id",
                     "username": "integration-test-user",
@@ -86,7 +91,10 @@ class CognitoJWTVerifier:
                     "token_use": "access",
                     "scope": "aws.cognito.signin.user.admin",
                 }
-            if token == "dev-integration-test-token-2":  # noqa: S105
+            if (
+                settings.integration_test_bypass_token_2
+                and token == settings.integration_test_bypass_token_2
+            ):
                 return {
                     "sub": "integration-test-user-id-2",
                     "username": "integration-test-user-2",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,11 @@ class Settings(BaseSettings):
     cognito_user_pool_id: str = ""
     cognito_app_client_id: str = ""
 
+    # 結合テスト用バイパストークン（dev 環境限定・デプロイ時に SSM 経由で注入）。
+    # ソースコードにハードコードせず、未設定（空文字）の場合はバイパスを一切行わない。
+    integration_test_bypass_token: str = ""
+    integration_test_bypass_token_2: str = ""
+
     # Amazon Bedrock (AI) 設定
     bedrock_region: str = "us-east-1"
     bedrock_model_id: str = "anthropic.claude-3-5-sonnet-20241022-v2:0"

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -9,10 +9,16 @@
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.models import AIEditJobRead
 from app.models.enums import ChatScope
+
+# AI 入力の上限値。Bedrock への過大入力によるトークン枯渇・コスト濫用を防ぐ。
+# content は長文ノート全体を許容しつつ、無制限の巨大ペイロードは拒否する。
+MAX_AI_CONTENT_CHARS = 100_000
+MAX_AI_INSTRUCTION_CHARS = 2_000
+MAX_AI_QUESTION_CHARS = 4_000
 
 
 class BedrockMessage(BaseModel):
@@ -46,9 +52,9 @@ class ChatRequest(BaseModel):
     scope: ChatScope = ChatScope.NOTE
     note_id: UUID | None = None
     folder_id: UUID | None = None
-    question: str
+    question: str = Field(max_length=MAX_AI_QUESTION_CHARS)
     history: list[BedrockMessage] | None = None
-    selected_content: str | None = None
+    selected_content: str | None = Field(default=None, max_length=MAX_AI_CONTENT_CHARS)
 
 
 class ChatResponse(BaseModel):
@@ -61,8 +67,8 @@ class ChatResponse(BaseModel):
 class EditRequest(BaseModel):
     """同期AI編集エンドポイントへのリクエスト。"""
 
-    content: str
-    instruction: str
+    content: str = Field(max_length=MAX_AI_CONTENT_CHARS)
+    instruction: str = Field(max_length=MAX_AI_INSTRUCTION_CHARS)
     note_id: UUID | None = None
 
 

--- a/backend/app/features/share/use_cases.py
+++ b/backend/app/features/share/use_cases.py
@@ -99,8 +99,13 @@ class ShareUseCases:
         if share is None:
             raise NotFound("Shared note not found")
 
-        if share.expires_at and share.expires_at < datetime.now(UTC):
-            raise ShareExpired("Share link has expired")
+        if share.expires_at is not None:
+            # DB によっては tzinfo が欠落した datetime が返るため、naive 値は UTC とみなす。
+            expires_at = share.expires_at
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
+            if expires_at < datetime.now(UTC):
+                raise ShareExpired("Share link has expired")
 
         note = self.session.get(Note, share.note_id)
         if note is None or note.deleted_at is not None:

--- a/backend/app/features/workspace/repositories/folders.py
+++ b/backend/app/features/workspace/repositories/folders.py
@@ -21,11 +21,22 @@ class FolderRepository(UserScopedRepository[Folder]):
     model = Folder
     resource_name = "Folder"
 
-    def list(self, *, include_deleted: bool = False) -> list[Folder]:
-        """ユーザーのフォルダ一覧を更新日時の降順で返す。削除済み除外に対応。"""
+    def list(
+        self,
+        *,
+        include_deleted: bool = False,
+        updated_after: datetime | None = None,
+    ) -> list[Folder]:
+        """ユーザーのフォルダ一覧を更新日時の降順で返す。
+
+        削除済み除外に加え、updated_after を指定するとその時刻より後に更新された
+        フォルダのみを返す（差分同期用）。
+        """
         statement = select(Folder).where(Folder.user_id == self.user_id)
         if not include_deleted:
             statement = statement.where(Folder.deleted_at.is_(None))
+        if updated_after is not None:
+            statement = statement.where(Folder.updated_at > updated_after)
         folders = self.session.exec(statement).all()
         for folder in folders:
             normalize_version(folder)

--- a/backend/app/features/workspace/repositories/notes.py
+++ b/backend/app/features/workspace/repositories/notes.py
@@ -6,6 +6,10 @@
     UserScopedRepository の共通 CRUD ヘルパーを継承する。
 """
 
+# `list` メソッド定義後にクラス名前空間で組み込み list が隠蔽されるため、
+# 後続メソッドの `list[Note]` 注釈を遅延評価（文字列化）して解決する。
+from __future__ import annotations
+
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -26,13 +30,20 @@ class NoteRepository(UserScopedRepository[Note]):
         folder_id: UUID | None = None,
         *,
         include_deleted: bool = False,
+        updated_after: datetime | None = None,
     ) -> list[Note]:
-        """ユーザーのノート一覧を更新日時の降順で返す。フォルダ絞り込みと削除済み除外に対応。"""
+        """ユーザーのノート一覧を更新日時の降順で返す。
+
+        フォルダ絞り込み・削除済み除外に加え、updated_after を指定すると
+        その時刻より後に更新されたノートのみを返す（差分同期用）。
+        """
         statement = select(Note).where(Note.user_id == self.user_id)
         if not include_deleted:
             statement = statement.where(Note.deleted_at.is_(None))
         if folder_id is not None:
             statement = statement.where(Note.folder_id == folder_id)
+        if updated_after is not None:
+            statement = statement.where(Note.updated_at > updated_after)
         notes = self.session.exec(statement).all()
         for note in notes:
             normalize_version(note)
@@ -48,10 +59,16 @@ class NoteRepository(UserScopedRepository[Note]):
         return self.save(note)
 
     def update(self, note_id: UUID, note_in: NoteUpdate) -> Note:
-        """指定ノートの差分フィールドを更新し、updated_at とバージョンをインクリメントする。"""
+        """指定ノートの差分フィールドを更新し、updated_at とバージョンをインクリメントする。
+
+        クライアントが明示的に送ったフィールドのみを適用する。model_fields_set を
+        用いることで、`folder_id` を `null` に明示設定して「フォルダ外（全ノート）」へ
+        移動するケースも正しく反映できる（exclude_unset の dump では既定値 None と
+        区別できず、明示的な null が握り潰されていた）。
+        """
         note = self.get_owned(note_id)
-        for key, value in note_in.model_dump(exclude_unset=True).items():
-            setattr(note, key, value)
+        for key in note_in.model_fields_set:
+            setattr(note, key, getattr(note_in, key))
         return self.save(note, touch=True, bump=True)
 
     def soft_delete(self, note_id: UUID) -> Note:
@@ -59,3 +76,18 @@ class NoteRepository(UserScopedRepository[Note]):
         note = self.get_owned(note_id)
         note.deleted_at = datetime.now(UTC)
         return self.save(note, touch=True, bump=True)
+
+    def clear_folder(self, folder_id: UUID) -> list[Note]:
+        """指定フォルダに属する未削除ノートの folder_id を解除する。
+
+        フォルダの論理削除時に呼び出し、子ノートが存在しないフォルダを参照し続ける
+        「孤立」状態を防ぐ。Aurora DSQL には外部キー制約がないため、この整合性は
+        アプリケーション層で明示的に担保する必要がある。
+        更新したノートは version / updated_at をインクリメントしてクライアントへ
+        同期されるようにする。
+        """
+        notes = self.list(folder_id=folder_id)
+        for note in notes:
+            note.folder_id = None
+            self.save(note, touch=True, bump=True)
+        return notes

--- a/backend/app/features/workspace/snapshot.py
+++ b/backend/app/features/workspace/snapshot.py
@@ -9,7 +9,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from app.features.workspace.dependencies import get_workspace_snapshot_use_case
 from app.features.workspace.schemas import WorkspaceSnapshotResponse
@@ -23,6 +23,18 @@ def get_workspace_snapshot(
     use_case: Annotated[
         WorkspaceSnapshotUseCase, Depends(get_workspace_snapshot_use_case)
     ],
+    since: Annotated[
+        str | None,
+        Query(
+            description=(
+                "差分同期用カーソル。指定するとこの時刻より後に更新された"
+                "エンティティ（削除済み tombstone を含む）のみを返す。"
+            )
+        ),
+    ] = None,
 ):
-    """ブートストラップおよび同期用のワークスペーススナップショットを返す。"""
-    return use_case.get_snapshot()
+    """ブートストラップおよび同期用のワークスペーススナップショットを返す。
+
+    since を指定すると差分のみ、未指定だと全件を返す。
+    """
+    return use_case.get_snapshot(since_cursor=since)

--- a/backend/app/features/workspace/use_cases/folders.py
+++ b/backend/app/features/workspace/use_cases/folders.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from sqlmodel import Session
 
-from app.features.workspace.repositories import FolderRepository
+from app.features.workspace.repositories import FolderRepository, NoteRepository
 from app.logging_utils import log_event
 from app.models import Folder, FolderCreate, FolderUpdate
 
@@ -23,6 +23,7 @@ class FolderUseCases:
 
     def __init__(self, session: Session, user_id: str):
         self.repository = FolderRepository(session, user_id)
+        self.note_repository = NoteRepository(session, user_id)
 
     def list_folders(self) -> list[Folder]:
         """ユーザーが所有するフォルダを一覧取得する。
@@ -73,12 +74,16 @@ class FolderUseCases:
         """フォルダを soft delete（deleted_at を現在時刻に設定）し、監査ログを記録する。
 
         物理削除は行わず、スナップショット取得時に削除済みとして返される。
+        所有者確認のためまずフォルダを soft delete し、その後フォルダに属する
+        未削除ノートの folder_id を解除して「孤立ノート」を防ぐ。
         """
         self.repository.soft_delete(folder_id)
+        orphaned = self.note_repository.clear_folder(folder_id)
         log_event(
             logger,
             logging.INFO,
             "audit.folder.deleted",
             folder_id=folder_id,
+            orphaned_note_count=len(orphaned),
             outcome="success",
         )

--- a/backend/app/features/workspace/use_cases/queries.py
+++ b/backend/app/features/workspace/use_cases/queries.py
@@ -7,6 +7,7 @@
     ワークスペース自身のルーターから利用される。
 """
 
+from datetime import datetime
 from uuid import UUID
 
 from sqlmodel import Session
@@ -30,14 +31,34 @@ class WorkspaceQueryUseCases:
         """ユーザーが所有するフォルダを取得する。存在しない場合は NotFound を送出。"""
         return self.folder_repository.get_owned(folder_id)
 
-    def list_folders(self, *, include_deleted: bool = False) -> list[Folder]:
-        """ユーザーのフォルダ一覧を返す。削除済みを含めるかは include_deleted で制御。"""
-        return self.folder_repository.list(include_deleted=include_deleted)
+    def list_folders(
+        self,
+        *,
+        include_deleted: bool = False,
+        updated_after: datetime | None = None,
+    ) -> list[Folder]:
+        """ユーザーのフォルダ一覧を返す。
+
+        include_deleted で削除済みの包含を、updated_after で差分同期の起点時刻を制御する。
+        """
+        return self.folder_repository.list(
+            include_deleted=include_deleted, updated_after=updated_after
+        )
 
     def list_folder_notes(self, folder_id: UUID) -> list[Note]:
         """指定フォルダ内のノート一覧を返す。"""
         return self.note_repository.list(folder_id)
 
-    def list_all_notes(self, *, include_deleted: bool = False) -> list[Note]:
-        """全ノート一覧を返す。削除済みを含めるかは include_deleted で制御。"""
-        return self.note_repository.list(include_deleted=include_deleted)
+    def list_all_notes(
+        self,
+        *,
+        include_deleted: bool = False,
+        updated_after: datetime | None = None,
+    ) -> list[Note]:
+        """全ノート一覧を返す。
+
+        include_deleted で削除済みの包含を、updated_after で差分同期の起点時刻を制御する。
+        """
+        return self.note_repository.list(
+            include_deleted=include_deleted, updated_after=updated_after
+        )

--- a/backend/app/features/workspace/use_cases/snapshot.py
+++ b/backend/app/features/workspace/use_cases/snapshot.py
@@ -26,24 +26,35 @@ class WorkspaceSnapshotUseCase:
     def __init__(self, session: Session, user_id: str):
         self.workspace_queries = WorkspaceQueryUseCases(session, user_id)
 
-    def get_snapshot(self) -> WorkspaceSnapshotResponse:
-        """全フォルダ・ノートを取得しスナップショットを返す。
+    def get_snapshot(
+        self, since_cursor: str | None = None
+    ) -> WorkspaceSnapshotResponse:
+        """フォルダ・ノートのスナップショットを返す。
 
-        include_deleted=True を指定することで soft delete 済みエントリも含める。
-        クライアントはこの一覧でローカル DB と差分同期を行う。
+        since_cursor が指定された場合は、そのカーソル時刻より後に更新された
+        エントリのみ（削除済みの tombstone を含む）を差分として返す。未指定の
+        場合は全件を返す（初回ブートストラップ用）。いずれも soft delete 済みを
+        含めることで、クライアントは削除も含めてローカル DB と同期できる。
         失敗時はエラーログを記録して例外を再送出する。
         """
         try:
+            updated_after = self._parse_cursor(since_cursor)
             folders = [
                 FolderRead.model_validate(folder)
-                for folder in self.workspace_queries.list_folders(include_deleted=True)
+                for folder in self.workspace_queries.list_folders(
+                    include_deleted=True, updated_after=updated_after
+                )
             ]
             notes = [
                 NoteRead.model_validate(note)
-                for note in self.workspace_queries.list_all_notes(include_deleted=True)
+                for note in self.workspace_queries.list_all_notes(
+                    include_deleted=True, updated_after=updated_after
+                )
             ]
             server_time = datetime.now(UTC)
-            cursor = self._build_cursor(folders, notes, server_time)
+            # 差分が空のときは起点カーソルを維持し、巻き戻りを防ぐ。
+            fallback = updated_after or server_time
+            cursor = self._build_cursor(folders, notes, fallback)
             return WorkspaceSnapshotResponse(
                 folders=folders,
                 notes=notes,
@@ -60,16 +71,34 @@ class WorkspaceSnapshotUseCase:
             raise
 
     @staticmethod
+    def _parse_cursor(since_cursor: str | None) -> datetime | None:
+        """カーソル文字列を tz-aware な datetime に変換する。
+
+        None・空文字・解析不能な値は None（差分なし＝全件取得）として扱う。
+        tzinfo が欠落している場合は UTC を補完する。
+        """
+        if not since_cursor:
+            return None
+        try:
+            parsed = datetime.fromisoformat(since_cursor)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed
+
+    @staticmethod
     def _build_cursor(
-        folders: list[FolderRead], notes: list[NoteRead], server_time: datetime
+        folders: list[FolderRead], notes: list[NoteRead], fallback: datetime
     ) -> str:
         """スナップショットのカーソルを算出して返す。
 
-        全フォルダ・ノートの updated_at の最大値を ISO 8601 文字列にして返す。
-        エントリが1件もない場合は server_time をデフォルト値として使用する。
+        返却したフォルダ・ノートの updated_at の最大値を ISO 8601 文字列にして返す。
+        差分が空の場合は fallback（起点カーソルまたはサーバー時刻）を使用し、
+        カーソルが過去に巻き戻らないようにする。
         """
         latest_updated_at = max(
             [item.updated_at for item in folders] + [item.updated_at for item in notes],
-            default=server_time,
+            default=fallback,
         )
         return latest_updated_at.isoformat()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -19,8 +19,26 @@ def api_base_url():
 
 @pytest.fixture(scope="session")
 def auth_token():
-    """Return the backdoor token for integration tests."""
-    return "dev-integration-test-token"
+    """Return the backdoor token for integration tests.
+
+    The token is no longer hardcoded in source. It is injected at deploy time
+    (Terraform-generated SecureString in SSM) and supplied to the test runner
+    via the INTEGRATION_TEST_BYPASS_TOKEN environment variable. Tests are
+    skipped when it is not provided.
+    """
+    token = os.getenv("INTEGRATION_TEST_BYPASS_TOKEN")
+    if not token:
+        pytest.skip("INTEGRATION_TEST_BYPASS_TOKEN is not set")
+    return token
+
+
+@pytest.fixture(scope="session")
+def auth_token_2():
+    """Return the second integration-test backdoor token (from the environment)."""
+    token = os.getenv("INTEGRATION_TEST_BYPASS_TOKEN_2")
+    if not token:
+        pytest.skip("INTEGRATION_TEST_BYPASS_TOKEN_2 is not set")
+    return token
 
 
 @pytest.fixture(scope="session")
@@ -30,12 +48,12 @@ def test_user_id():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def set_integration_test_token_limits(api_base_url, auth_token):
+def set_integration_test_token_limits(api_base_url, auth_token, auth_token_2):
     """
     Set a large token limit for integration test users at the start of the session.
     This prevents AI endpoint tests from hitting the monthly token limit.
     """
-    for token in (auth_token, "dev-integration-test-token-2"):
+    for token in (auth_token, auth_token_2):
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
@@ -67,13 +85,13 @@ def client(api_base_url, auth_token):
 
 
 @pytest.fixture
-def another_client(api_base_url):
+def another_client(api_base_url, auth_token_2):
     """
     Create an httpx Client authenticated as a SECOND integration test user.
     Used to verify that user A cannot access user B's resources.
     """
     headers = {
-        "Authorization": "Bearer dev-integration-test-token-2",
+        "Authorization": f"Bearer {auth_token_2}",
         "Content-Type": "application/json",
     }
     with httpx.Client(base_url=api_base_url, headers=headers, timeout=30.0) as client:

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -158,6 +158,37 @@ def test_edit_note_content(client: TestClient, session: Session, mock_ai_service
     assert data["tokens_used"] == 30
 
 
+def test_edit_oversized_content_returns_422(
+    client: TestClient, session: Session, mock_ai_service
+):
+    """Content beyond the max size must be rejected before reaching Bedrock.
+
+    Guards against token/cost exhaustion via unbounded AI input payloads.
+    """
+    response = client.post(
+        "/api/ai/edit",
+        json={
+            "content": "A" * 100_001,
+            "instruction": "Summarize",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_edit_oversized_instruction_returns_422(
+    client: TestClient, session: Session, mock_ai_service
+):
+    """Instruction beyond the max size must be rejected."""
+    response = client.post(
+        "/api/ai/edit",
+        json={
+            "content": "Hello world",
+            "instruction": "x" * 2_001,
+        },
+    )
+    assert response.status_code == 422
+
+
 def test_edit_with_note_id(client: TestClient, session: Session, mock_ai_service):
     user_id = "test-user-123"
     note = Note(title="Test Note", content="Test Content", user_id=user_id)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -232,9 +232,56 @@ async def test_dev_integration_token_blocked_in_local(mock_settings):
 @pytest.mark.asyncio
 async def test_dev_integration_token_bypass_in_dev(mock_settings):
     mock_settings.environment = "dev"
+    mock_settings.integration_test_bypass_token = "injected-secret-token"
+    mock_settings.integration_test_bypass_token_2 = "injected-secret-token-2"
     verifier = CognitoJWTVerifier()
-    result = await verifier.verify_token("dev-integration-test-token")
+    result = await verifier.verify_token("injected-secret-token")
     assert result["sub"] == "integration-test-user-id"
+    result2 = await verifier.verify_token("injected-secret-token-2")
+    assert result2["sub"] == "integration-test-user-id-2"
+
+
+@pytest.mark.asyncio
+async def test_bypass_disabled_when_token_unset_in_dev(mock_settings):
+    """バイパストークンが未設定なら、dev でも結合テストトークンは通常検証され拒否される。
+
+    これがセキュリティ修正の要: ソースにハードコードされた推測可能トークンを廃し、
+    デプロイ時に注入された秘密値が無い限りバイパスは成立しない。
+    """
+    mock_settings.environment = "dev"
+    mock_settings.integration_test_bypass_token = ""
+    mock_settings.integration_test_bypass_token_2 = ""
+    verifier = CognitoJWTVerifier()
+    with patch("httpx.AsyncClient", autospec=True) as MockClient:
+        mock_instance = MockClient.return_value
+        mock_instance.__aenter__.return_value = mock_instance
+        mock_instance.__aexit__.return_value = None
+        mock_response = Mock()
+        mock_response.json.return_value = {"keys": []}
+        mock_response.raise_for_status.return_value = None
+        mock_instance.get = mock.AsyncMock(return_value=mock_response)
+        # かつての推測可能トークンはもはやバイパスされず、署名検証で失敗する
+        with pytest.raises(JWTError):
+            await verifier.verify_token("dev-integration-test-token")
+
+
+@pytest.mark.asyncio
+async def test_bypass_rejects_wrong_token_in_dev(mock_settings):
+    """バイパストークンが設定されていても、一致しないトークンは通常検証へ回す。"""
+    mock_settings.environment = "dev"
+    mock_settings.integration_test_bypass_token = "injected-secret-token"
+    mock_settings.integration_test_bypass_token_2 = ""
+    verifier = CognitoJWTVerifier()
+    with patch("httpx.AsyncClient", autospec=True) as MockClient:
+        mock_instance = MockClient.return_value
+        mock_instance.__aenter__.return_value = mock_instance
+        mock_instance.__aexit__.return_value = None
+        mock_response = Mock()
+        mock_response.json.return_value = {"keys": []}
+        mock_response.raise_for_status.return_value = None
+        mock_instance.get = mock.AsyncMock(return_value=mock_response)
+        with pytest.raises(JWTError):
+            await verifier.verify_token("dev-integration-test-token")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -130,6 +130,28 @@ class TestDeleteFolder:
         response = client.delete(f"/api/folders/{fake_id}")
         assert response.status_code == 404
 
+    def test_delete_folder_orphans_child_notes(self, client: TestClient):
+        """Deleting a folder must detach (not lose) its notes.
+
+        Child notes survive (deleted_at stays None) but their folder_id is
+        cleared so they no longer reference a tombstoned folder and remain
+        visible in "All Notes".
+        """
+        folder_id = client.post("/api/folders", json={"name": "Box"}).json()["id"]
+        note_id = client.post(
+            "/api/notes", json={"title": "Child", "folder_id": folder_id}
+        ).json()["id"]
+
+        delete_response = client.delete(f"/api/folders/{folder_id}")
+        assert delete_response.status_code == 204
+
+        snapshot = client.get("/api/workspace/snapshot").json()
+        note = next(n for n in snapshot["notes"] if n["id"] == note_id)
+        assert note["deleted_at"] is None
+        assert note["folder_id"] is None
+        # version bumped because the note was modified during folder deletion
+        assert note["version"] >= 2
+
 
 class TestFolderAuthorization:
     """Tests for folder authorization (user isolation)."""

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -153,3 +153,80 @@ class TestUploadImage:
 
         assert response.status_code == 201
         assert response.json()["url"].endswith(".jpg")
+
+    def test_upload_spoofed_png_header_with_jpeg_content_returns_400(
+        self, client: TestClient
+    ):
+        """A request claiming image/png but carrying JPEG bytes must be rejected.
+
+        This exercises the magic-byte mismatch branch (header vs. content), the
+        core of the recently added anti-spoofing defense.
+        """
+        jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 10
+
+        response = client.post(
+            "/api/images",
+            files={"file": ("evil.png", io.BytesIO(jpeg_bytes), "image/png")},
+        )
+
+        assert response.status_code == 400
+        assert "mismatch" in response.json()["detail"]
+
+    def test_upload_spoofed_jpeg_header_with_png_content_returns_400(
+        self, client: TestClient
+    ):
+        """A request claiming image/jpeg but carrying PNG bytes must be rejected."""
+        png_bytes = make_png_bytes()
+
+        response = client.post(
+            "/api/images",
+            files={"file": ("evil.jpg", io.BytesIO(png_bytes), "image/jpeg")},
+        )
+
+        assert response.status_code == 400
+        assert "mismatch" in response.json()["detail"]
+
+    def test_upload_unrecognized_magic_bytes_returns_400(self, client: TestClient):
+        """Binary that matches no supported format signature must be rejected."""
+        garbage = b"\x00\x01\x02\x03" + b"A" * 100
+
+        response = client.post(
+            "/api/images",
+            files={"file": ("data.png", io.BytesIO(garbage), "image/png")},
+        )
+
+        assert response.status_code == 400
+        assert "does not match" in response.json()["detail"]
+
+    def test_upload_valid_webp_returns_201(self, client: TestClient):
+        """A minimal valid WebP (RIFF....WEBP) should pass magic-byte validation."""
+        # RIFF + 4-byte little-endian size + "WEBP" + minimal padding
+        webp_bytes = b"RIFF" + b"\x24\x00\x00\x00" + b"WEBP" + b"VP8 " + b"\x00" * 20
+
+        with patch("app.features.images.use_cases.boto3") as mock_boto3:
+            mock_s3 = MagicMock()
+            mock_boto3.client.return_value = mock_s3
+
+            response = client.post(
+                "/api/images",
+                files={"file": ("img.webp", io.BytesIO(webp_bytes), "image/webp")},
+            )
+
+        assert response.status_code == 201
+        assert response.json()["url"].endswith(".webp")
+
+    def test_upload_valid_gif_returns_201(self, client: TestClient):
+        """A minimal valid GIF (GIF89a) should pass magic-byte validation."""
+        gif_bytes = b"GIF89a" + b"\x00" * 20
+
+        with patch("app.features.images.use_cases.boto3") as mock_boto3:
+            mock_s3 = MagicMock()
+            mock_boto3.client.return_value = mock_s3
+
+            response = client.post(
+                "/api/images",
+                files={"file": ("img.gif", io.BytesIO(gif_bytes), "image/gif")},
+            )
+
+        assert response.status_code == 201
+        assert response.json()["url"].endswith(".gif")

--- a/backend/tests/test_notes.py
+++ b/backend/tests/test_notes.py
@@ -150,6 +150,24 @@ class TestUpdateNote:
         assert response.status_code == 200
         assert response.json()["folder_id"] == folder_id
 
+    def test_update_note_move_out_of_folder_with_explicit_null(
+        self, client: TestClient
+    ):
+        """Sending folder_id: null must move a note out to "All Notes".
+
+        Regression test: exclude_unset previously dropped an explicit null
+        because it could not be distinguished from the default, so the move
+        was silently ignored.
+        """
+        folder_id = client.post("/api/folders", json={"name": "Folder"}).json()["id"]
+        note_id = client.post(
+            "/api/notes", json={"title": "Note", "folder_id": folder_id}
+        ).json()["id"]
+
+        response = client.patch(f"/api/notes/{note_id}", json={"folder_id": None})
+        assert response.status_code == 200
+        assert response.json()["folder_id"] is None
+
     def test_update_note_not_found(self, client: TestClient):
         """Test updating a non-existent note."""
         fake_id = "00000000-0000-0000-0000-000000000000"

--- a/backend/tests/test_share.py
+++ b/backend/tests/test_share.py
@@ -1,9 +1,12 @@
 """Tests for share API endpoints."""
 
-from uuid import uuid4
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
+from sqlmodel import Session, select
 
+from app.models import NoteShare
 from tests.conftest import TEST_USER_ID
 
 
@@ -129,6 +132,32 @@ class TestGetSharedNote:
         fake_token = str(uuid4())
         response = client.get(f"/api/shared/{fake_token}")
         assert response.status_code == 404
+
+    def test_get_expired_shared_note_returns_410(
+        self, client: TestClient, session: Session
+    ):
+        """An expired share link must return 410 Gone.
+
+        Exercises the ShareExpired branch in get_shared_note, which was
+        previously untested by any unit/integration test.
+        """
+        note_response = client.post(
+            "/api/notes", json={"title": "Expiring", "content": "soon gone"}
+        )
+        note_id = note_response.json()["id"]
+        share_token = client.post(f"/api/notes/{note_id}/share").json()["share_token"]
+
+        # Force the share into the past directly in the DB.
+        share = session.exec(
+            select(NoteShare).where(NoteShare.share_token == UUID(share_token))
+        ).first()
+        assert share is not None
+        share.expires_at = datetime.now(UTC) - timedelta(hours=1)
+        session.add(share)
+        session.commit()
+
+        response = client.get(f"/api/shared/{share_token}")
+        assert response.status_code == 410
 
     def test_get_shared_note_no_auth_required(self, make_client):
         """Test that shared notes don't require authentication."""

--- a/backend/tests/test_workspace_snapshot.py
+++ b/backend/tests/test_workspace_snapshot.py
@@ -91,6 +91,56 @@ class TestWorkspaceSnapshot:
         assert [folder["name"] for folder in data["folders"]] == ["Visible Folder"]
         assert [note["title"] for note in data["notes"]] == ["Visible Note"]
 
+    def test_snapshot_since_cursor_returns_only_changes(self, client: TestClient):
+        """A `since` cursor must return only entities updated after it."""
+        # Seed two notes, then capture the cursor (full snapshot).
+        client.post("/api/notes", json={"title": "Old A", "content": "x"})
+        client.post("/api/notes", json={"title": "Old B", "content": "y"})
+        cursor = client.get("/api/workspace/snapshot").json()["cursor"]
+
+        # A change after the cursor.
+        new_note_id = client.post(
+            "/api/notes", json={"title": "New", "content": "z"}
+        ).json()["id"]
+
+        delta = client.get("/api/workspace/snapshot", params={"since": cursor}).json()
+        delta_ids = [n["id"] for n in delta["notes"]]
+        assert delta_ids == [new_note_id]
+        # Cursor advances past the new change.
+        assert delta["cursor"] >= cursor
+
+    def test_snapshot_since_cursor_includes_deletion_tombstones(
+        self, client: TestClient
+    ):
+        """Deletions after the cursor must appear as tombstones in the delta."""
+        note_id = client.post(
+            "/api/notes", json={"title": "ToDelete", "content": "x"}
+        ).json()["id"]
+        cursor = client.get("/api/workspace/snapshot").json()["cursor"]
+
+        client.delete(f"/api/notes/{note_id}")
+
+        delta = client.get("/api/workspace/snapshot", params={"since": cursor}).json()
+        tombstone = next(n for n in delta["notes"] if n["id"] == note_id)
+        assert tombstone["deleted_at"] is not None
+
+    def test_snapshot_since_latest_cursor_returns_empty_delta(self, client: TestClient):
+        """Requesting changes since the latest cursor yields an empty delta."""
+        client.post("/api/notes", json={"title": "Only", "content": "x"})
+        cursor = client.get("/api/workspace/snapshot").json()["cursor"]
+
+        delta = client.get("/api/workspace/snapshot", params={"since": cursor}).json()
+        assert delta["notes"] == []
+        assert delta["folders"] == []
+        # Empty delta must not rewind the cursor.
+        assert delta["cursor"] == cursor
+
+    def test_snapshot_invalid_cursor_falls_back_to_full(self, client: TestClient):
+        """An unparseable cursor is ignored and a full snapshot is returned."""
+        client.post("/api/notes", json={"title": "Note", "content": "x"})
+        delta = client.get("/api/workspace/snapshot?since=not-a-date").json()
+        assert len(delta["notes"]) == 1
+
     def test_snapshot_includes_deleted_tombstones(self, client: TestClient):
         folder = client.post("/api/folders", json={"name": "Deleted Folder"}).json()
         note = client.post(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
@@ -24,7 +24,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
@@ -24,7 +24,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
@@ -24,7 +24,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/horizontalRule.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/horizontalRule.test.ts
@@ -26,7 +26,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown()],
   });
   // lezer-markdown は遅延パースするため強制フルパース（5000ms で JIT 未ウォームアップ時も対応）
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/images.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/images.test.ts
@@ -25,7 +25,7 @@ function makeState(doc: string, cursorPos: number): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
@@ -26,7 +26,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/links.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/links.test.ts
@@ -25,7 +25,7 @@ function makeState(doc: string, cursorPos: number): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
@@ -27,7 +27,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     selection: EditorSelection.cursor(cursorPos),
     extensions: [markdown()],
   });
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/taskList.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/taskList.test.ts
@@ -29,7 +29,7 @@ function makeState(doc: string, cursorPos = 0): EditorState {
   });
   // lezer-markdown は遅延パースするため、テストでは強制的にフルパースしておく
   // 5000ms に設定: JIT未ウォームアップ時でも確実にパースが完了する余裕を持たせる
-  ensureSyntaxTree(state, state.doc.length, 5000);
+  ensureSyntaxTree(state, state.doc.length, 1e9);
   return state;
 }
 

--- a/frontend/src/hooks/workspace/useWorkspaceAIState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceAIState.ts
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * ワークスペースの AI 関連状態（チャット・トークン使用量・AI 編集の受理/適用）を集約するフック。
+ * AI が生成した編集をノートへ反映する際に、ノート更新ハンドラーや UI トグルへ橋渡しする。
+ *
+ * 主なエクスポート:
+ * - useWorkspaceAIState: チャット状態・トークン使用量・AI 編集ハンドラーを返す
+ *
+ * 呼び出し関係: useWorkspaceState から合成される。ノート更新・サーバー同期・
+ *   UI トグルなどを依存として受け取る。
+ */
+import { useCallback, useMemo } from "react";
+
+import type { MobileView } from "@/components/layout";
+import { useAIChat } from "@/hooks/useAIChat";
+import { useTokenUsage } from "@/hooks/useTokenUsage";
+
+interface ContentOverride {
+  noteId: string;
+  content: string;
+  version: number;
+}
+
+interface AIStateOptions {
+  isAuthenticated: boolean;
+  selectedNoteId: string | null;
+  setContentOverride: (
+    updater: (prev: ContentOverride | null) => ContentOverride | null
+  ) => void;
+  handleUpdateNote: (
+    id: string,
+    updates: { content?: string; title?: string; folder_id?: string | null },
+    options?: { immediate?: boolean }
+  ) => void;
+  triggerServerSync: (id: string) => void | Promise<void>;
+  setIsChatOpen: (open: boolean) => void;
+  setMobileView: (view: MobileView) => void;
+}
+
+export function useWorkspaceAIState({
+  isAuthenticated,
+  selectedNoteId,
+  setContentOverride,
+  handleUpdateNote,
+  triggerServerSync,
+  setIsChatOpen,
+  setMobileView,
+}: AIStateOptions) {
+  const { tokenUsage, recordUsage } = useTokenUsage(isAuthenticated);
+  const {
+    chatMessages,
+    isAILoading,
+    isEditMode,
+    setIsEditMode,
+    handleSummarize,
+    handleSendMessage,
+    handleSendEditRequest,
+    handleAcceptEdit,
+    handleRejectEdit,
+    clearChat,
+  } = useAIChat(recordUsage);
+
+  const handleAcceptEditAndApply = useCallback(
+    (messageIndex: number) => {
+      const editedContent = handleAcceptEdit(messageIndex);
+      if (editedContent && selectedNoteId) {
+        setContentOverride((prev) => ({
+          noteId: selectedNoteId,
+          content: editedContent,
+          version: (prev?.version ?? 0) + 1,
+        }));
+        handleUpdateNote(
+          selectedNoteId,
+          { content: editedContent },
+          { immediate: true }
+        );
+      }
+    },
+    [handleAcceptEdit, handleUpdateNote, selectedNoteId, setContentOverride]
+  );
+
+  const pendingEditEntry = useMemo(
+    () =>
+      chatMessages.reduce<{
+        message: (typeof chatMessages)[0];
+        index: number;
+      } | null>(
+        (found, message, index) =>
+          message.editProposal?.status === "pending" ? { message, index } : found,
+        null
+      ),
+    [chatMessages]
+  );
+
+  const handleSummarizeNote = useCallback(
+    async (id: string) => {
+      await triggerServerSync(id);
+      await handleSummarize(id);
+      setIsChatOpen(true);
+      setMobileView("chat");
+    },
+    [triggerServerSync, handleSummarize, setIsChatOpen, setMobileView]
+  );
+
+  const handleSendEditRequestFromPanel = useCallback(
+    (
+      instruction: string,
+      content: string,
+      noteId?: string,
+      selectionRange?: { start: number; end: number }
+    ) => handleSendEditRequest(instruction, content, noteId, selectionRange),
+    [handleSendEditRequest]
+  );
+
+  const handlePendingAcceptEdit = useMemo(
+    () =>
+      pendingEditEntry
+        ? () => handleAcceptEditAndApply(pendingEditEntry.index)
+        : undefined,
+    [pendingEditEntry, handleAcceptEditAndApply]
+  );
+
+  const handlePendingRejectEdit = useMemo(
+    () =>
+      pendingEditEntry
+        ? () => handleRejectEdit(pendingEditEntry.index)
+        : undefined,
+    [pendingEditEntry, handleRejectEdit]
+  );
+
+  return {
+    tokenUsage,
+    chatMessages,
+    isAILoading,
+    isEditMode,
+    setIsEditMode,
+    handleSummarize,
+    handleSendMessage,
+    handleSendEditRequest,
+    handleAcceptEditAndApply,
+    handleRejectEdit,
+    clearChat,
+    pendingEditEntry,
+    handleSummarizeNote,
+    handleSendEditRequestFromPanel,
+    handlePendingAcceptEdit,
+    handlePendingRejectEdit,
+  };
+}

--- a/frontend/src/hooks/workspace/useWorkspaceNavigationState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceNavigationState.ts
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * ワークスペースのナビゲーション状態（フォルダ/ノート選択・検索・URL 同期・絞り込み）を集約するフック。
+ * 選択中エンティティの導出やコンテンツオーバーライドの管理もここで担う。
+ *
+ * 主なエクスポート:
+ * - useWorkspaceNavigationState: 選択状態・検索・URL 連携・派生値を返す
+ *
+ * 呼び出し関係: useWorkspaceState から合成される。データ（folders/notes）と
+ *   UI の setMobileView を依存として受け取る。
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type { MobileView } from "@/components/layout";
+import { useNoteFilter } from "@/hooks/useNoteFilter";
+import type { Folder, Note } from "@/types";
+
+interface ContentOverride {
+  noteId: string;
+  content: string;
+  version: number;
+}
+
+interface NavigationStateOptions {
+  isDataLoading: boolean;
+  folders: Folder[];
+  notes: Note[];
+  setMobileView: (view: MobileView) => void;
+}
+
+export function useWorkspaceNavigationState({
+  isDataLoading,
+  folders,
+  notes,
+  setMobileView,
+}: NavigationStateOptions) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlNoteId = searchParams.get("note");
+  const urlFolderId = searchParams.get("folder");
+
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [contentOverride, setContentOverride] = useState<ContentOverride | null>(
+    null
+  );
+
+  /** ?folder=<id>&?note=<id> を含む URL 文字列を生成するヘルパー。 */
+  const buildHref = useCallback(
+    (folderId: string | null, noteId: string | null) => {
+      const params = new URLSearchParams();
+      if (folderId) params.set("folder", folderId);
+      if (noteId) params.set("note", noteId);
+      const qs = params.toString();
+      return qs ? `${pathname}?${qs}` : pathname;
+    },
+    [pathname]
+  );
+
+  // URL クエリパラメータから選択状態を復元する。
+  // isDataLoading が true の間は folders/notes が未確定なので ID の有効性を検証できない。
+  // prev との比較は、同一値での setState を省略して不要な再レンダーを防ぐため。
+  useEffect(() => {
+    if (isDataLoading) return;
+    const validFolderId =
+      urlFolderId && folders.some((f) => f.id === urlFolderId) ? urlFolderId : null;
+    const validNoteId =
+      urlNoteId && notes.some((n) => n.id === urlNoteId) ? urlNoteId : null;
+
+    setSelectedFolderId((prev) => (prev !== validFolderId ? validFolderId : prev));
+    setSelectedNoteId((prev) => {
+      if (prev === validNoteId) return prev;
+      setContentOverride(null);
+      if (validNoteId) setMobileView("editor");
+      return validNoteId;
+    });
+  }, [urlFolderId, urlNoteId, isDataLoading, folders, notes, setMobileView]);
+
+  const handleSelectFolder = useCallback(
+    (id: string | null) => {
+      setSelectedFolderId(id);
+      setSearchQuery("");
+      setMobileView("notes");
+      router.push(buildHref(id, selectedNoteId), { scroll: false });
+    },
+    [router, buildHref, selectedNoteId, setMobileView]
+  );
+
+  const handleSelectNote = useCallback(
+    (id: string | null) => {
+      setSelectedNoteId(id);
+      setContentOverride(null);
+      if (id) setMobileView("editor");
+      router.push(buildHref(selectedFolderId, id), { scroll: false });
+    },
+    [router, buildHref, selectedFolderId, setMobileView]
+  );
+
+  const selectedNote = useMemo(
+    () => notes.find((note) => note.id === selectedNoteId) ?? null,
+    [notes, selectedNoteId]
+  );
+  const selectedFolder = useMemo(
+    () => folders.find((folder) => folder.id === selectedFolderId) ?? null,
+    [folders, selectedFolderId]
+  );
+  const selectedFolderName = selectedFolder?.name;
+  const filteredNotes = useNoteFilter(notes, selectedFolderId, searchQuery);
+
+  return {
+    selectedFolderId,
+    setSelectedFolderId,
+    selectedNoteId,
+    searchQuery,
+    setSearchQuery,
+    contentOverride,
+    setContentOverride,
+    buildHref,
+    handleSelectFolder,
+    handleSelectNote,
+    selectedNote,
+    selectedFolder,
+    selectedFolderName,
+    filteredNotes,
+  };
+}

--- a/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceSnapshotState.ts
@@ -16,10 +16,17 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth-context";
 import { notesDB } from "@/lib/indexedDB";
 import { logger } from "@/lib/logger";
-import { mergeFolders, mergeNotes } from "@/lib/merge";
+import {
+  mergeFolders,
+  mergeNotes,
+  reconcileFoldersDelta,
+  reconcileNotesDelta,
+} from "@/lib/merge";
 import {
   getActiveFolders,
   getActiveNotes,
+  getWorkspaceCursor,
+  isDeletedEntity,
   persistWorkspaceSnapshot,
   withSnippet,
 } from "@/lib/workspaceSync";
@@ -75,16 +82,31 @@ export function useWorkspaceSnapshotState(isAuthenticated: boolean) {
 
         if (navigator.onLine) {
           const apiClient = await getApi();
-          const snapshot = await apiClient.getWorkspaceSnapshot();
+          // ローカルキャッシュとカーソルがある再訪時は差分のみ取得し、初回は全件取得する。
+          const cursor = getWorkspaceCursor();
+          const useDelta =
+            cursor !== null &&
+            (localFolders.length > 0 || localNotes.length > 0);
+          const snapshot = await apiClient.getWorkspaceSnapshot(
+            useDelta ? cursor : undefined
+          );
           if (!isActive) {
             return;
           }
 
-          const serverFolders = getActiveFolders(snapshot);
-          const serverNotes = getActiveNotes(snapshot);
-
-          setFolders(mergeFolders(localFolders, serverFolders));
-          setNotes(mergeNotes(localNotes, serverNotes));
+          if (useDelta) {
+            // 差分: tombstone を含む delta をローカルへ適用（取りこぼし防止）
+            const deltaNotes = snapshot.notes.map((note) =>
+              isDeletedEntity(note) ? note : withSnippet(note)
+            );
+            setFolders(reconcileFoldersDelta(localFolders, snapshot.folders));
+            setNotes(reconcileNotesDelta(localNotes, deltaNotes));
+          } else {
+            const serverFolders = getActiveFolders(snapshot);
+            const serverNotes = getActiveNotes(snapshot);
+            setFolders(mergeFolders(localFolders, serverFolders));
+            setNotes(mergeNotes(localNotes, serverNotes));
+          }
 
           await persistWorkspaceSnapshot(snapshot);
         }

--- a/frontend/src/hooks/workspace/useWorkspaceState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceState.ts
@@ -1,55 +1,35 @@
 "use client";
 
 /**
- * ワークスペース全体の UI 状態・データ・操作を集約するルートフック。
- * フォルダ/ノート/チャット/エディタ/モバイルビューなど全画面に関わるステートと
- * ハンドラーをまとめ、ページコンポーネントへ一括提供する。
+ * ワークスペース全体の状態・データ・操作を合成するルートフック。
+ *
+ * 実際の状態は責務ごとに分割された 4 つのスライスが保持する:
+ * - useWorkspaceSyncState     : データ層（folders / notes / 同期ステータス）
+ * - useWorkspaceUIState       : パネル開閉・モバイルビュー・チャット幅
+ * - useWorkspaceNavigationState: 選択・検索・URL 同期・絞り込み
+ * - useWorkspaceAIState       : チャット・トークン使用量・AI 編集
+ *
+ * このフックはそれらを配線し、エディタ連携の橋渡しを加えて、ページコンポーネントへ
+ * 従来どおり一括のフラットなインターフェースで提供する。
  *
  * 主なエクスポート:
  * - useWorkspaceState: ワークスペースに必要なすべての状態・ハンドラーを返す
  *
  * 呼び出し関係: WorkspacePage などのトップレベルページコンポーネントから呼ばれる。
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useRef } from "react";
 
-import type { MobileView } from "@/components/layout";
-import { useAIChat } from "@/hooks/useAIChat";
 import { useFolders } from "@/hooks/useFolders";
-import { useNoteFilter } from "@/hooks/useNoteFilter";
 import { useNotes } from "@/hooks/useNotes";
-import { usePersistedBoolean } from "@/hooks/usePersistedBoolean";
-import { useResizable } from "@/hooks/useResizable";
-import { useTokenUsage } from "@/hooks/useTokenUsage";
 import { noteBodyStore } from "@/lib/sync/noteBodyStore";
 
+import { useWorkspaceAIState } from "./useWorkspaceAIState";
+import { useWorkspaceNavigationState } from "./useWorkspaceNavigationState";
 import { useWorkspaceSyncState } from "./useWorkspaceSyncState";
+import { useWorkspaceUIState } from "./useWorkspaceUIState";
 
 export function useWorkspaceState(isAuthenticated: boolean) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const urlNoteId = searchParams.get("note");
-  const urlFolderId = searchParams.get("folder");
-
-  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
-  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [isChatOpen, setIsChatOpen] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = usePersistedBoolean("notes-sidebar-open", true);
-  const [isNoteListOpen, setIsNoteListOpen] = usePersistedBoolean("notes-notelist-open", true);
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [mobileView, setMobileView] = useState<MobileView>("folders");
-  const [contentOverride, setContentOverride] = useState<{
-    noteId: string;
-    content: string;
-    version: number;
-  } | null>(null);
-
-  const editorContentRef = useRef("");
-  const editorSelectedTextRef = useRef("");
-  const selectionSubscribersRef = useRef(new Set<() => void>());
-
+  // データ層: フォルダ・ノート・同期ステータス
   const {
     folders,
     setFolders,
@@ -63,63 +43,23 @@ export function useWorkspaceState(isAuthenticated: boolean) {
     applySnapshot,
   } = useWorkspaceSyncState(isAuthenticated);
 
+  // UI 層: パネル開閉・モバイルビュー・チャット幅
+  const ui = useWorkspaceUIState();
+
+  // ナビゲーション層: 選択・検索・URL 同期・派生値
+  const nav = useWorkspaceNavigationState({
+    isDataLoading,
+    folders,
+    notes,
+    setMobileView: ui.setMobileView,
+  });
+
   const { handleCreateFolder, handleRenameFolder, handleDeleteFolder } = useFolders(
     folders,
     setFolders,
-    selectedFolderId,
-    setSelectedFolderId,
+    nav.selectedFolderId,
+    nav.setSelectedFolderId,
     { onSnapshotSynced: applySnapshot }
-  );
-
-  /** ?folder=<id>&?note=<id> を含む URL 文字列を生成するヘルパー。 */
-  const buildHref = useCallback(
-    (folderId: string | null, noteId: string | null) => {
-      const params = new URLSearchParams();
-      if (folderId) params.set("folder", folderId);
-      if (noteId) params.set("note", noteId);
-      const qs = params.toString();
-      return qs ? `${pathname}?${qs}` : pathname;
-    },
-    [pathname]
-  );
-
-  // URL クエリパラメータから選択状態を復元する。
-  // isDataLoading が true の間は folders/notes が未確定なので ID の有効性を検証できない。
-  // prev との比較は、同一値での setState を省略して不要な再レンダーを防ぐため。
-  useEffect(() => {
-    if (isDataLoading) return;
-    const validFolderId =
-      urlFolderId && folders.some((f) => f.id === urlFolderId) ? urlFolderId : null;
-    const validNoteId =
-      urlNoteId && notes.some((n) => n.id === urlNoteId) ? urlNoteId : null;
-
-    setSelectedFolderId((prev) => (prev !== validFolderId ? validFolderId : prev));
-    setSelectedNoteId((prev) => {
-      if (prev === validNoteId) return prev;
-      setContentOverride(null);
-      if (validNoteId) setMobileView("editor");
-      return validNoteId;
-    });
-  }, [urlFolderId, urlNoteId, isDataLoading, folders, notes]);
-
-  const handleSelectFolder = useCallback(
-    (id: string | null) => {
-      setSelectedFolderId(id);
-      setSearchQuery("");
-      setMobileView("notes");
-      router.push(buildHref(id, selectedNoteId), { scroll: false });
-    },
-    [router, buildHref, selectedNoteId]
-  );
-
-  const handleSelectNote = useCallback(
-    (id: string | null) => {
-      setSelectedNoteId(id);
-      setContentOverride(null);
-      if (id) setMobileView("editor");
-      router.push(buildHref(selectedFolderId, id), { scroll: false });
-    },
-    [router, buildHref, selectedFolderId]
   );
 
   const {
@@ -132,149 +72,64 @@ export function useWorkspaceState(isAuthenticated: boolean) {
   } = useNotes(
     notes,
     setNotes,
-    selectedFolderId,
-    selectedNoteId,
-    handleSelectNote,
+    nav.selectedFolderId,
+    nav.selectedNoteId,
+    nav.handleSelectNote,
     { onSnapshotSynced: applySnapshot }
   );
 
-  const { tokenUsage, recordUsage } = useTokenUsage(isAuthenticated);
-  const {
-    chatMessages,
-    isAILoading,
-    isEditMode,
-    setIsEditMode,
-    handleSummarize,
-    handleSendMessage,
-    handleSendEditRequest,
-    handleAcceptEdit,
-    handleRejectEdit,
-    clearChat,
-  } = useAIChat(recordUsage);
+  // AI 層: チャット・トークン使用量・AI 編集（ノート更新と UI トグルへ橋渡し）
+  const ai = useWorkspaceAIState({
+    isAuthenticated,
+    selectedNoteId: nav.selectedNoteId,
+    setContentOverride: nav.setContentOverride,
+    handleUpdateNote,
+    triggerServerSync,
+    setIsChatOpen: ui.setIsChatOpen,
+    setMobileView: ui.setMobileView,
+  });
 
-  const handleEditorContentChange = useCallback((content: string) => {
-    editorContentRef.current = content;
-    if (selectedNoteId) noteBodyStore.set(selectedNoteId, content);
-  }, [selectedNoteId]);
+  // エディタ連携: 本文・選択範囲の最新値を ref で保持し、購読者へ通知する
+  const editorContentRef = useRef("");
+  const editorSelectedTextRef = useRef("");
+  const selectionSubscribersRef = useRef(new Set<() => void>());
+
+  const handleEditorContentChange = useCallback(
+    (content: string) => {
+      editorContentRef.current = content;
+      if (nav.selectedNoteId) noteBodyStore.set(nav.selectedNoteId, content);
+    },
+    [nav.selectedNoteId]
+  );
 
   const handleEditorSelectionChange = useCallback((selectedText: string) => {
     editorSelectedTextRef.current = selectedText;
     selectionSubscribersRef.current.forEach((cb) => cb());
   }, []);
 
-  const subscribeToEditorSelectionChange = useCallback(
-    (callback: () => void) => {
-      selectionSubscribersRef.current.add(callback);
-      return () => { selectionSubscribersRef.current.delete(callback); };
-    },
-    []
-  );
-
-  const handleAcceptEditAndApply = useCallback(
-    (messageIndex: number) => {
-      const editedContent = handleAcceptEdit(messageIndex);
-      if (editedContent && selectedNoteId) {
-        setContentOverride((prev) => ({
-          noteId: selectedNoteId,
-          content: editedContent,
-          version: (prev?.version ?? 0) + 1,
-        }));
-        handleUpdateNote(selectedNoteId, { content: editedContent }, { immediate: true });
-      }
-    },
-    [handleAcceptEdit, handleUpdateNote, selectedNoteId]
-  );
-
-  const pendingEditEntry = useMemo(
-    () =>
-      chatMessages.reduce<{
-        message: (typeof chatMessages)[0];
-        index: number;
-      } | null>(
-        (found, message, index) =>
-          message.editProposal?.status === "pending" ? { message, index } : found,
-        null
-      ),
-    [chatMessages]
-  );
-
-  const chatPanelResize = useResizable({
-    storageKey: "notes-chat-width",
-    defaultWidth: 320,
-    minWidth: 280,
-    maxWidth: 600,
-    direction: "right",
-  });
-
-  const handleToggleSidebar = useCallback(() => setIsSidebarOpen((v) => !v), [setIsSidebarOpen]);
-  const handleToggleNoteList = useCallback(() => setIsNoteListOpen((v) => !v), [setIsNoteListOpen]);
-  const handleToggleChat = useCallback(() => setIsChatOpen((v) => !v), []);
-
-  const handleMobileViewChange = useCallback((view: MobileView) => {
-    setMobileView(view);
-    setIsChatOpen(view === "chat");
+  const subscribeToEditorSelectionChange = useCallback((callback: () => void) => {
+    selectionSubscribersRef.current.add(callback);
+    return () => {
+      selectionSubscribersRef.current.delete(callback);
+    };
   }, []);
 
-  const selectedNote = useMemo(
-    () => notes.find((note) => note.id === selectedNoteId) ?? null,
-    [notes, selectedNoteId]
-  );
-  const selectedFolder = useMemo(
-    () => folders.find((folder) => folder.id === selectedFolderId) ?? null,
-    [folders, selectedFolderId]
-  );
-  const selectedFolderName = selectedFolder?.name;
-  const filteredNotes = useNoteFilter(notes, selectedFolderId, searchQuery);
-
-  const handleSummarizeNote = useCallback(
-    async (id: string) => {
-      await triggerServerSync(id);
-      await handleSummarize(id);
-      setIsChatOpen(true);
-      setMobileView("chat");
-    },
-    [triggerServerSync, handleSummarize]
-  );
-
-  const handleSendEditRequestFromPanel = useCallback(
-    (
-      instruction: string,
-      content: string,
-      noteId?: string,
-      selectionRange?: { start: number; end: number }
-    ) => handleSendEditRequest(instruction, content, noteId, selectionRange),
-    [handleSendEditRequest]
-  );
-
-  const handlePendingAcceptEdit = useMemo(
-    () =>
-      pendingEditEntry
-        ? () => handleAcceptEditAndApply(pendingEditEntry.index)
-        : undefined,
-    [pendingEditEntry, handleAcceptEditAndApply]
-  );
-
-  const handlePendingRejectEdit = useMemo(
-    () =>
-      pendingEditEntry
-        ? () => handleRejectEdit(pendingEditEntry.index)
-        : undefined,
-    [pendingEditEntry, handleRejectEdit]
-  );
-
   const getCurrentEditorContent = useCallback((): string => {
-    return (selectedNoteId && noteBodyStore.get(selectedNoteId)) || editorContentRef.current;
-  }, [selectedNoteId]);
+    return (
+      (nav.selectedNoteId && noteBodyStore.get(nav.selectedNoteId)) ||
+      editorContentRef.current
+    );
+  }, [nav.selectedNoteId]);
 
   return {
-    selectedFolderId,
-    selectedNoteId,
-    searchQuery,
-    isChatOpen,
-    isSidebarOpen,
-    isNoteListOpen,
-    isSettingsOpen,
-    mobileView,
+    selectedFolderId: nav.selectedFolderId,
+    selectedNoteId: nav.selectedNoteId,
+    searchQuery: nav.searchQuery,
+    isChatOpen: ui.isChatOpen,
+    isSidebarOpen: ui.isSidebarOpen,
+    isNoteListOpen: ui.isNoteListOpen,
+    isSettingsOpen: ui.isSettingsOpen,
+    mobileView: ui.mobileView,
     folders,
     notes,
     isDataLoading,
@@ -284,49 +139,49 @@ export function useWorkspaceState(isAuthenticated: boolean) {
     offlineSyncStatus,
     offlineSyncErrorMessage,
     pendingChangesCount,
-    tokenUsage,
-    chatMessages,
-    isAILoading,
-    isEditMode,
-    contentOverride,
-    chatPanelResize,
-    selectedNote,
-    selectedFolder,
-    selectedFolderName,
-    filteredNotes,
-    pendingEditEntry,
-    setSearchQuery,
-    setIsChatOpen,
-    setIsSidebarOpen,
-    setIsNoteListOpen,
-    setIsSettingsOpen,
-    setMobileView,
-    setIsEditMode,
+    tokenUsage: ai.tokenUsage,
+    chatMessages: ai.chatMessages,
+    isAILoading: ai.isAILoading,
+    isEditMode: ai.isEditMode,
+    contentOverride: nav.contentOverride,
+    chatPanelResize: ui.chatPanelResize,
+    selectedNote: nav.selectedNote,
+    selectedFolder: nav.selectedFolder,
+    selectedFolderName: nav.selectedFolderName,
+    filteredNotes: nav.filteredNotes,
+    pendingEditEntry: ai.pendingEditEntry,
+    setSearchQuery: nav.setSearchQuery,
+    setIsChatOpen: ui.setIsChatOpen,
+    setIsSidebarOpen: ui.setIsSidebarOpen,
+    setIsNoteListOpen: ui.setIsNoteListOpen,
+    setIsSettingsOpen: ui.setIsSettingsOpen,
+    setMobileView: ui.setMobileView,
+    setIsEditMode: ai.setIsEditMode,
     handleCreateFolder,
     handleRenameFolder,
     handleDeleteFolder,
-    handleSelectFolder,
-    handleSelectNote,
+    handleSelectFolder: nav.handleSelectFolder,
+    handleSelectNote: nav.handleSelectNote,
     handleCreateNote,
     handleUpdateNote,
     handleDeleteNote,
     triggerServerSync,
-    handleSummarize,
-    handleSendMessage,
-    handleSendEditRequest,
-    handleAcceptEditAndApply,
-    handleRejectEdit,
-    clearChat,
+    handleSummarize: ai.handleSummarize,
+    handleSendMessage: ai.handleSendMessage,
+    handleSendEditRequest: ai.handleSendEditRequest,
+    handleAcceptEditAndApply: ai.handleAcceptEditAndApply,
+    handleRejectEdit: ai.handleRejectEdit,
+    clearChat: ai.clearChat,
     handleEditorContentChange,
     handleEditorSelectionChange,
-    handleToggleSidebar,
-    handleToggleNoteList,
-    handleToggleChat,
-    handleMobileViewChange,
-    handleSummarizeNote,
-    handleSendEditRequestFromPanel,
-    handlePendingAcceptEdit,
-    handlePendingRejectEdit,
+    handleToggleSidebar: ui.handleToggleSidebar,
+    handleToggleNoteList: ui.handleToggleNoteList,
+    handleToggleChat: ui.handleToggleChat,
+    handleMobileViewChange: ui.handleMobileViewChange,
+    handleSummarizeNote: ai.handleSummarizeNote,
+    handleSendEditRequestFromPanel: ai.handleSendEditRequestFromPanel,
+    handlePendingAcceptEdit: ai.handlePendingAcceptEdit,
+    handlePendingRejectEdit: ai.handlePendingRejectEdit,
     getCurrentEditorContent,
     getCurrentEditorSelectedText: () => editorSelectedTextRef.current,
     subscribeToEditorSelectionChange,

--- a/frontend/src/hooks/workspace/useWorkspaceUIState.ts
+++ b/frontend/src/hooks/workspace/useWorkspaceUIState.ts
@@ -1,0 +1,71 @@
+"use client";
+
+/**
+ * ワークスペースのパネル開閉・モバイルビュー・チャット幅などの純粋な UI 状態を集約するフック。
+ * データやナビゲーションに依存しない表示レイヤーの状態のみを扱う。
+ *
+ * 主なエクスポート:
+ * - useWorkspaceUIState: パネル開閉ステートとトグルハンドラーを返す
+ *
+ * 呼び出し関係: useWorkspaceState から合成される。
+ */
+import { useCallback, useState } from "react";
+
+import type { MobileView } from "@/components/layout";
+import { usePersistedBoolean } from "@/hooks/usePersistedBoolean";
+import { useResizable } from "@/hooks/useResizable";
+
+export function useWorkspaceUIState() {
+  const [isChatOpen, setIsChatOpen] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = usePersistedBoolean(
+    "notes-sidebar-open",
+    true
+  );
+  const [isNoteListOpen, setIsNoteListOpen] = usePersistedBoolean(
+    "notes-notelist-open",
+    true
+  );
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [mobileView, setMobileView] = useState<MobileView>("folders");
+
+  const chatPanelResize = useResizable({
+    storageKey: "notes-chat-width",
+    defaultWidth: 320,
+    minWidth: 280,
+    maxWidth: 600,
+    direction: "right",
+  });
+
+  const handleToggleSidebar = useCallback(
+    () => setIsSidebarOpen((v) => !v),
+    [setIsSidebarOpen]
+  );
+  const handleToggleNoteList = useCallback(
+    () => setIsNoteListOpen((v) => !v),
+    [setIsNoteListOpen]
+  );
+  const handleToggleChat = useCallback(() => setIsChatOpen((v) => !v), []);
+
+  const handleMobileViewChange = useCallback((view: MobileView) => {
+    setMobileView(view);
+    setIsChatOpen(view === "chat");
+  }, []);
+
+  return {
+    isChatOpen,
+    setIsChatOpen,
+    isSidebarOpen,
+    setIsSidebarOpen,
+    isNoteListOpen,
+    setIsNoteListOpen,
+    isSettingsOpen,
+    setIsSettingsOpen,
+    mobileView,
+    setMobileView,
+    chatPanelResize,
+    handleToggleSidebar,
+    handleToggleNoteList,
+    handleToggleChat,
+    handleMobileViewChange,
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,14 +19,7 @@ import type {
   EditJobRequest,
   EditRequest,
   EditResponse,
-  Folder,
-  FolderCreate,
-  FolderUpdate,
-
-  Note,
-  NoteCreate,
   NoteShare,
-  NoteUpdate,
   SettingsResponse,
   SharedNote,
   SummarizeRequest,
@@ -112,68 +105,21 @@ class ApiClient {
     return response.json();
   }
 
-  // Folders API
-  async listFolders(): Promise<Folder[]> {
-    return this.request<Folder[]>("/api/folders");
-  }
-
-  async createFolder(data: FolderCreate): Promise<Folder> {
-    return this.request<Folder>("/api/folders", {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
-  }
-
-  async getFolder(id: string): Promise<Folder> {
-    return this.request<Folder>(`/api/folders/${id}`);
-  }
-
-  async updateFolder(id: string, data: FolderUpdate): Promise<Folder> {
-    return this.request<Folder>(`/api/folders/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify(data),
-    });
-  }
-
-  async deleteFolder(id: string): Promise<void> {
-    return this.request<void>(`/api/folders/${id}`, {
-      method: "DELETE",
-    });
-  }
-
-  // Notes API
-  async listNotes(folderId?: string): Promise<Note[]> {
-    const query = folderId ? `?folder_id=${folderId}` : "";
-    return this.request<Note[]>(`/api/notes${query}`);
-  }
-
-  async createNote(data: NoteCreate): Promise<Note> {
-    return this.request<Note>("/api/notes", {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
-  }
-
-  async getNote(id: string): Promise<Note> {
-    return this.request<Note>(`/api/notes/${id}`);
-  }
-
-  async updateNote(id: string, data: NoteUpdate): Promise<Note> {
-    return this.request<Note>(`/api/notes/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify(data),
-    });
-  }
-
-  async deleteNote(id: string): Promise<void> {
-    return this.request<void>(`/api/notes/${id}`, {
-      method: "DELETE",
-    });
-  }
-
   // Workspace Sync API
-  async getWorkspaceSnapshot(): Promise<WorkspaceSnapshotResponse> {
-    return this.request<WorkspaceSnapshotResponse>("/api/workspace/snapshot");
+  //
+  // All note/folder reads and writes flow through the workspace snapshot and
+  // changes endpoints below. The per-entity REST methods (listNotes,
+  // createFolder, ...) were removed as dead code — the backend routers remain
+  // for the external API-key integration, but the in-app client never used them.
+  async getWorkspaceSnapshot(
+    sinceCursor?: string
+  ): Promise<WorkspaceSnapshotResponse> {
+    const query = sinceCursor
+      ? `?since=${encodeURIComponent(sinceCursor)}`
+      : "";
+    return this.request<WorkspaceSnapshotResponse>(
+      `/api/workspace/snapshot${query}`
+    );
   }
 
   async applyWorkspaceChanges(

--- a/frontend/src/lib/merge.test.ts
+++ b/frontend/src/lib/merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeNotes, mergeFolders } from './merge';
+import { mergeNotes, mergeFolders, reconcileNotesDelta } from './merge';
 import { Note, Folder } from '../types';
 
 describe('mergeNotes', () => {
@@ -64,6 +64,75 @@ describe('mergeNotes', () => {
 
     const result = mergeNotes([local], [server]);
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('reconcileNotesDelta', () => {
+  const baseNote: Note = {
+    id: '1',
+    title: 'Test Note',
+    content: 'Content',
+    user_id: 'u1',
+    folder_id: null,
+    version: 1,
+    created_at: '2023-01-01T10:00:00Z',
+    updated_at: '2023-01-01T10:00:00Z',
+    deleted_at: null,
+  };
+
+  it('keeps local notes that are absent from the delta', () => {
+    const localA = { ...baseNote, id: 'a' };
+    const localB = { ...baseNote, id: 'b' };
+    const deltaB = { ...baseNote, id: 'b', title: 'B updated', version: 2 };
+
+    const result = reconcileNotesDelta([localA, localB], [deltaB]);
+    expect(result).toHaveLength(2);
+    expect(result.find((n) => n.id === 'a')).toEqual(localA);
+    expect(result.find((n) => n.id === 'b')?.title).toBe('B updated');
+  });
+
+  it('upserts new notes from the delta', () => {
+    const localA = { ...baseNote, id: 'a' };
+    const deltaC = { ...baseNote, id: 'c', title: 'New' };
+
+    const result = reconcileNotesDelta([localA], [deltaC]);
+    expect(result).toHaveLength(2);
+    expect(result.find((n) => n.id === 'c')?.title).toBe('New');
+  });
+
+  it('removes notes that arrive as tombstones in the delta', () => {
+    const localA = { ...baseNote, id: 'a' };
+    const localB = { ...baseNote, id: 'b' };
+    const tombstoneB = {
+      ...baseNote,
+      id: 'b',
+      version: 2,
+      deleted_at: '2023-01-02T10:00:00Z',
+    };
+
+    const result = reconcileNotesDelta([localA, localB], [tombstoneB]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+  });
+
+  it('preserves a newer unsynced local edit over an older delta entry', () => {
+    const localNewer = {
+      ...baseNote,
+      id: 'a',
+      title: 'Local offline edit',
+      version: 3,
+      updated_at: '2023-01-05T10:00:00Z',
+    };
+    const deltaOlder = {
+      ...baseNote,
+      id: 'a',
+      title: 'Stale server',
+      version: 2,
+      updated_at: '2023-01-03T10:00:00Z',
+    };
+
+    const result = reconcileNotesDelta([localNewer], [deltaOlder]);
+    expect(result[0].title).toBe('Local offline edit');
   });
 });
 

--- a/frontend/src/lib/merge.ts
+++ b/frontend/src/lib/merge.ts
@@ -97,3 +97,52 @@ export function mergeNotes(localNotes: Note[], serverNotes: Note[]): Note[] {
 export function mergeFolders(localFolders: Folder[], serverFolders: Folder[]): Folder[] {
   return mergeWorkspaceEntities(localFolders, serverFolders);
 }
+
+/**
+ * サーバーからの差分（delta）スナップショットを既存のローカルリストへ適用する。
+ *
+ * mergeWorkspaceEntities がサーバー側を基準（全件スナップショット前提）にするのに対し、
+ * こちらは「現在のローカルリストを基準」に delta だけを反映するため、delta に含まれない
+ * 既存エンティティを取りこぼさない。差分同期（GET /snapshot?since=cursor）専用。
+ *
+ * - 論理削除済み（tombstone）の到着エンティティはローカルから除去する。
+ * - それ以外は upsert する。ただしローカルの方が新しい（未同期のオフライン編集）場合は
+ *   ローカルを保持し、古いサーバー値で上書きしない。
+ */
+function reconcileDeltaEntities<T extends {
+  id: string;
+  version: number;
+  updated_at: string;
+  deleted_at: string | null;
+}>(localEntities: T[], deltaEntities: T[]): T[] {
+  const mergedMap = new Map<string, T>(
+    localEntities.map((entity) => [entity.id, entity])
+  );
+
+  for (const deltaEntity of deltaEntities) {
+    if (isDeletedEntity(deltaEntity)) {
+      mergedMap.delete(deltaEntity.id);
+      continue;
+    }
+
+    const localEntity = mergedMap.get(deltaEntity.id);
+    if (localEntity && isLocalEntityNewer(localEntity, deltaEntity)) {
+      // 未同期のローカル編集の方が新しい場合は上書きしない
+      continue;
+    }
+    mergedMap.set(deltaEntity.id, deltaEntity);
+  }
+
+  return Array.from(mergedMap.values());
+}
+
+export function reconcileNotesDelta(localNotes: Note[], deltaNotes: Note[]): Note[] {
+  return reconcileDeltaEntities(localNotes, deltaNotes);
+}
+
+export function reconcileFoldersDelta(
+  localFolders: Folder[],
+  deltaFolders: Folder[]
+): Folder[] {
+  return reconcileDeltaEntities(localFolders, deltaFolders);
+}

--- a/frontend/src/lib/sync/useNoteSyncEngine.test.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.test.ts
@@ -373,6 +373,74 @@ describe("useNoteSyncEngine", () => {
     vi.useRealTimers();
   });
 
+  it("coalesces a rapid title + content edit into a single change so neither field is lost", async () => {
+    vi.useFakeTimers();
+
+    const initialNote = buildNote();
+    const serverNote = buildNote({
+      title: "New Title",
+      content: "New body",
+      version: 2,
+      updated_at: "2024-01-02T00:00:00.000Z",
+    });
+    const applyWorkspaceChanges = vi.fn().mockResolvedValue({
+      applied: [
+        {
+          entity: "note",
+          operation: "update",
+          entity_id: serverNote.id,
+          client_mutation_id: null,
+          folder: null,
+          note: serverNote,
+        },
+      ],
+      snapshot: {
+        folders: [],
+        notes: [serverNote],
+        cursor: "cursor-2",
+        server_time: "2024-01-02T00:00:00.000Z",
+      },
+    });
+    getApiMock.mockResolvedValue({ applyWorkspaceChanges });
+
+    const { result } = renderHook(() =>
+      useNoteSyncEngineHarness([initialNote], null, initialNote.id)
+    );
+
+    // Title edit followed immediately by a content edit, both inside the debounce window.
+    await act(async () => {
+      await result.current.handleUpdateNote(initialNote.id, { title: "New Title" });
+    });
+    await act(async () => {
+      await result.current.handleUpdateNote(initialNote.id, { content: "New body" });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+      await result.current.triggerServerSync(initialNote.id);
+    });
+
+    // A single coalesced update carrying BOTH fields with one expected_version —
+    // no second version-checked request that could 409 and drop the title.
+    expect(applyWorkspaceChanges).toHaveBeenCalledTimes(1);
+    expect(applyWorkspaceChanges).toHaveBeenCalledWith({
+      device_id: "device-1",
+      base_cursor: "cursor-1",
+      changes: [
+        {
+          entity: "note",
+          operation: "update",
+          entity_id: initialNote.id,
+          expected_version: 1,
+          payload: { title: "New Title", content: "New body" },
+        },
+      ],
+    });
+    expect(result.current.syncStatus.remote).toBe("synced");
+
+    vi.useRealTimers();
+  });
+
   it("metadata-only update calls saveNote, not saveNoteBody", async () => {
     const initialNote = buildNote();
     const { result } = renderHook(() =>

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -82,6 +82,10 @@ export function useNoteSyncEngine({
   const retryArgsRef = useRef<{ id: string; updates: NoteSyncUpdates; expectedVersion?: number } | null>(null);
   const syncNoteToServerRef = useRef<((id: string, updates: NoteSyncUpdates, expectedVersion?: number) => Promise<void>) | null>(null);
   const serverVersionByNoteIdRef = useRef<Record<string, number>>({});
+  // ノート ID ごとに、デバウンス窓の間に発生した更新フィールドを統合して保持する。
+  // タイトルと本文を相次いで編集した場合に、両方を 1 件の変更にまとめて送ることで
+  // 同一 expected_version の競合 (409) によるフィールド消失を防ぐ。
+  const pendingUpdatesByNoteIdRef = useRef<Record<string, NoteSyncUpdates>>({});
   const handleSnapshotSynced = onSnapshotSynced ?? NOOP_SNAPSHOT_SYNC;
 
   /**
@@ -141,6 +145,9 @@ export function useNoteSyncEngine({
    */
   const syncNoteToServer = useCallback(
     async (id: string, updates: NoteSyncUpdates, expectedVersion?: number) => {
+      // 送信時点で当該ノートの保留統合バッファを確定・クリアする。
+      // これ以降に到着する編集は、新しい expected_version を基にした次の同期へ蓄積される。
+      delete pendingUpdatesByNoteIdRef.current[id];
       if (navigator.onLine) {
         const task = async () => {
           setRemoteStatus("syncing");
@@ -477,13 +484,22 @@ export function useNoteSyncEngine({
         }
       }
 
+      // デバウンス窓内の更新フィールドを統合する。
+      // 例: 先にタイトル {title}、続いて本文 {content} が来た場合、{title, content} に
+      // まとめて 1 件の変更として送信し、同一 expected_version での競合を回避する。
+      const mergedUpdates: NoteSyncUpdates = {
+        ...pendingUpdatesByNoteIdRef.current[id],
+        ...updates,
+      };
+      pendingUpdatesByNoteIdRef.current[id] = mergedUpdates;
+
       const expectedVersion = getExpectedVersion(id, noteForLocalSave?.version);
       setRemoteStatus("unsynced");
       if (options?.immediate) {
         cancelServerSync();
-        void syncNoteToServer(id, updates, expectedVersion);
+        void syncNoteToServer(id, mergedUpdates, expectedVersion);
       } else {
-        debouncedServerSync(id, updates, expectedVersion);
+        debouncedServerSync(id, mergedUpdates, expectedVersion);
       }
     },
     [cancelServerSync, debouncedServerSync, getExpectedVersion, setNotes, syncNoteToServer, t]
@@ -497,6 +513,8 @@ export function useNoteSyncEngine({
     async (id: string) => {
       try {
         cancelServerSync();
+        // 削除されるノートの保留統合バッファを破棄し、不要な更新送信を防ぐ。
+        delete pendingUpdatesByNoteIdRef.current[id];
         const noteToDelete = await notesDB.getNote(id);
         const expectedVersion = getExpectedVersion(id, noteToDelete?.version);
 

--- a/frontend/tests/golden-path.spec.ts
+++ b/frontend/tests/golden-path.spec.ts
@@ -278,7 +278,7 @@ test.describe("Golden Path: Note Lifecycle", () => {
       60000,
     );
     await deleteButton.click();
-    await page.getByRole("button", { name: "Confirm" }).click();
+    await page.getByRole("button", { name: /Confirm|確認/ }).click();
     await deleteResponse;
     markNoteDeleted(note.id);
 
@@ -344,7 +344,7 @@ test.describe("Golden Path: Note Lifecycle", () => {
       60000,
     );
     await deleteButton.click();
-    await page.getByRole("button", { name: "Confirm" }).click();
+    await page.getByRole("button", { name: /Confirm|確認/ }).click();
     await deleteResponse;
     markFolderDeleted(folder.id);
 
@@ -588,7 +588,7 @@ test.describe("Golden Path: Note Lifecycle", () => {
       60000,
     );
     await deleteFolderButton.click();
-    await page.getByRole("button", { name: "Confirm" }).click();
+    await page.getByRole("button", { name: /Confirm|確認/ }).click();
     await deleteFolderResponse;
     markFolderDeleted(createdFolderId);
     markNoteDeleted(createdNoteId);

--- a/frontend/tests/regression/ai-edit.spec.ts
+++ b/frontend/tests/regression/ai-edit.spec.ts
@@ -6,6 +6,7 @@ import {
   getNoteFixture,
   waitForWorkspaceSnapshotReady,
 } from '../helpers/apiFixtures';
+import { waitForWorkspaceChange } from '../helpers/workspaceSync';
 
 const SNAPSHOT_WARMUP = { attempts: 12, delayMs: 5000, timeoutMs: 30000 };
 
@@ -35,6 +36,31 @@ test.describe('Regression: AI Edit (#78 / #79 contentOverride scope)', () => {
     await noteItem.click();
     await expect(layout.getByTestId('editor-title-input')).toHaveValue(noteTitle, { timeout: 20000 });
 
+    // Mock the edit-jobs API: Lambda/Bedrock is too slow in dev for an unguarded real call.
+    // The accept flow (diff view → accept → persist) is what we're testing here; actual AI
+    // output quality is covered by the integration test suite.
+    const mockedEditedContent = 'This sentence has been improved. It is a formal test case.';
+    await page.route('**/api/ai/edit-jobs', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            job: {
+              id: 'mock-accept-job',
+              status: 'completed',
+              edited_content: mockedEditedContent,
+              tokens_used: 10,
+              error_message: null,
+              note_id: null,
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
     // Open AI chat panel
     await layout.getByTestId('editor-chat-button').click();
 
@@ -49,8 +75,8 @@ test.describe('Regression: AI Edit (#78 / #79 contentOverride scope)', () => {
     await chatInput.fill('Make this text more formal and concise.');
 
     const editResponsePromise = page.waitForResponse(
-      (resp) => resp.url().includes('/api/ai/edit') && resp.status() < 400,
-      { timeout: 120000 }
+      (resp) => resp.url().includes('/api/ai/edit-jobs') && resp.request().method() === 'POST' && resp.status() < 400,
+      { timeout: 10000 }
     );
     await layout.getByTestId('ai-chat-send-button').click();
     await editResponsePromise;
@@ -67,14 +93,17 @@ test.describe('Regression: AI Edit (#78 / #79 contentOverride scope)', () => {
     await expect(acceptButton).toBeVisible({ timeout: 10000 });
     await acceptButton.click();
 
-    // After accepting, the diff panel should collapse and the editor re-appear
+    // After accepting, the diff panel should collapse and the editor re-appear.
+    // The accept triggers an immediate server sync — wait for it before reading the API.
+    const syncResponse = waitForWorkspaceChange(page, 'note', 'update', 30000);
     await expect(diffPanel).not.toBeVisible({ timeout: 15000 });
     await expect(layout.getByTestId('editor-content-input')).toBeVisible({ timeout: 10000 });
+    await syncResponse;
 
-    // Verify the note content changed (was updated to the edited version)
+    // Verify the note content changed to the mocked edited version
     const updatedNote = await getNoteFixture(page, note.id);
     expect(updatedNote.content).not.toBe(originalContent);
-    expect(updatedNote.content.trim().length).toBeGreaterThan(0);
+    expect(updatedNote.content.trim()).toBe(mockedEditedContent);
 
     await deleteNoteFixture(page, note.id);
   });

--- a/frontend/tests/regression/ai-edit.spec.ts
+++ b/frontend/tests/regression/ai-edit.spec.ts
@@ -50,7 +50,7 @@ test.describe('Regression: AI Edit (#78 / #79 contentOverride scope)', () => {
 
     const editResponsePromise = page.waitForResponse(
       (resp) => resp.url().includes('/api/ai/edit') && resp.status() < 400,
-      { timeout: 60000 }
+      { timeout: 120000 }
     );
     await layout.getByTestId('ai-chat-send-button').click();
     await editResponsePromise;

--- a/frontend/tests/regression/api-key.spec.ts
+++ b/frontend/tests/regression/api-key.spec.ts
@@ -19,7 +19,12 @@ async function openSettings(
   const container = isMobile
     ? page.getByTestId('mobile-layout-folders')
     : page.getByTestId('desktop-layout');
-  const settingsButton = container.locator('button[title="Settings"]').first();
+  // The settings button title/aria-label is localized (en: "Settings", ja: "設定"),
+  // so match by accessible name in either language to keep the helper
+  // language-agnostic regardless of the shared dev account's saved locale.
+  const settingsButton = container
+    .getByRole('button', { name: /Settings|設定/ })
+    .first();
   await expect(settingsButton).toBeVisible({ timeout: 15000 });
   await settingsButton.click();
 }
@@ -184,7 +189,6 @@ test.describe('Regression: API Key Lifecycle', () => {
 
       // D. Revoke via UI — navigate from the unique key name up to its row div
       const keyRow = dialog.locator('p').filter({ hasText: keyName }).locator('xpath=ancestor::div[button][1]');
-      page.once('dialog', (d) => d.accept());
       const revokeRespPromise = page.waitForResponse(
         (r) =>
           r.url().includes(`/api/settings/api-keys/${createdKeyId}`) &&
@@ -192,6 +196,9 @@ test.describe('Regression: API Key Lifecycle', () => {
         { timeout: 30_000 },
       );
       await keyRow.getByRole('button', { name: /Revoke|失効/i }).click();
+      // Revoke opens an in-app confirm modal (migrated from native window.confirm
+      // in #129); confirm it. Label is localized: en "Confirm" / ja "確認".
+      await page.getByRole('button', { name: /^(Confirm|確認)$/ }).click();
       const revokeResp = await revokeRespPromise;
       expect(revokeResp.status()).toBe(204);
       createdKeyId = null;

--- a/frontend/tests/regression/settings.spec.ts
+++ b/frontend/tests/regression/settings.spec.ts
@@ -12,7 +12,12 @@ async function openSettings(page: Parameters<typeof waitForWorkspaceSnapshotRead
   const container = isMobile
     ? page.getByTestId('mobile-layout-folders')
     : page.getByTestId('desktop-layout');
-  const settingsButton = container.locator('button[title="Settings"]').first();
+  // The settings button title/aria-label is localized (en: "Settings", ja: "設定"),
+  // so match by accessible name in either language to keep the helper
+  // language-agnostic regardless of the shared dev account's saved locale.
+  const settingsButton = container
+    .getByRole('button', { name: /Settings|設定/ })
+    .first();
   await expect(settingsButton).toBeVisible({ timeout: 15000 });
   await settingsButton.click();
 }

--- a/frontend/tests/regression/settings.spec.ts
+++ b/frontend/tests/regression/settings.spec.ts
@@ -25,7 +25,7 @@ async function openSettings(page: Parameters<typeof waitForWorkspaceSnapshotRead
 test.describe('Regression: Settings', () => {
   test('should display all expected controls', async ({ page, isMobile, browserName }) => {
     if (browserName === 'webkit') test.skip();
-    test.setTimeout(60000);
+    test.setTimeout(90000);
 
     await page.goto('/');
     await waitForWorkspaceSnapshotReady(page, SNAPSHOT_WARMUP);

--- a/frontend/tests/regression/settings.spec.ts
+++ b/frontend/tests/regression/settings.spec.ts
@@ -12,6 +12,9 @@ async function openSettings(page: Parameters<typeof waitForWorkspaceSnapshotRead
   const container = isMobile
     ? page.getByTestId('mobile-layout-folders')
     : page.getByTestId('desktop-layout');
+  // Wait for the workspace to finish loading (desktop-layout is replaced by a spinner
+  // while isDataLoading=true, e.g. during Lambda cold-start + snapshot fetch on dev).
+  await expect(container).toBeVisible({ timeout: 60000 });
   // The settings button title/aria-label is localized (en: "Settings", ja: "設定"),
   // so match by accessible name in either language to keep the helper
   // language-agnostic regardless of the shared dev account's saved locale.
@@ -48,7 +51,7 @@ test.describe('Regression: Settings', () => {
 
   test('should switch language and persist after save', async ({ page, isMobile, browserName }) => {
     if (browserName === 'webkit') test.skip();
-    test.setTimeout(90000);
+    test.setTimeout(150000);
 
     await page.goto('/');
     await waitForWorkspaceSnapshotReady(page, SNAPSHOT_WARMUP);

--- a/frontend/tests/regression/settings.spec.ts
+++ b/frontend/tests/regression/settings.spec.ts
@@ -18,7 +18,7 @@ async function openSettings(page: Parameters<typeof waitForWorkspaceSnapshotRead
   const settingsButton = container
     .getByRole('button', { name: /Settings|設定/ })
     .first();
-  await expect(settingsButton).toBeVisible({ timeout: 15000 });
+  await expect(settingsButton).toBeVisible({ timeout: 30000 });
   await settingsButton.click();
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,12 @@
+# Tool versions for the project. Run `mise install` after cloning.
+# All versions are pinned to concrete releases for reproducibility across
+# machines and CI — do not use "latest" (a floating version makes the
+# pre-commit hooks and lint output non-deterministic between contributors).
 [tools]
 node = "24.14.0"
 python = "3.12.3"
-go = "1.26.0"
-terraform = "1"
-"awscli" = "latest"
-uv = "latest"
-lefthook = "latest"
-"github:open-policy-agent/conftest" = "latest"
+terraform = "1.15.5"
+awscli = "2.34.57"
+uv = "0.11.17"
+lefthook = "2.1.9"
+"github:open-policy-agent/conftest" = "0.68.2"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -3,7 +3,18 @@
 locals {
   sentry_backend_dsn_parameter_name = "/${var.project_name}/${terraform.workspace}/sentry-dsn-backend"
 
+  # 結合テスト用バイパストークンは dev 環境でのみ有効。値は Terraform が生成し
+  # SSM SecureString に保存したうえで Lambda 環境変数に注入する。
+  # ソースコードには一切ハードコードしない。
+  enable_integration_bypass = terraform.workspace == "dev"
+
+  integration_bypass_env = local.enable_integration_bypass ? {
+    INTEGRATION_TEST_BYPASS_TOKEN   = random_password.integration_test_bypass_token[0].result
+    INTEGRATION_TEST_BYPASS_TOKEN_2 = random_password.integration_test_bypass_token_2[0].result
+  } : {}
+
   backend_lambda_environment = merge(
+    local.integration_bypass_env,
     {
       COGNITO_USER_POOL_ID  = aws_cognito_user_pool.main.id
       COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.main.id
@@ -28,6 +39,44 @@ locals {
       SENTRY_TRACES_SAMPLE_RATE = tostring(var.sentry_traces_sample_rate)
     }
   )
+}
+
+# Integration-test bypass tokens (dev only).
+# Terraform generates random secrets, stores them in SSM SecureString for
+# auditability/retrieval by the test runner, and injects them into the Lambda
+# environment above. Never hardcoded in source.
+resource "random_password" "integration_test_bypass_token" {
+  count   = local.enable_integration_bypass ? 1 : 0
+  length  = 48
+  special = false
+}
+
+resource "random_password" "integration_test_bypass_token_2" {
+  count   = local.enable_integration_bypass ? 1 : 0
+  length  = 48
+  special = false
+}
+
+resource "aws_ssm_parameter" "integration_test_bypass_token" {
+  count = local.enable_integration_bypass ? 1 : 0
+  name  = "/${var.project_name}/${terraform.workspace}/integration-test-bypass-token"
+  type  = "SecureString"
+  value = random_password.integration_test_bypass_token[0].result
+
+  tags = {
+    Name = "${var.project_name}-integration-bypass-token-${terraform.workspace}"
+  }
+}
+
+resource "aws_ssm_parameter" "integration_test_bypass_token_2" {
+  count = local.enable_integration_bypass ? 1 : 0
+  name  = "/${var.project_name}/${terraform.workspace}/integration-test-bypass-token-2"
+  type  = "SecureString"
+  value = random_password.integration_test_bypass_token_2[0].result
+
+  tags = {
+    Name = "${var.project_name}-integration-bypass-token-2-${terraform.workspace}"
+  }
 }
 
 # Lambda function
@@ -131,7 +180,7 @@ resource "aws_apigatewayv2_api" "api" {
       "https://${local.current_env.admin_domain_name}"
     ]
     allow_methods     = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
-    allow_headers     = ["Authorization", "Content-Type", "sentry-trace", "baggage"]
+    allow_headers     = ["Authorization", "Content-Type", "X-API-Key", "X-Request-ID", "sentry-trace", "baggage"]
     allow_credentials = true
     max_age           = 86400
   }
@@ -266,4 +315,18 @@ output "api_url" {
 output "ecr_repository_url" {
   description = "ECR repository URL for API container"
   value       = aws_ecr_repository.api.repository_url
+}
+
+# Integration-test bypass tokens (dev only). Sensitive: consumed by the test
+# runner via `terraform output -raw`. Empty string in non-dev workspaces.
+output "integration_test_bypass_token" {
+  description = "Integration test bypass token (dev only)"
+  value       = local.enable_integration_bypass ? random_password.integration_test_bypass_token[0].result : ""
+  sensitive   = true
+}
+
+output "integration_test_bypass_token_2" {
+  description = "Second integration test bypass token (dev only)"
+  value       = local.enable_integration_bypass ? random_password.integration_test_bypass_token_2[0].result : ""
+  sensitive   = true
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 

--- a/terraform/policies/security/lambda.rego
+++ b/terraform/policies/security/lambda.rego
@@ -38,11 +38,15 @@ deny contains msg if {
 
 # --- Check 3: Every Lambda must have an explicit CloudWatch log group ---
 
-# Collect log group names that are being created/updated
+# Collect log group names that will exist after apply.
+# This includes no-op log groups (already provisioned, unchanged in this plan),
+# not just those being created/updated — otherwise an incremental plan that only
+# updates a Lambda (e.g. a new image digest or environment variable) would falsely
+# fail because its pre-existing log group is a no-op in resource_changes.
 _log_group_names contains name if {
 	rc := input.resource_changes[_]
 	rc.type == "aws_cloudwatch_log_group"
-	resource_applies(rc)
+	rc.change.after != null
 	name := rc.change.after.name
 }
 


### PR DESCRIPTION
## Summary

Remediation of the multi-agent code review findings, verified end-to-end on the local stack and the deployed **dev** environment. 12 logically-scoped commits.

### Security
- **Auth bypass hardened** — the dev integration-test bypass no longer honors hardcoded token strings. Tokens are generated by Terraform, stored in SSM SecureString, and injected into the dev Lambda env; the bypass is inert unless the secret is present and matches. Integration tests read the tokens from `terraform output`.
- **AI input size caps** — `EditRequest`/`ChatRequest` fields bounded to prevent unbounded Bedrock token consumption (422 on oversized input).
- **CORS** — added `X-API-Key`/`X-Request-ID` to the API Gateway allow_headers to match FastAPI (fixes silent browser preflight blocks). Confirmed live on dev.

### Bug fixes
- **Folder delete no longer orphans notes** — child notes get `folder_id` cleared (survive in All Notes) instead of referencing a tombstoned folder.
- **`folder_id: null` honored** — `NoteRepository.update` uses `model_fields_set`, so moving a note out of a folder is no longer dropped.
- **Share expiry** — naive `expires_at` treated as UTC (was a 500 instead of 410).
- **Concurrent title+content edit no longer loses the title** (real data-loss bug, reproduced in-browser on dev) — pending updates are coalesced per note id into a single versioned change. _(implemented via a sub-agent)_

### Architecture
- `useWorkspaceState` god hook split into UI / navigation / AI slices + a thin composition root (public API unchanged).
- Cursor-based **delta workspace snapshot sync** (`GET /snapshot?since=`); the previously-unused cursor is now functional. Removed 10 dead `ApiClient` CRUD methods (backend routers retained — they back the external API-key feature).

### Tests / DX / infra
- Added tests: image magic-byte spoofing, share-expiry 410, folder orphan, `folder_id:null` move, snapshot delta, AI size caps, and the title/content coalescing regression.
- Made flaky livePreview decoration tests deterministic under CPU load.
- Fixed pre-existing dev E2E regression helpers (locale-agnostic settings button + modal-confirm revoke).
- Fixed a conftest Lambda log-group policy false-positive on incremental plans.
- Pinned `mise` tool versions, removed phantom Go dep, documented `make dev-stack`.

### Notes
- Two review findings were **inaccurate and intentionally not acted on**: `.env` files are already gitignored (not committed), and the backend notes/folders routers are *not* dead (they power the external API-key feature).

## Verification
- `make test`: backend **219** + frontend **396** + lint — green.
- Local E2E (Chromium): golden-path **5/5**, regression **20/20**.
- **Dev**: deployed backend + frontend; integration tests **31/31**; CORS confirmed; manual Chrome check of note CRUD / title+content persistence / modal-confirm delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)