### PR TITLE
fix: stop 401 infinite retry and show session-expired banner

### DIFF
--- a/frontend/src/components/ui/SessionExpiredBanner.tsx
+++ b/frontend/src/components/ui/SessionExpiredBanner.tsx
@@ -1,0 +1,49 @@
+/**
+ * セッション失効時に表示するバナーコンポーネント。
+ * useAuth().sessionExpired が true のときに表示し、再ログイン導線を提供する。
+ * 自動サインアウトはしない。再ログイン後に sessionExpired が false になりバナーが消える。
+ *
+ * 主なエクスポート:
+ * - SessionExpiredBanner: セッション失効通知バナー
+ *
+ * 呼び出し関係: AuthenticatedWorkspace から fixed 表示で使用される。
+ */
+"use client";
+
+import Link from "next/link";
+import { LogInIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useTranslation } from "@/hooks";
+import { useAuth } from "@/lib/auth-context";
+import { Button } from "@/components/ui/button";
+
+/**
+ * セッション失効バナー。
+ * sessionExpired フラグを auth-context から直接読むため props 不要。
+ * 表示されていない場合は何も描画しない。
+ */
+export function SessionExpiredBanner({ className }: { className?: string }) {
+  const { sessionExpired } = useAuth();
+  const { t } = useTranslation();
+
+  if (!sessionExpired) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 px-4 py-2 text-xs rounded-full",
+        "bg-background/80 backdrop-blur-sm border border-destructive/40",
+        "shadow-sm text-destructive",
+        className
+      )}
+    >
+      <LogInIcon className="h-4 w-4 shrink-0" />
+      <span className="text-muted-foreground">{t("sync.sessionExpired")}</span>
+      <Button asChild size="sm" variant="outline" className="h-6 px-2 text-xs shrink-0">
+        <Link href="/login">{t("auth.login")}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/AuthenticatedWorkspace.tsx
+++ b/frontend/src/components/workspace/AuthenticatedWorkspace.tsx
@@ -18,6 +18,7 @@ import {
   ThreeColumnLayout,
 } from "@/components/layout";
 import { SyncStatusIndicator } from "@/components/ui/SyncStatusIndicator";
+import { SessionExpiredBanner } from "@/components/ui/SessionExpiredBanner";
 import { WorkspaceSidebarFooter } from "@/components/workspace/WorkspaceSidebarFooter";
 import { useTranslation } from "@/hooks";
 import { useWorkspaceState } from "@/hooks/workspace/useWorkspaceState";
@@ -150,6 +151,7 @@ export function AuthenticatedWorkspace({
         savedLocally={false}
         className="fixed bottom-20 md:bottom-4 right-4 z-50"
       />
+      <SessionExpiredBanner className="fixed bottom-32 md:bottom-16 right-4 z-50" />
       <SettingsDialog
         open={workspace.isSettingsOpen}
         onOpenChange={workspace.setIsSettingsOpen}

--- a/frontend/src/hooks/useNotes.test.ts
+++ b/frontend/src/hooks/useNotes.test.ts
@@ -58,7 +58,15 @@ vi.mock("@/lib/workspaceSync", () => ({
   getWorkspaceSyncRequestMetadata: () => getWorkspaceSyncRequestMetadataMock(),
   withSnippet: (note: Note) => ({ ...note, snippet: (note.content ?? "").slice(0, 80) }),
   isConflictApiError: () => false,
+  isAuthApiError: () => false,
   refreshWorkspaceSnapshot: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    sessionExpired: false,
+    notifySessionExpired: vi.fn(),
+  }),
 }));
 
 import { useNotes } from "./useNotes";

--- a/frontend/src/hooks/useOfflineSync.test.ts
+++ b/frontend/src/hooks/useOfflineSync.test.ts
@@ -19,6 +19,15 @@ vi.mock('./useApi', () => ({
   }),
 }))
 
+// Mock auth-context
+const notifySessionExpiredMock = vi.fn()
+vi.mock('@/lib/auth-context', () => ({
+  useAuth: () => ({
+    sessionExpired: false,
+    notifySessionExpired: notifySessionExpiredMock,
+  }),
+}))
+
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
     t: (key: string) => {

--- a/frontend/src/hooks/useOfflineSync.ts
+++ b/frontend/src/hooks/useOfflineSync.ts
@@ -17,6 +17,7 @@ import { logger } from "@/lib/logger";
 import { syncQueue, type SyncStatus } from "@/lib/syncQueue";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useApi } from "./useApi";
+import { useAuth } from "@/lib/auth-context";
 import type { WorkspaceSnapshotResponse } from "@/types";
 
 const NOOP_SNAPSHOT_SYNC: (snapshot: WorkspaceSnapshotResponse) => void = () => {};
@@ -45,6 +46,7 @@ export function useOfflineSync(
   const [pendingChangesCount, setPendingChangesCount] = useState(0);
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
   const { getApi } = useApi();
+  const { sessionExpired, notifySessionExpired } = useAuth();
   const { t } = useTranslation();
   const syncInProgressRef = useRef(false);
   const onSnapshotSynced = options.onSnapshotSynced ?? NOOP_SNAPSHOT_SYNC;
@@ -61,7 +63,8 @@ export function useOfflineSync(
 
   // Sync function
   const performSync = useCallback(async () => {
-    if (syncInProgressRef.current || !navigator.onLine) {
+    // セッション失効中はキュー処理をスキップする。再ログイン後に通常フローで再開される。
+    if (syncInProgressRef.current || !navigator.onLine || sessionExpired) {
       return;
     }
 
@@ -79,6 +82,10 @@ export function useOfflineSync(
       } else if (result.errorCode === "conflict") {
         setSyncStatus("error");
         setLastErrorMessage(t("sync.conflictReloaded"));
+      } else if (result.errorCode === "auth") {
+        setSyncStatus("error");
+        setLastErrorMessage(t("sync.sessionExpired"));
+        notifySessionExpired();
       } else if (result.failedCount > 0) {
         setSyncStatus("error");
         setLastErrorMessage(t("sync.serverSyncFailed"));
@@ -93,7 +100,7 @@ export function useOfflineSync(
     } finally {
       syncInProgressRef.current = false;
     }
-  }, [getApi, onSnapshotSynced, t, updatePendingCount]);
+  }, [getApi, notifySessionExpired, onSnapshotSynced, sessionExpired, t, updatePendingCount]);
 
   // Force sync exposed to consumers
   const forceSync = useCallback(async () => {

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -42,6 +42,8 @@ interface AuthContextType {
   user: User | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  sessionExpired: boolean;
+  notifySessionExpired: () => void;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string) => Promise<{ needsConfirmation: boolean }>;
   confirmSignUp: (email: string, code: string) => Promise<void>;
@@ -60,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isDevAuthBypass ? { ...BYPASS_USER } : null
   );
   const [isLoading, setIsLoading] = useState(!isDevAuthBypass);
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   /**
    * Cognito の現在ユーザーを取得して state を更新する。
@@ -89,11 +92,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     logger.setUser(user?.userId ?? null);
   }, [user]);
 
+  /** セッション失効フラグを立てる。autosave / オフラインキューから呼ばれる。 */
+  const notifySessionExpired = useCallback(() => {
+    setSessionExpired(true);
+  }, []);
+
   /** メールアドレスとパスワードでサインインし、ユーザー情報を再取得する。 */
   const handleSignIn = async (email: string, password: string) => {
     if (isDevAuthBypass) return;
     const input: SignInInput = { username: email, password };
     await signIn(input);
+    setSessionExpired(false);
     await checkUser();
   };
 
@@ -124,6 +133,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (isDevAuthBypass) return;
     await signOut();
     setUser(null);
+    setSessionExpired(false);
   };
 
   const getAccessToken = useCallback(async (): Promise<string | null> => {
@@ -142,6 +152,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         isLoading,
         isAuthenticated: !!user,
+        sessionExpired,
+        notifySessionExpired,
         signIn: handleSignIn,
         signUp: handleSignUp,
         confirmSignUp: handleConfirmSignUp,

--- a/frontend/src/lib/sync/syncConfig.ts
+++ b/frontend/src/lib/sync/syncConfig.ts
@@ -3,7 +3,8 @@
  *
  * リトライ間隔は retryBaseDelayMs * 2^attempt で計算し、
  * retryMaxDelayMs を上限として頭打ちにする。
- * 一時的なエラー（ネットワーク障害など）は成功するまでリトライし続ける。
+ * 一時的なエラー（ネットワーク障害など）は maxRetryAttempts 回まで再試行する。
+ * 401 認証エラーはセッション失効を意味するため即時非リトライ（バナー表示）。
  * 409 競合エラーのみリトライ対象外（スナップショット再取得で解決）。
  * オフライン時は syncQueue に積み、再接続時にフラッシュする。
  */
@@ -12,4 +13,6 @@ export const SYNC_RETRY_CONFIG = {
   retryBaseDelayMs: 2000,
   /** リトライ間隔の上限 (ms)。バックオフが際限なく伸びないよう制限（例: 2s→4s→8s→16s→30s→30s…） */
   retryMaxDelayMs: 30000,
+  /** 最大リトライ試行回数。超過した場合はリトライを打ち切り failed で終端する */
+  maxRetryAttempts: 10,
 } as const;

--- a/frontend/src/lib/sync/useNoteSyncEngine.test.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.test.ts
@@ -19,6 +19,8 @@ const translationMap = {
   "sync.localSaveFailed": "Failed to save locally",
   "sync.conflictReloaded": "Conflict reloaded",
   "sync.retryingIn": "Retrying in {{seconds}}s...",
+  "sync.sessionExpired": "Your session expired. Please sign in again.",
+  "sync.retryExhausted": "Sync failed after multiple attempts (saved locally).",
 } as const;
 const refreshWorkspaceSnapshotMock = vi.fn();
 const onSnapshotSyncedMock = vi.fn();
@@ -64,8 +66,17 @@ vi.mock("@/lib/workspaceSync", () => ({
     refreshWorkspaceSnapshotMock(...args),
   isConflictApiError: (error: unknown) =>
     error instanceof ApiError && error.status === 409,
+  isAuthApiError: (error: unknown) =>
+    error instanceof ApiError && error.status === 401,
   getWorkspaceSyncRequestMetadata: () => getWorkspaceSyncRequestMetadataMock(),
   withSnippet: (note: Note) => ({ ...note, snippet: (note.content ?? "").slice(0, 80) }),
+}));
+
+const notifySessionExpiredMock = vi.fn();
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    notifySessionExpired: notifySessionExpiredMock,
+  }),
 }));
 
 import { useNoteSyncEngine } from "./useNoteSyncEngine";

--- a/frontend/src/lib/sync/useNoteSyncEngine.ts
+++ b/frontend/src/lib/sync/useNoteSyncEngine.ts
@@ -18,12 +18,14 @@ import { syncQueue } from "@/lib/syncQueue";
 import { calculateHash } from "@/lib/utils";
 import {
   getWorkspaceSyncRequestMetadata,
+  isAuthApiError,
   isConflictApiError,
   persistWorkspaceSnapshotIncremental,
   refreshWorkspaceSnapshot,
   withSnippet,
 } from "@/lib/workspaceSync";
 import { useApi } from "@/hooks/useApi";
+import { useAuth } from "@/lib/auth-context";
 import type { Note, WorkspaceSnapshotResponse } from "@/types";
 
 import { useDebouncedAsync } from "./useDebouncedAsync";
@@ -69,6 +71,7 @@ export function useNoteSyncEngine({
   onSnapshotSynced,
 }: NoteSyncEngineParams): NoteSyncEngineResult {
   const { getApi } = useApi();
+  const { notifySessionExpired } = useAuth();
   const { t } = useTranslation();
   const [localStatus, setLocalStatus] = useState<LocalSyncStatus>("saved");
   const [remoteStatus, setRemoteStatus] = useState<RemoteSyncStatus>("synced");
@@ -201,6 +204,24 @@ export function useNoteSyncEngine({
               setLastError(t("sync.conflictReloaded"));
               return;
             }
+            // 401: セッション失効。リトライでは回復しないため即時中断しバナーを表示する。
+            if (isAuthApiError(error)) {
+              logger.warn("Session expired during note sync", error);
+              await syncQueue.addChange("update", "note", id, updates, {
+                expectedVersion,
+              });
+              clearTimeout(retryTimeoutRef.current ?? undefined);
+              clearInterval(retryIntervalRef.current ?? undefined);
+              retryTimeoutRef.current = null;
+              retryIntervalRef.current = null;
+              retryAttemptRef.current = 0;
+              retryArgsRef.current = null;
+              setRetryCountdown(undefined);
+              setRemoteStatus("failed");
+              setLastError(t("sync.sessionExpired"));
+              notifySessionExpired();
+              return;
+            }
             logger.error("Failed to sync note to server", error);
             await syncQueue.addChange("update", "note", id, updates, {
               expectedVersion,
@@ -210,7 +231,11 @@ export function useNoteSyncEngine({
 
             const attempt = retryAttemptRef.current;
             // 指数バックオフで次のリトライ遅延を計算し、最大値でクランプする。
-            // 一時的な失敗は成功するまで無限にリトライし続ける（上限なし）。
+            // maxRetryAttempts 回を超えた場合はリトライを打ち切り failed で終端する。
+            if (attempt >= SYNC_RETRY_CONFIG.maxRetryAttempts) {
+              setLastError(t("sync.retryExhausted"));
+              return;
+            }
             const delayMs = Math.min(
               SYNC_RETRY_CONFIG.retryBaseDelayMs * Math.pow(2, attempt),
               SYNC_RETRY_CONFIG.retryMaxDelayMs
@@ -264,6 +289,7 @@ export function useNoteSyncEngine({
     [
       getApi,
       handleSnapshotSynced,
+      notifySessionExpired,
       setNotes,
       setServerVersion,
       syncServerVersionsFromSnapshot,
@@ -361,6 +387,18 @@ export function useNoteSyncEngine({
           setLastError(t("sync.conflictReloaded"));
           return;
         }
+        if (isAuthApiError(error)) {
+          logger.warn("Session expired during note create", error);
+          await syncQueue.addChange("create", "note", tempId, {
+            title: "",
+            content: "",
+            folder_id: selectedFolderId,
+          });
+          setRemoteStatus("failed");
+          setLastError(t("sync.sessionExpired"));
+          notifySessionExpired();
+          return;
+        }
         logger.error("Failed to create note on server", error);
         await syncQueue.addChange("create", "note", tempId, {
           title: "",
@@ -381,6 +419,7 @@ export function useNoteSyncEngine({
   }, [
     getApi,
     handleSnapshotSynced,
+    notifySessionExpired,
     selectedFolderId,
     setNotes,
     setSelectedNoteId,
@@ -557,6 +596,18 @@ export function useNoteSyncEngine({
               setLastError(t("sync.conflictReloaded"));
               return;
             }
+            if (isAuthApiError(error)) {
+              logger.warn("Session expired during note delete", error);
+              if (!id.startsWith("temp-")) {
+                await syncQueue.addChange("delete", "note", id, undefined, {
+                  expectedVersion,
+                });
+              }
+              setRemoteStatus("failed");
+              setLastError(t("sync.sessionExpired"));
+              notifySessionExpired();
+              return;
+            }
             logger.error("Failed to delete note on server", error);
             if (!id.startsWith("temp-")) {
               await syncQueue.addChange("delete", "note", id, undefined, {
@@ -581,6 +632,7 @@ export function useNoteSyncEngine({
       getApi,
       getExpectedVersion,
       handleSnapshotSynced,
+      notifySessionExpired,
       selectedNoteId,
       setNotes,
       setSelectedNoteId,

--- a/frontend/src/lib/syncQueue.test.ts
+++ b/frontend/src/lib/syncQueue.test.ts
@@ -29,6 +29,8 @@ vi.mock("./workspaceSync", () => ({
   }),
   isConflictApiError: (error: unknown) =>
     error instanceof ApiError && error.status === 409,
+  isAuthApiError: (error: unknown) =>
+    error instanceof ApiError && error.status === 401,
   refreshWorkspaceSnapshot: vi.fn(async (apiClient: {
     getWorkspaceSnapshot: () => Promise<{
       cursor: string;

--- a/frontend/src/lib/syncQueue.ts
+++ b/frontend/src/lib/syncQueue.ts
@@ -14,6 +14,7 @@ import { ApiError } from "./api";
 import {
   getWorkspaceSyncRequestMetadata,
   persistWorkspaceSnapshot,
+  isAuthApiError,
   isConflictApiError,
   refreshWorkspaceSnapshot,
 } from "./workspaceSync";
@@ -34,7 +35,7 @@ interface SyncResult {
   failedCount: number;
   errors: Error[];
   snapshot?: WorkspaceChangesResponse["snapshot"];
-  errorCode?: "conflict";
+  errorCode?: "conflict" | "auth";
 }
 
 interface ProcessQueueOptions {
@@ -179,6 +180,11 @@ class SyncQueueManager {
           result.snapshot = snapshot;
           result.errorCode = "conflict";
           result.success = false;
+        } else if (isAuthApiError(error)) {
+          // 401 セッション失効: 変更は保留のまま残す（破棄しない）。
+          // 呼び出し元が notifySessionExpired() を呼んでバナーを表示する。
+          result.errorCode = "auth";
+          result.success = false;
         } else if (this.isPermanentError(error)) {
           for (const change of changes) {
             await notesDB.removePendingChange(change.id);
@@ -251,6 +257,7 @@ class SyncQueueManager {
   /**
    * リトライ不要な永続的エラーかを判定する。
    * 4xx のうち認証・権限・タイムアウト・競合・レート制限を除いたものを永続エラーとみなす。
+   * 401 は auth 分岐で別処理（変更を保留したまま呼び出し元がバナーを表示する）。
    */
   private isPermanentError(error: unknown): boolean {
     if (!(error instanceof ApiError)) {
@@ -258,7 +265,7 @@ class SyncQueueManager {
     }
 
     const status = error.status;
-    // 401/403/408/409/429 はリトライ対象のため除外する
+    // 401 は isAuthApiError で先に捕捉される。403/408/409/429 はリトライ対象のため除外する
     return status >= 400 && status < 500 && ![401, 403, 408, 409, 429].includes(status);
   }
 }

--- a/frontend/src/lib/workspaceSync.ts
+++ b/frontend/src/lib/workspaceSync.ts
@@ -184,6 +184,14 @@ export function isConflictApiError(error: unknown): error is ApiError {
 }
 
 /**
+ * HTTP 401 認証エラーかどうかを型ガード付きで判定する。
+ * セッション完全失効時に返される。リトライでは回復しないため非リトライ扱いとする。
+ */
+export function isAuthApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError && error.status === 401;
+}
+
+/**
  * サーバーから最新のワークスペーススナップショットを取得し、IndexedDB に保存して返す。
  * 競合エラー（409）発生時にローカル状態をサーバーの真実で上書きするために使用する。
  */

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -235,6 +235,8 @@ export const en = {
     localSaveFailed: "Failed to save locally",
     conflictReloaded: "A sync conflict was detected, so the latest server state was reloaded",
     retryingIn: "Retrying in {{seconds}}s...",
+    sessionExpired: "Your session expired. Please sign in again.",
+    retryExhausted: "Sync failed after multiple attempts (saved locally).",
   },
 
   // Share
@@ -516,6 +518,8 @@ export type TranslationKeys = {
     localSaveFailed: string;
     conflictReloaded: string;
     retryingIn: string;
+    sessionExpired: string;
+    retryExhausted: string;
   };
   share: {
     title: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -235,6 +235,8 @@ export const ja = {
     localSaveFailed: "ローカル保存に失敗しました",
     conflictReloaded: "競合を検出したため最新状態を再読み込みしました",
     retryingIn: "{{seconds}}秒後にリトライ...",
+    sessionExpired: "セッションが切れました。再度サインインしてください。",
+    retryExhausted: "複数回試行しましたが同期に失敗しました（ローカルに保存済み）。",
   },
 
   // Share


### PR DESCRIPTION
## 概要

本番環境でCognitoセッションが完全失効した場合、`POST /api/workspace/changes` が 401 を返し続けるにもかかわらず、autosave リトライループ（#132）が無限にリトライし続け、同一ペイロード（43KB）を連打しながら Sentry に exception を毎回撃ち込んでいた。

401はリトライで回復しない（リフレッシュトークン自体が死んでいる）ため、検知次第リトライを打ち切り、ユーザーにセッション失効バナーと再ログイン導線を表示する。編集内容はIndexedDBに保持し、再ログイン後に自動フラッシュされる。

## 変更内容

- **`lib/workspaceSync.ts`**: `isAuthApiError()` ヘルパーを追加（401判定）
- **`lib/auth-context.tsx`**: `sessionExpired` 状態と `notifySessionExpired()` を追加。signIn/signOut 時にクリア
- **`lib/sync/syncConfig.ts`**: `maxRetryAttempts: 10` を追加し、一過性エラーの青天井リトライを廃止
- **`lib/sync/useNoteSyncEngine.ts`**: update/create/delete 全3経路の catch に 401 ガードを追加。リトライ停止・IndexedDB保持・`notifySessionExpired()` 呼び出し・`logger.warn`（Sentry exception を撃たない）
- **`lib/syncQueue.ts`**: `processQueue` に auth 分岐を追加。401時は保留変更を**破棄せず**、`errorCode: "auth"` を返す
- **`hooks/useOfflineSync.ts`**: `sessionExpired` 中はキュー処理をスキップ。`errorCode === "auth"` で `notifySessionExpired()` 呼び出し
- **`components/ui/SessionExpiredBanner.tsx`**: 新規コンポーネント。`sessionExpired=true` のときのみ表示。メッセージ + `/login` 導線
- **`components/workspace/AuthenticatedWorkspace.tsx`**: バナーを配線（fixed, bottom-right）
- **`locales/en.ts` / `locales/ja.ts`**: `sync.sessionExpired` / `sync.retryExhausted` キーを追加
- **テストファイル3件**: `isAuthApiError` モックと `useAuth` モックを追加

## テスト方法

- [ ] `make test-frontend` で全397テストが通ること
- [ ] ローカル環境で `getAccessToken` を一時的に `null` 返却にし、ノートを編集する
  - ネットワークタブで `workspace/changes` の連打が止まることを確認
  - セッション失効バナー（右下）が表示され、「Login」ボタンで `/login` へ遷移することを確認
  - Sentry にスパムが出ないことを確認（warn 1件のみ）
  - ページリロードせずに再ログインすると保留変更がフラッシュされることを確認
- [ ] 通常のオンライン復帰・409競合・ネットワーク一時断のリトライ動作がリグレッションしないことを確認

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（en/ja）