### PR TITLE
test: エディタ実入力によるMarkdown表現のE2E/ユニットテスト拡充 + flaky/陳腐化spec修正

### DIFF
--- a/frontend/src/components/editor/extensions/__tests__/markdownListContinuation.test.ts
+++ b/frontend/src/components/editor/extensions/__tests__/markdownListContinuation.test.ts
@@ -82,4 +82,30 @@ describe("markdownListContinuation — Enter", () => {
     view = makeView("- item", 6);
     expect(enterRun(view)).toBe(true);
   });
+
+  it("continues a GFM task list line as a list (marker carried to next line)", () => {
+    // この拡張単体ではチェックボックス `[ ]` を引き継がず `- ` のみ継続する。
+    // 実エディタでは @codemirror/lang-markdown の Prec.high キーマップ
+    // (insertNewlineContinueMarkup) が先に Enter を処理するため `- [ ] ` が継続される
+    // （E2E: tests/regression/markdown-typing.spec.ts が実挙動を担保）。
+    view = makeView("- [ ] task", 10);
+    expect(enterRun(view)).toBe(true);
+    const lines = view.state.doc.toString().split("\n");
+    expect(lines[0]).toBe("- [ ] task");
+    expect(lines[1]).toMatch(/^- /);
+  });
+
+  it("continues mid-line: text after cursor stays on the original line", () => {
+    // "- item" でカーソルが "it|em" の位置 — 改行後 "em" は次行へ移動せず
+    // 現実装は beforeCursor のみで継続行を作るため "em" は元の行末に残る
+    view = makeView("- item", 4);
+    enterRun(view);
+    expect(view.state.doc.toString()).toBe("- it\n- em");
+  });
+
+  it("does not continue when cursor is before the marker", () => {
+    // 行頭（マーカーより前）で Enter — マーカー情報が beforeCursor に無いので false
+    view = makeView("- item", 0);
+    expect(enterRun(view)).toBe(false);
+  });
 });

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/blockquote.test.ts
@@ -25,7 +25,10 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown()],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 function getLineDecs(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/codeBlocks.test.ts
@@ -25,7 +25,10 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown()],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 function getLineDecs(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/headings.test.ts
@@ -25,7 +25,10 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown()],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 function getLineDecs(

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/horizontalRule.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/horizontalRule.test.ts
@@ -27,7 +27,10 @@ function makeState(doc: string, cursorPos = 0): EditorState {
   });
   // lezer-markdown は遅延パースするため強制フルパース（5000ms で JIT 未ウォームアップ時も対応）
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 function getLineDecs(decs: Range<Decoration>[]): Range<Decoration>[] {

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/images.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/images.test.ts
@@ -26,7 +26,10 @@ function makeState(doc: string, cursorPos: number): EditorState {
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 /** widget を持つ replace デコレーションを取得する */

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/inlineStyles.test.ts
@@ -7,8 +7,9 @@
 import { describe, expect, it } from "vitest";
 import { EditorState, EditorSelection, type Range } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
-import { markdown } from "@codemirror/lang-markdown";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { ensureSyntaxTree } from "@codemirror/language";
+import { GFM } from "@lezer/markdown";
 import { buildInlineDecorations } from "../inlineStyles";
 
 /** DOM なしで動作する最小限の EditorView シム */
@@ -27,7 +28,24 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown()],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
+}
+
+/** Strikethrough（~~）は GFM 拡張のノードなので GFM 入りでパースする */
+function makeGfmState(doc: string, cursorPos = 0): EditorState {
+  const state = EditorState.create({
+    doc,
+    selection: EditorSelection.cursor(cursorPos),
+    extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
+  });
+  ensureSyntaxTree(state, state.doc.length, 1e9);
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 // ---------------------------------------------------------------
@@ -164,6 +182,53 @@ describe("buildInlineDecorations — InlineCode", () => {
     const decs = buildInlineDecorations(state, makeFakeView(state));
     const marks = getMarkDecs(decs, "cm-md-code");
     expect(marks.some((d) => d.from === 7 && d.to === 11)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------
+// Strikethrough  (~~gone~~) — GFM extension node
+// ---------------------------------------------------------------
+describe("buildInlineDecorations — Strikethrough (GFM)", () => {
+  const doc = "hello ~~gone~~ end";
+  //           0123456789...
+  // ~~gone~~ spans [6, 14]: ~~ at [6,8], "gone" at [8,12], ~~ at [12,14]
+
+  it("emits a cm-md-strikethrough mark decoration covering the full node", () => {
+    const state = makeGfmState(doc);
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const marks = getMarkDecs(decs, "cm-md-strikethrough");
+    expect(marks.length).toBeGreaterThanOrEqual(1);
+    expect(marks.some((d) => d.from === 6 && d.to === 14)).toBe(true);
+  });
+
+  it("emits replace decorations for both ~~ markers when cursor is outside", () => {
+    const state = makeGfmState(doc, 0);
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const replaces = getReplaceDecs(decs);
+    expect(replaces.some((d) => d.from === 6 && d.to === 8)).toBe(true);
+    expect(replaces.some((d) => d.from === 12 && d.to === 14)).toBe(true);
+  });
+
+  it("does NOT emit replace decorations when cursor is inside ~~gone~~", () => {
+    const state = makeGfmState(doc, 10); // cursor inside "gone"
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const replaces = getReplaceDecs(decs);
+    expect(replaces.some((d) => d.from === 6 && d.to === 8)).toBe(false);
+    expect(replaces.some((d) => d.from === 12 && d.to === 14)).toBe(false);
+  });
+
+  it("emits cm-md-marker on ~~ markers when cursor is inside", () => {
+    const state = makeGfmState(doc, 10);
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    const markers = getMarkDecs(decs, "cm-md-marker");
+    expect(markers.some((d) => d.from === 6 && d.to === 8)).toBe(true);
+    expect(markers.some((d) => d.from === 12 && d.to === 14)).toBe(true);
+  });
+
+  it("emits no strikethrough decorations without GFM-parseable syntax", () => {
+    const state = makeGfmState("plain text only");
+    const decs = buildInlineDecorations(state, makeFakeView(state));
+    expect(getMarkDecs(decs, "cm-md-strikethrough").length).toBe(0);
   });
 });
 

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/links.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/links.test.ts
@@ -26,7 +26,10 @@ function makeState(doc: string, cursorPos: number): EditorState {
     extensions: [markdown({ base: markdownLanguage, extensions: [GFM] })],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 /** cm-md-link マークデコレーションを抽出する */

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/lists.test.ts
@@ -28,7 +28,10 @@ function makeState(doc: string, cursorPos = 0): EditorState {
     extensions: [markdown()],
   });
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 /** 指定クラスの mark デコレーションを取得する */

--- a/frontend/src/components/editor/extensions/livePreview/__tests__/taskList.test.ts
+++ b/frontend/src/components/editor/extensions/livePreview/__tests__/taskList.test.ts
@@ -30,7 +30,10 @@ function makeState(doc: string, cursorPos = 0): EditorState {
   // lezer-markdown は遅延パースするため、テストでは強制的にフルパースしておく
   // 5000ms に設定: JIT未ウォームアップ時でも確実にパースが完了する余裕を持たせる
   ensureSyntaxTree(state, state.doc.length, 1e9);
-  return state;
+  // LanguageState.tree は state 生成時のスナップショット。初期パース（20ms 予算）が
+  // CPU 負荷で時間切れになると syntaxTree(state) が部分木を返し flaky になるため、
+  // 空トランザクションを適用して ensureSyntaxTree 完了後の完全な木を反映した state を返す。
+  return state.update({}).state;
 }
 
 /** widget を持つ replace デコレーションを取得する */

--- a/frontend/src/components/layout/EditorMarkdownPreview.test.tsx
+++ b/frontend/src/components/layout/EditorMarkdownPreview.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * EditorMarkdownPreview のユニットテスト。
+ * remarkGfm を含むプラグイン構成で、代表的な Markdown / GFM 構文が
+ * 正しい HTML 要素としてレンダリングされることを検証する。
+ */
+import { describe, it, expect } from "vitest";
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { EditorMarkdownPreview } from "./EditorMarkdownPreview";
+
+function renderPreview(content: string) {
+  return render(
+    <EditorMarkdownPreview
+      deferredContent={content}
+      markdownComponents={{}}
+      previewContainerRef={createRef<HTMLDivElement>()}
+      onPreviewScroll={undefined}
+      isDesktopViewport={true}
+      previewPlaceholder="Nothing to preview"
+    />
+  );
+}
+
+describe("EditorMarkdownPreview — markdown rendering", () => {
+  it("renders headings as h1-h3 elements", () => {
+    const { container } = renderPreview("# Title\n\n## Section\n\n### Sub");
+    expect(container.querySelector("h1")?.textContent).toBe("Title");
+    expect(container.querySelector("h2")?.textContent).toBe("Section");
+    expect(container.querySelector("h3")?.textContent).toBe("Sub");
+  });
+
+  it("renders bold, italic and inline code", () => {
+    const { container } = renderPreview("**bold** *italic* `code`");
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+    expect(container.querySelector("em")?.textContent).toBe("italic");
+    expect(container.querySelector("code")?.textContent).toBe("code");
+  });
+
+  it("renders unordered and ordered lists", () => {
+    const { container } = renderPreview("- one\n- two\n\n1. first\n2. second");
+    const ulItems = container.querySelectorAll("ul > li");
+    const olItems = container.querySelectorAll("ol > li");
+    expect(ulItems.length).toBe(2);
+    expect(olItems.length).toBe(2);
+    expect(olItems[1].textContent).toBe("second");
+  });
+
+  it("renders a fenced code block as pre > code", () => {
+    const { container } = renderPreview("```js\nconst a = 1;\n```");
+    const code = container.querySelector("pre > code");
+    expect(code).toBeTruthy();
+    expect(code?.textContent).toContain("const a = 1;");
+  });
+
+  it("renders blockquote and horizontal rule", () => {
+    const { container } = renderPreview("> quoted\n\n---");
+    expect(container.querySelector("blockquote")?.textContent).toContain("quoted");
+    expect(container.querySelector("hr")).toBeTruthy();
+  });
+
+  it("renders links with href and images with src/alt", () => {
+    const { container } = renderPreview(
+      "[site](https://example.com)\n\n![logo](https://example.com/a.png)"
+    );
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+    expect(link?.textContent).toBe("site");
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("https://example.com/a.png");
+    expect(img?.getAttribute("alt")).toBe("logo");
+  });
+
+  it("renders a GFM table with header and body cells", () => {
+    const { container } = renderPreview(
+      "| Name | Qty |\n| --- | --- |\n| pen | 3 |\n| book | 7 |"
+    );
+    const table = container.querySelector("table");
+    expect(table).toBeTruthy();
+    const headers = container.querySelectorAll("th");
+    expect(headers.length).toBe(2);
+    expect(headers[0].textContent).toBe("Name");
+    const cells = container.querySelectorAll("td");
+    expect(cells.length).toBe(4);
+    expect(cells[3].textContent).toBe("7");
+  });
+
+  it("renders GFM strikethrough as a del element", () => {
+    const { container } = renderPreview("~~obsolete~~ current");
+    expect(container.querySelector("del")?.textContent).toBe("obsolete");
+  });
+
+  it("renders GFM task list items as checkboxes with correct checked state", () => {
+    const { container } = renderPreview("- [ ] todo\n- [x] done");
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    expect(checkboxes.length).toBe(2);
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(false);
+    expect((checkboxes[1] as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("renders GFM autolink as an anchor", () => {
+    const { container } = renderPreview("visit https://example.com now");
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+  });
+
+  it("annotates task list lines with data-source-line for checkbox toggling", () => {
+    // remarkSourceLine が data-source-line を注入する — EditorPanel の
+    // checkbox onChange はこの属性で対象行を特定するため、欠落すると壊れる
+    const { container } = renderPreview("intro\n\n- [ ] todo on line 3");
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox).toBeTruthy();
+    const annotated = checkbox?.closest("[data-source-line]");
+    expect(annotated?.getAttribute("data-source-line")).toBe("3");
+  });
+
+  it("renders the placeholder in italics when content is empty", () => {
+    const { container } = renderPreview("");
+    expect(container.querySelector("em")?.textContent).toBe("Nothing to preview");
+  });
+});

--- a/frontend/tests/auth.spec.ts
+++ b/frontend/tests/auth.spec.ts
@@ -24,6 +24,13 @@ async function navigateToLogin(page: Page): Promise<void> {
 }
 
 test.describe('Authentication', () => {
+  // In local bypass mode there is no Cognito login page — /login/ redirects
+  // straight into the authenticated workspace, so these tests are meaningless.
+  test.skip(
+    process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS === 'true',
+    'Cognito login is bypassed in local mode'
+  );
+
   test('should login successfully', async ({ page, isMobile }) => {
     await navigateToLogin(page);
     

--- a/frontend/tests/regression/markdown-typing.spec.ts
+++ b/frontend/tests/regression/markdown-typing.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * エディタへの実キー入力による Markdown 表現の E2E テスト。
+ *
+ * - raw モードでの Markdown 入力がそのまま永続化されること
+ * - live-preview モードでの装飾（見出し・インライン・ブロック要素）が
+ *   実際の入力とカーソル移動に追従すること
+ * - タスクチェックボックスのクリックがドキュメントを書き換えて保存されること
+ * - Enter / Tab / Shift+Tab によるリスト継続・リナンバリング
+ * - プレビューペインでの GFM（テーブル・取り消し線）レンダリング
+ *
+ * AI 機能は一切呼び出さない（課金対象の Bedrock 呼び出しなし）。
+ */
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+import {
+  createNoteFixture,
+  deleteNoteFixture,
+  waitForWorkspaceSnapshotReady,
+  waitForNoteContentFixture,
+} from '../helpers/apiFixtures';
+
+const SNAPSHOT_WARMUP = { attempts: 12, delayMs: 5000, timeoutMs: 30000 };
+const DISPLAY_MODE_KEY = 'editor-display-mode';
+
+/** ノートを fixture で作成し、UI 上で開いて contentInput を返す共通セットアップ */
+async function openNote(
+  page: Page,
+  title: string,
+  content: string
+): Promise<{ noteId: string; layout: Locator; contentInput: Locator }> {
+  await page.goto('/');
+  const note = await createNoteFixture(page, { title, content });
+
+  await waitForWorkspaceSnapshotReady(page, SNAPSHOT_WARMUP);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+
+  const layout = page.getByTestId('desktop-layout');
+  await layout.getByTestId('sidebar-nav-all-notes').click();
+
+  const noteItem = layout
+    .locator('[data-testid^="note-list-item-"]')
+    .filter({ hasText: title })
+    .first();
+  await expect(noteItem).toBeVisible({ timeout: 30000 });
+  await noteItem.click();
+  await expect(layout.getByTestId('editor-title-input')).toHaveValue(title, { timeout: 20000 });
+
+  const contentInput = layout.getByTestId('editor-content-input');
+  await expect(contentInput).toBeVisible({ timeout: 20000 });
+  return { noteId: note.id, layout, contentInput };
+}
+
+/** live-preview モードへ切り替える（beforeEach で raw に初期化されている前提） */
+async function switchToLivePreview(layout: Locator, page: Page): Promise<void> {
+  const toggleButton = layout.getByTestId('editor-display-mode-toggle');
+  await toggleButton.click();
+  await expect(toggleButton).toHaveAttribute('aria-label', /raw.?text|source|生テキスト/i, { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+test.describe('Regression: Markdown typing and live rendering', () => {
+  test.skip(({ isMobile }) => isMobile, 'Editor keyboard tests are desktop-only');
+  // WebKit has known differences in CodeMirror keyboard/composition handling;
+  // these typing-driven specs run on Chromium only (same policy as editor-ime.spec.ts).
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate((key) => localStorage.removeItem(key), DISPLAY_MODE_KEY);
+  });
+
+  test('should persist a typed markdown document exactly (raw mode)', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-roundtrip-${Date.now()}`;
+    const { noteId, contentInput } = await openNote(page, noteTitle, '');
+
+    await contentInput.click();
+    await page.keyboard.type('# Title');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('**bold** and *italic* and `code`');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    // List continuation inserts "- " automatically; Enter on the empty item exits
+    // the list by deleting the marker (lang-markdown insertNewlineContinueMarkup)
+    await page.keyboard.type('- one');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('two');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('---');
+
+    const expectedContent =
+      '# Title\n\n**bold** and *italic* and `code`\n\n- one\n- two\n---';
+
+    await expect(contentInput).toContainText('two', { timeout: 5000 });
+    await contentInput.blur();
+    await waitForNoteContentFixture(page, noteId, expectedContent, 30000);
+
+    await deleteNoteFixture(page, noteId);
+  });
+
+  test('should decorate headings and inline styles while typing (live-preview)', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-inline-${Date.now()}`;
+    const { noteId, layout, contentInput } = await openNote(page, noteTitle, '');
+    await switchToLivePreview(layout, page);
+
+    await contentInput.click();
+    await page.keyboard.type('# Hello');
+
+    // Cursor is on the heading line — the marker stays visible and the line is styled
+    await expect(contentInput.locator('.cm-md-h1')).toBeVisible({ timeout: 5000 });
+    await expect(contentInput).toContainText('# Hello');
+
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('**bold** text');
+
+    // Cursor left the heading line — the "# " marker must now be hidden
+    await expect(contentInput).not.toContainText('#', { timeout: 5000 });
+    await expect(contentInput).toContainText('Hello');
+
+    // Cursor is after "**bold**" content — both ** markers must be hidden
+    await expect(contentInput.locator('.cm-md-strong')).toBeVisible({ timeout: 5000 });
+    await expect(contentInput).not.toContainText('**');
+    await expect(contentInput).toContainText('bold');
+
+    // Click inside the bold text — the cursor enters the range and markers must reappear
+    await contentInput.locator('.cm-md-strong').click();
+    await expect(contentInput).toContainText('**', { timeout: 5000 });
+
+    await contentInput.blur();
+    await waitForNoteContentFixture(page, noteId, '# Hello\n**bold** text', 30000);
+
+    await deleteNoteFixture(page, noteId);
+  });
+
+  test('should render block elements of an existing note (live-preview)', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-blocks-${Date.now()}`;
+    const content = [
+      'intro',
+      '',
+      '```js',
+      'const x = 1;',
+      '```',
+      '',
+      '> quoted line',
+      '',
+      '- bullet one',
+      '',
+      '1. numbered',
+      '',
+      '[site](https://example.com)',
+      '',
+      '---',
+      '',
+      'end',
+    ].join('\n');
+    const { noteId, layout, contentInput } = await openNote(page, noteTitle, content);
+    await switchToLivePreview(layout, page);
+
+    // Fenced code block: lines styled, fence markers hidden (cursor is not in the block)
+    await expect(contentInput.locator('.cm-md-fenced').first()).toBeVisible({ timeout: 10000 });
+    await expect(contentInput).toContainText('const x = 1;');
+    await expect(contentInput).not.toContainText('```');
+
+    // Blockquote: line styled, "> " marker hidden
+    await expect(contentInput.locator('.cm-md-blockquote')).toBeVisible();
+    await expect(contentInput).toContainText('quoted line');
+    await expect(contentInput).not.toContainText('>');
+
+    // List markers: bullet and ordered marks styled (not replaced)
+    await expect(contentInput.locator('.cm-md-bullet')).toBeVisible();
+    await expect(contentInput.locator('.cm-md-ol-mark')).toBeVisible();
+
+    // Link: label styled, URL part hidden
+    await expect(contentInput.locator('.cm-md-link')).toBeVisible();
+    await expect(contentInput).toContainText('site');
+    await expect(contentInput).not.toContainText('https://example.com');
+
+    // Horizontal rule: --- replaced by the styled rule line
+    await expect(contentInput.locator('.cm-md-hr-line')).toBeVisible();
+
+    await deleteNoteFixture(page, noteId);
+  });
+
+  test('should toggle a task checkbox by click and persist [x] (live-preview)', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-task-${Date.now()}`;
+    const { noteId, layout, contentInput } = await openNote(
+      page,
+      noteTitle,
+      '- [ ] buy milk\n- [x] pay bills'
+    );
+    await switchToLivePreview(layout, page);
+
+    const checkboxes = contentInput.locator('input.cm-md-task-checkbox');
+    await expect(checkboxes).toHaveCount(2, { timeout: 10000 });
+    await expect(checkboxes.first()).not.toBeChecked();
+    await expect(checkboxes.last()).toBeChecked();
+
+    // Focus the editor first so blur-triggered save works after the click
+    await contentInput.click();
+    await checkboxes.first().click();
+    await expect(checkboxes.first()).toBeChecked({ timeout: 5000 });
+
+    await contentInput.blur();
+    await waitForNoteContentFixture(page, noteId, '- [x] buy milk\n- [x] pay bills', 30000);
+
+    await deleteNoteFixture(page, noteId);
+  });
+
+  test('should continue and renumber ordered lists with Enter/Tab/Shift+Tab', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-ol-${Date.now()}`;
+    const { noteId, contentInput } = await openNote(page, noteTitle, '');
+
+    await contentInput.click();
+    await page.keyboard.type('1. first');
+    await page.keyboard.press('Enter');
+    // Continuation must auto-insert "2. "
+    await expect(contentInput).toContainText('2.', { timeout: 5000 });
+    await page.keyboard.type('second');
+    await page.keyboard.press('Enter');
+    // Now on the auto-inserted "3. " line; Tab indents and renumbers to "1."
+    await page.keyboard.press('Tab');
+    await page.keyboard.type('nested');
+    await expect(contentInput).toContainText('nested', { timeout: 5000 });
+
+    // Shift+Tab unindents and renumbers back to the parent level ("3.")
+    await page.keyboard.press('Shift+Tab');
+    await expect(contentInput).toContainText('3. nested', { timeout: 5000 });
+
+    await contentInput.blur();
+    await waitForNoteContentFixture(page, noteId, '1. first\n2. second\n3. nested', 30000);
+
+    await deleteNoteFixture(page, noteId);
+  });
+
+  test('should continue task lists and blockquotes on Enter while typing', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-continue-${Date.now()}`;
+    const { noteId, contentInput } = await openNote(page, noteTitle, '');
+
+    await contentInput.click();
+    // Task list: Enter must auto-insert an unchecked "- [ ] " marker
+    await page.keyboard.type('- [ ] milk');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('eggs');
+    await page.keyboard.press('Enter');
+    // Enter on the empty task item exits the list
+    await page.keyboard.press('Enter');
+    // Blockquote: Enter must auto-insert "> "
+    await page.keyboard.type('> quote');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('more');
+
+    await expect(contentInput).toContainText('more', { timeout: 5000 });
+    await contentInput.blur();
+    await waitForNoteContentFixture(
+      page,
+      noteId,
+      '- [ ] milk\n- [ ] eggs\n> quote\n> more',
+      30000
+    );
+
+    await deleteNoteFixture(page, noteId);
+  });
+
+  test('should render typed GFM table and strikethrough in the preview pane', async ({ page, browserName }) => {
+    if (browserName === 'webkit') test.skip();
+    test.setTimeout(120000);
+
+    const noteTitle = `regression-md-gfm-${Date.now()}`;
+    const { noteId, layout, contentInput } = await openNote(page, noteTitle, '');
+
+    await contentInput.click();
+    await page.keyboard.type('| Name | Qty |');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('| --- | --- |');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('| pen | 3 |');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('~~old~~ new');
+
+    // Open the side-by-side preview pane and verify GFM rendering
+    await layout.getByTestId('editor-preview-toggle').click();
+    const previewPane = layout.getByTestId('editor-preview-pane');
+    await expect(previewPane).toBeVisible({ timeout: 10000 });
+
+    await expect(previewPane.locator('table')).toBeVisible({ timeout: 10000 });
+    await expect(previewPane.locator('th').first()).toHaveText('Name');
+    await expect(previewPane.locator('td').first()).toHaveText('pen');
+    await expect(previewPane.locator('del')).toHaveText('old');
+
+    await contentInput.blur();
+    await waitForNoteContentFixture(
+      page,
+      noteId,
+      '| Name | Qty |\n| --- | --- |\n| pen | 3 |\n\n~~old~~ new',
+      30000
+    );
+
+    await deleteNoteFixture(page, noteId);
+  });
+});

--- a/frontend/tests/share.spec.ts
+++ b/frontend/tests/share.spec.ts
@@ -134,7 +134,8 @@ test.describe('Sharing Functionality', () => {
     console.log('[Share E2E] Navigated to shared URL');
 
     // Verify the shared note page displays correctly
-    await expect(sharedPage.getByText('Read-only')).toBeVisible();
+    // The shared page renders in the user's saved language — accept EN or JA
+    await expect(sharedPage.getByText(/Read-only|読み取り専用/)).toBeVisible();
     await expect(sharedPage.getByText(noteTitle).first()).toBeVisible({ timeout: 10000 });
 
     // Verify content is rendered
@@ -155,15 +156,19 @@ test.describe('Sharing Functionality', () => {
     const revokeButton = page.getByTestId('share-revoke-button');
     await expect(revokeButton).toBeVisible();
 
-    // Handle the confirmation dialog
-    page.once('dialog', dialog => dialog.accept());
-
     const deletePromise = page.waitForResponse(
       resp => resp.url().includes('/share') && resp.request().method() === 'DELETE' && resp.status() < 400,
       { timeout: 15000 }
     );
 
     await revokeButton.click();
+
+    // The app shows a custom in-page ConfirmDialog (window.confirm was replaced
+    // in 284cd1c) — click its Confirm button (EN or JA label)
+    const confirmButton = page.getByRole('button', { name: /^(Confirm|確認)$/ });
+    await expect(confirmButton).toBeVisible({ timeout: 5000 });
+    await confirmButton.click();
+
     await deletePromise;
     console.log('[Share E2E] Share revoked');
 
@@ -174,8 +179,8 @@ test.describe('Sharing Functionality', () => {
     const verifyPage = await context.newPage();
     await verifyPage.goto(shareUrl);
 
-    // Should show not found or error
-    await expect(verifyPage.getByRole('heading', { name: /not found/i })).toBeVisible({ timeout: 15000 });
+    // Should show not found or error (EN or JA)
+    await expect(verifyPage.getByRole('heading', { name: /not found|見つかりません/i })).toBeVisible({ timeout: 15000 });
     console.log('[Share E2E] Revoked link shows not found');
 
     await verifyPage.close();


### PR DESCRIPTION
## 概要

エディタに「実際にキー入力する」タイプのテスト、特に Markdown 表現（見出し・インライン装飾・リスト・タスクリスト・テーブル等）の入力〜レンダリング〜永続化を検証するテストが欠けていたため、E2E とユニットテストを拡充する。あわせて調査中に発見した既存テストの flaky 1件と陳腐化した spec 2件を修正する。プロダクションコードの変更はなし（全てテストコード）。

## 変更内容

**新規 E2E: `frontend/tests/regression/markdown-typing.spec.ts`（7テスト、AI機能は不使用）**
- raw モードで Markdown 文書をタイプし、保存内容が API 経由で完全一致すること
- live-preview モードで `# Hello` / `**bold**` 入力中のデコレーションとカーソル位置に応じたマーカー表示/非表示
- コードフェンス・引用・リンク・HR・リストのブロック装飾レンダリング
- タスクチェックボックスのクリックで `[ ]`→`[x]` がサーバーへ永続化されること
- 番号付きリストの Enter 継続 / Tab・Shift+Tab でのリナンバリング
- タスクリスト（`- [ ]`）・引用（`>`）の Enter 自動継続
- タイプした GFM テーブル・取り消し線のプレビューペインレンダリング

**ユニットテスト追加（+20）**
- `inlineStyles`: `~~取り消し線~~` のデコレーション5件（未テストだった）
- `EditorMarkdownPreview.test.tsx`（新規）: GFM テーブル・タスクリスト・`data-source-line` 注入等のレンダリング12件
- `markdownListContinuation`: タスクリスト行・行中 Enter・マーカー前カーソルのエッジケース3件

**既存テストの修正**
- **flaky 根本修正**: livePreview 系テストヘルパー10箇所。CM6 の `LanguageState.tree` は state 生成時の20ms予算パースのスナップショットを返すため、CPU 負荷時に部分木のまま `syntaxTree(state)` が固定され `taskList.test.ts` が全suite実行の約1/3で失敗していた。`ensureSyntaxTree` 後に空トランザクションを適用し完全な木を反映するよう修正
- **share.spec**: 284cd1c で `window.confirm()` が `ConfirmDialog` に置換された際の追従漏れ（`page.once('dialog')` のまま）を修正。また dev のテストユーザー言語設定が ja のため落ちる英語固定アサート2箇所を EN/JA 両対応に修正
- **auth.spec**: ローカル auth bypass モードでは `/login/` が即ワークスペースへリダイレクトされるため skip ガードを追加（dev/prd では従来通り実行）

## 発見事項（本PRでは未変更・要判断）

`markdownListContinuation.ts` の Enter キーバインドは、`@codemirror/lang-markdown` の `markdown()` が `Prec.high` で同梱する `insertNewlineContinueMarkup` に常に上書きされており、実アプリでは実行されない（事実上の dead code）。実挙動は lang-markdown 側が担っており E2E はその挙動を担保。将来的に当該バインドの削除か `addKeymap: false` での独自実装有効化を検討。

## テスト方法

- [x] `make test` — バックエンド 219 passed / フロントエンド 417 passed / lint エラー0
- [x] フロントエンド unit を6連続実行し flaky 解消を確認（修正前は約1/3で失敗）
- [x] `make test-e2e-local` — ローカル bypass スタックで全suite 42 passed / 3 skipped / 0 failed
- [x] dev 環境で新規 spec + 修正 spec を実行（markdown-typing / share / auth）すべて passed
- [x] 新規 markdown-typing spec は `--repeat-each=2` で安定性確認済み

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した（対象なし）
- [ ] ユーザー向けテキストの i18n 対応を行った（該当なし — テストのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)