### PR TITLE
feature: パスキー (WebAuthn) 認証対応

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -8,7 +8,7 @@
  */
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,7 @@ export default function LoginPage() {
   const [passkeySupported, setPasskeySupported] = useState(false);
   const { signIn, signInWithPasskey } = useAuth();
   const router = useRouter();
+  const emailRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (isDevAuthBypass) router.replace("/");
@@ -41,8 +42,14 @@ export default function LoginPage() {
     );
   }, []);
 
+  // パスワードログイン。メール・パスワード両方を JS で検証する
+  // （HTML5 の required には頼らず、パスキー経路に干渉させない）。
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!email || !password) {
+      setError("Enter your email and password");
+      return;
+    }
     setError(null);
     setIsLoading(true);
 
@@ -56,9 +63,11 @@ export default function LoginPage() {
     }
   };
 
+  // パスキーログインはメールのみで完了する（パスワードは不要）。
   const handlePasskeySignIn = async () => {
     if (!email) {
-      setError("Enter your email to sign in with a passkey");
+      setError("Enter your email above, then tap the passkey button");
+      emailRef.current?.focus();
       return;
     }
     setError(null);
@@ -96,12 +105,12 @@ export default function LoginPage() {
                 Email
               </label>
               <Input
+                ref={emailRef}
                 id="email"
                 type="email"
                 placeholder="you@example.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                required
                 disabled={isLoading}
                 data-testid="login-email-input"
               />
@@ -117,7 +126,6 @@ export default function LoginPage() {
                 placeholder="••••••••"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                required
                 disabled={isLoading}
                 data-testid="login-password-input"
               />
@@ -164,6 +172,9 @@ export default function LoginPage() {
                 <KeyRoundIcon className="h-4 w-4 mr-2" />
                 Sign in with a passkey
               </Button>
+              <p className="mt-2 text-center text-xs text-muted-foreground">
+                Just your email — no password needed
+              </p>
             </>
           )}
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/lib/auth-context";
-import { FileTextIcon, Loader2Icon } from "lucide-react";
+import { FileTextIcon, Loader2Icon, KeyRoundIcon } from "lucide-react";
 import { isDevAuthBypass } from "@/lib/dev-bypass";
 
 /**
@@ -26,12 +26,20 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const { signIn } = useAuth();
+  const [passkeySupported, setPasskeySupported] = useState(false);
+  const { signIn, signInWithPasskey } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     if (isDevAuthBypass) router.replace("/");
   }, [router]);
+
+  // WebAuthn 非対応ブラウザではパスキーボタンを表示しない。
+  useEffect(() => {
+    setPasskeySupported(
+      typeof window !== "undefined" && !!window.PublicKeyCredential
+    );
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,6 +51,24 @@ export default function LoginPage() {
       router.push("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Sign in failed");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePasskeySignIn = async () => {
+    if (!email) {
+      setError("Enter your email to sign in with a passkey");
+      return;
+    }
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      await signInWithPasskey(email);
+      router.push("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Passkey sign in failed");
     } finally {
       setIsLoading(false);
     }
@@ -119,6 +145,27 @@ export default function LoginPage() {
               )}
             </Button>
           </form>
+
+          {passkeySupported && (
+            <>
+              <div className="my-6 flex items-center gap-3">
+                <div className="h-px flex-1 bg-zinc-700/50" />
+                <span className="text-xs text-muted-foreground">or</span>
+                <div className="h-px flex-1 bg-zinc-700/50" />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={handlePasskeySignIn}
+                disabled={isLoading}
+                data-testid="login-passkey-button"
+              >
+                <KeyRoundIcon className="h-4 w-4 mr-2" />
+                Sign in with a passkey
+              </Button>
+            </>
+          )}
 
           <div className="mt-6 text-center text-sm">
             <span className="text-muted-foreground">Don&apos;t have an account? </span>

--- a/frontend/src/components/layout/SettingsDialog.tsx
+++ b/frontend/src/components/layout/SettingsDialog.tsx
@@ -28,8 +28,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { logger } from "@/lib/logger";
-import { CheckIcon, Loader2Icon } from "lucide-react";
+import { CheckIcon, Loader2Icon, KeyRoundIcon } from "lucide-react";
 import { useApi, useTranslation } from "@/hooks";
+import { useAuth } from "@/lib/auth-context";
+import type { AuthWebAuthnCredential } from "aws-amplify/auth";
 import type {
   AvailableLanguage,
   AvailableModel,
@@ -49,6 +51,11 @@ type ApiKeysErrorKey =
   | "settings.apiKeysCreateError"
   | "settings.apiKeysRevokeError"
   | "common.error";
+type PasskeysErrorKey =
+  | "settings.passkeysListError"
+  | "settings.passkeysAddError"
+  | "settings.passkeysDeleteError"
+  | "common.error";
 
 /**
  * 設定ダイアログ本体。
@@ -61,6 +68,7 @@ export function SettingsDialog({
 }: SettingsDialogProps) {
   const { getApi } = useApi();
   const { t, language, setLanguage } = useTranslation();
+  const { registerPasskey, listPasskeys, deletePasskey } = useAuth();
   const [selectedModelId, setSelectedModelId] = useState<string>("");
   const [selectedLanguage, setSelectedLanguage] = useState<string>(language);
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
@@ -77,6 +85,17 @@ export function SettingsDialog({
   const [isCreatingApiKey, setIsCreatingApiKey] = useState(false);
   const [revokingApiKeyId, setRevokingApiKeyId] = useState<string | null>(null);
   const [confirmRevokeKeyId, setConfirmRevokeKeyId] = useState<string | null>(null);
+  const [passkeys, setPasskeys] = useState<AuthWebAuthnCredential[]>([]);
+  const [isPasskeysLoading, setIsPasskeysLoading] = useState(false);
+  const [isAddingPasskey, setIsAddingPasskey] = useState(false);
+  const [deletingPasskeyId, setDeletingPasskeyId] = useState<string | null>(null);
+  const [confirmDeletePasskeyId, setConfirmDeletePasskeyId] = useState<string | null>(
+    null
+  );
+  const [passkeysErrorKey, setPasskeysErrorKey] = useState<PasskeysErrorKey | null>(
+    null
+  );
+  const [passkeySupported, setPasskeySupported] = useState(false);
   const [secretCopied, setSecretCopied] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [errorKey, setErrorKey] = useState<SettingsErrorKey | null>(null);
@@ -107,6 +126,28 @@ export function SettingsDialog({
       } finally {
         if (isMounted) {
           setIsApiKeysLoading(false);
+        }
+      }
+    }
+
+    async function loadPasskeys() {
+      if (typeof window === "undefined" || !window.PublicKeyCredential) {
+        return;
+      }
+      setIsPasskeysLoading(true);
+      setPasskeysErrorKey(null);
+
+      try {
+        const credentials = await listPasskeys();
+        if (!isMounted) return;
+        setPasskeys(credentials);
+      } catch (err) {
+        if (!isMounted) return;
+        logger.error("Failed to load passkeys", err);
+        setPasskeysErrorKey("settings.passkeysListError");
+      } finally {
+        if (isMounted) {
+          setIsPasskeysLoading(false);
         }
       }
     }
@@ -144,6 +185,7 @@ export function SettingsDialog({
 
         setIsLoading(false);
         void loadApiKeys(apiClient);
+        void loadPasskeys();
       } catch (err) {
         if (!isMounted) return;
 
@@ -161,7 +203,13 @@ export function SettingsDialog({
     return () => {
       isMounted = false;
     };
-  }, [open, getApi]);
+  }, [open, getApi, listPasskeys]);
+
+  useEffect(() => {
+    setPasskeySupported(
+      typeof window !== "undefined" && !!window.PublicKeyCredential
+    );
+  }, []);
 
   useEffect(() => {
     if (open) return;
@@ -171,6 +219,7 @@ export function SettingsDialog({
     setSecretCopied(false);
     setErrorKey(null);
     setApiKeysErrorKey(null);
+    setPasskeysErrorKey(null);
     setSaveSuccess(false);
   }, [open]);
 
@@ -280,6 +329,44 @@ export function SettingsDialog({
     }
   };
 
+  /**
+   * 認証済みユーザーにパスキーを登録するハンドラ。
+   * associateWebAuthnCredential がブラウザの WebAuthn プロンプトを起動し、
+   * 完了後に一覧を再取得する。
+   */
+  const handleAddPasskey = async () => {
+    setIsAddingPasskey(true);
+    setPasskeysErrorKey(null);
+
+    try {
+      await registerPasskey();
+      const credentials = await listPasskeys();
+      setPasskeys(credentials);
+    } catch (err) {
+      logger.error("Failed to register passkey", err);
+      setPasskeysErrorKey("settings.passkeysAddError");
+    } finally {
+      setIsAddingPasskey(false);
+    }
+  };
+
+  const handleDeletePasskey = async (credentialId: string) => {
+    setDeletingPasskeyId(credentialId);
+    setPasskeysErrorKey(null);
+
+    try {
+      await deletePasskey(credentialId);
+      setPasskeys((prev) =>
+        prev.filter((credential) => credential.credentialId !== credentialId)
+      );
+    } catch (err) {
+      logger.error("Failed to delete passkey", err);
+      setPasskeysErrorKey("settings.passkeysDeleteError");
+    } finally {
+      setDeletingPasskeyId(null);
+    }
+  };
+
   const formatLastUsed = (value: string | null) => {
     if (!value) {
       return t("settings.apiKeysNeverUsed");
@@ -296,6 +383,13 @@ export function SettingsDialog({
       title={t("settings.apiKeysRevokeButton")}
       description={t("settings.apiKeysRevokeConfirm")}
       onConfirm={() => { if (confirmRevokeKeyId) void handleRevokeApiKey(confirmRevokeKeyId); }}
+    />
+    <ConfirmDialog
+      open={confirmDeletePasskeyId !== null}
+      onOpenChange={(isOpen) => { if (!isOpen) setConfirmDeletePasskeyId(null); }}
+      title={t("settings.passkeysDeleteButton")}
+      description={t("settings.passkeysDeleteConfirm")}
+      onConfirm={() => { if (confirmDeletePasskeyId) void handleDeletePasskey(confirmDeletePasskeyId); }}
     />
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
@@ -492,6 +586,84 @@ export function SettingsDialog({
                   )}
                 </div>
               </div>
+
+              {passkeySupported && (
+                <div className="space-y-4 border-t pt-6">
+                  <div className="space-y-1">
+                    <h4 className="text-sm font-medium leading-none">
+                      {t("settings.passkeysTitle")}
+                    </h4>
+                    <p className="text-sm text-muted-foreground">
+                      {t("settings.passkeysDescription")}
+                    </p>
+                  </div>
+
+                  <Button
+                    onClick={handleAddPasskey}
+                    disabled={isAddingPasskey}
+                    data-testid="add-passkey-button"
+                  >
+                    {isAddingPasskey ? (
+                      <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <KeyRoundIcon className="mr-2 h-4 w-4" />
+                    )}
+                    {t("settings.passkeysAddButton")}
+                  </Button>
+
+                  {passkeysErrorKey ? (
+                    <p className="text-sm text-red-500">{t(passkeysErrorKey)}</p>
+                  ) : null}
+
+                  <div className="space-y-2">
+                    {isPasskeysLoading ? (
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Loader2Icon className="h-4 w-4 animate-spin" />
+                        <span>{t("common.loading")}</span>
+                      </div>
+                    ) : passkeys.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        {t("settings.passkeysEmpty")}
+                      </p>
+                    ) : (
+                      passkeys.map((credential) => (
+                        <div
+                          key={credential.credentialId}
+                          data-testid={`passkey-row-${credential.credentialId}`}
+                          className="flex items-center justify-between rounded-md border p-3"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium">
+                              {credential.friendlyCredentialName ||
+                                t("settings.passkeysUnnamed")}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {t("settings.passkeysCreatedAt")}:{" "}
+                              {credential.createdAt
+                                ? new Date(credential.createdAt).toLocaleString()
+                                : "-"}
+                            </p>
+                          </div>
+                          <Button
+                            variant="outline"
+                            onClick={() => {
+                              if (credential.credentialId) {
+                                setConfirmDeletePasskeyId(credential.credentialId);
+                              }
+                            }}
+                            disabled={deletingPasskeyId === credential.credentialId}
+                          >
+                            {deletingPasskeyId === credential.credentialId ? (
+                              <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                            ) : null}
+                            {t("settings.passkeysDeleteButton")}
+                          </Button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              )}
 
               <div className="space-y-4 border-t pt-6">
                 <div className="space-y-1">

--- a/frontend/src/lib/auth-context.test.tsx
+++ b/frontend/src/lib/auth-context.test.tsx
@@ -1,8 +1,18 @@
 import * as Sentry from "@sentry/nextjs";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import {
+  signIn,
+  associateWebAuthnCredential,
+  listWebAuthnCredentials,
+  deleteWebAuthnCredential,
+} from "aws-amplify/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthProvider, useAuth } from "./auth-context";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
 
 function AuthConsumer() {
   const { isLoading, user } = useAuth();
@@ -33,5 +43,59 @@ describe("AuthProvider", () => {
     await waitFor(() => {
       expect(Sentry.setUser).toHaveBeenLastCalledWith({ id: "test-user-id" });
     });
+  });
+});
+
+describe("AuthProvider passkeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("signs in with a passkey via the USER_AUTH / WEB_AUTHN flow", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await result.current.signInWithPasskey("user@example.com");
+
+    expect(signIn).toHaveBeenCalledWith({
+      username: "user@example.com",
+      options: { authFlowType: "USER_AUTH", preferredChallenge: "WEB_AUTHN" },
+    });
+  });
+
+  it("registers a passkey via associateWebAuthnCredential", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await result.current.registerPasskey();
+
+    expect(associateWebAuthnCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists registered passkeys", async () => {
+    vi.mocked(listWebAuthnCredentials).mockResolvedValueOnce({
+      credentials: [
+        {
+          credentialId: "cred-1",
+          friendlyCredentialName: "MacBook",
+          relyingPartyId: "notes.dev.devtools.site",
+          authenticatorTransports: ["internal"],
+          createdAt: new Date("2026-06-01T00:00:00Z"),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    const credentials = await result.current.listPasskeys();
+
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0].credentialId).toBe("cred-1");
+  });
+
+  it("deletes a passkey by credential id", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await result.current.deletePasskey("cred-1");
+
+    expect(deleteWebAuthnCredential).toHaveBeenCalledWith({ credentialId: "cred-1" });
   });
 });

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -25,9 +25,13 @@ import {
   confirmSignUp,
   getCurrentUser,
   fetchAuthSession,
+  associateWebAuthnCredential,
+  listWebAuthnCredentials,
+  deleteWebAuthnCredential,
   type SignInInput,
   type SignUpInput,
   type ConfirmSignUpInput,
+  type AuthWebAuthnCredential,
 } from "aws-amplify/auth";
 import { logger } from "@/lib/logger";
 import { isDevAuthBypass, BYPASS_TOKEN, BYPASS_USER } from "@/lib/dev-bypass";
@@ -45,10 +49,14 @@ interface AuthContextType {
   sessionExpired: boolean;
   notifySessionExpired: () => void;
   signIn: (email: string, password: string) => Promise<void>;
+  signInWithPasskey: (email: string) => Promise<void>;
   signUp: (email: string, password: string) => Promise<{ needsConfirmation: boolean }>;
   confirmSignUp: (email: string, code: string) => Promise<void>;
   signOut: () => Promise<void>;
   getAccessToken: () => Promise<string | null>;
+  registerPasskey: () => Promise<void>;
+  listPasskeys: () => Promise<AuthWebAuthnCredential[]>;
+  deletePasskey: (credentialId: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -113,6 +121,47 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   /**
+   * パスキー (WebAuthn) でパスワードレスにサインインする。
+   * USER_AUTH (choice-based) フローで WEB_AUTHN チャレンジを優先する。
+   * 事前にパスキーを登録済みであることが前提。
+   */
+  const handleSignInWithPasskey = async (email: string) => {
+    if (isDevAuthBypass) return;
+    // パスワードログインと同様、セッション失効中は旧セッションを先にクリアする。
+    if (sessionExpired) {
+      try { await signOut(); } catch { /* 旧セッションのクリアに失敗しても続行 */ }
+    }
+    await signIn({
+      username: email,
+      options: { authFlowType: "USER_AUTH", preferredChallenge: "WEB_AUTHN" },
+    });
+    setSessionExpired(false);
+    await checkUser();
+  };
+
+  /**
+   * 認証済みユーザーのアカウントにパスキーを登録する。
+   * ブラウザの WebAuthn プロンプトが表示される。
+   */
+  const handleRegisterPasskey = async () => {
+    if (isDevAuthBypass) return;
+    await associateWebAuthnCredential();
+  };
+
+  /** 登録済みパスキーの一覧を取得する。 */
+  const handleListPasskeys = useCallback(async (): Promise<AuthWebAuthnCredential[]> => {
+    if (isDevAuthBypass) return [];
+    const result = await listWebAuthnCredentials();
+    return result.credentials ?? [];
+  }, []);
+
+  /** 指定したパスキーを削除する。 */
+  const handleDeletePasskey = async (credentialId: string) => {
+    if (isDevAuthBypass) return;
+    await deleteWebAuthnCredential({ credentialId });
+  };
+
+  /**
    * 新規アカウントを作成する。
    * 確認コードが必要な場合は needsConfirmation: true を返す。
    */
@@ -161,10 +210,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         sessionExpired,
         notifySessionExpired,
         signIn: handleSignIn,
+        signInWithPasskey: handleSignInWithPasskey,
         signUp: handleSignUp,
         confirmSignUp: handleConfirmSignUp,
         signOut: handleSignOut,
         getAccessToken,
+        registerPasskey: handleRegisterPasskey,
+        listPasskeys: handleListPasskeys,
+        deletePasskey: handleDeletePasskey,
       }}
     >
       {children}

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -58,6 +58,18 @@ export const en = {
     apiKeysCreatedDescription: "Copy this secret now. It will only be shown once.",
     apiKeysLastUsed: "Last used",
     apiKeysNeverUsed: "Never used",
+    passkeysTitle: "Passkeys",
+    passkeysDescription:
+      "Register a passkey to sign in without a password using your device biometrics or security key.",
+    passkeysEmpty: "No passkeys registered yet.",
+    passkeysAddButton: "Add a passkey",
+    passkeysAddError: "Failed to register passkey",
+    passkeysListError: "Failed to load passkeys",
+    passkeysDeleteButton: "Delete",
+    passkeysDeleteConfirm: "Delete this passkey?",
+    passkeysDeleteError: "Failed to delete passkey",
+    passkeysCreatedAt: "Registered",
+    passkeysUnnamed: "Passkey",
     exportTitle: "Data Export",
     exportDescription: "Export all notes as a ZIP file.",
     exportButton: "Download ZIP",
@@ -359,6 +371,17 @@ export type TranslationKeys = {
     apiKeysCreatedDescription: string;
     apiKeysLastUsed: string;
     apiKeysNeverUsed: string;
+    passkeysTitle: string;
+    passkeysDescription: string;
+    passkeysEmpty: string;
+    passkeysAddButton: string;
+    passkeysAddError: string;
+    passkeysListError: string;
+    passkeysDeleteButton: string;
+    passkeysDeleteConfirm: string;
+    passkeysDeleteError: string;
+    passkeysCreatedAt: string;
+    passkeysUnnamed: string;
     exportTitle: string;
     exportDescription: string;
     exportButton: string;

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -58,6 +58,18 @@ export const ja = {
     apiKeysCreatedDescription: "このシークレットは今だけ表示されます。必ず控えてください。",
     apiKeysLastUsed: "最終使用",
     apiKeysNeverUsed: "未使用",
+    passkeysTitle: "パスキー",
+    passkeysDescription:
+      "パスキーを登録すると、デバイスの生体認証やセキュリティキーでパスワードなしにサインインできます。",
+    passkeysEmpty: "パスキーはまだ登録されていません。",
+    passkeysAddButton: "パスキーを追加",
+    passkeysAddError: "パスキーの登録に失敗しました",
+    passkeysListError: "パスキーの読み込みに失敗しました",
+    passkeysDeleteButton: "削除",
+    passkeysDeleteConfirm: "このパスキーを削除しますか？",
+    passkeysDeleteError: "パスキーの削除に失敗しました",
+    passkeysCreatedAt: "登録日",
+    passkeysUnnamed: "パスキー",
     exportTitle: "データエクスポート",
     exportDescription: "すべてのノートをZIP形式でエクスポートします。",
     exportButton: "ZIPをダウンロード",
@@ -358,6 +370,17 @@ export type TranslationKeys = {
     apiKeysCreatedDescription: string;
     apiKeysLastUsed: string;
     apiKeysNeverUsed: string;
+    passkeysTitle: string;
+    passkeysDescription: string;
+    passkeysEmpty: string;
+    passkeysAddButton: string;
+    passkeysAddError: string;
+    passkeysListError: string;
+    passkeysDeleteButton: string;
+    passkeysDeleteConfirm: string;
+    passkeysDeleteError: string;
+    passkeysCreatedAt: string;
+    passkeysUnnamed: string;
     exportTitle: string;
     exportDescription: string;
     exportButton: string;

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -40,6 +40,10 @@ vi.mock('aws-amplify/auth', () => ({
   signUp: vi.fn(),
   signOut: vi.fn(),
   confirmSignUp: vi.fn(),
+  confirmSignIn: vi.fn(),
+  associateWebAuthnCredential: vi.fn().mockResolvedValue(undefined),
+  listWebAuthnCredentials: vi.fn().mockResolvedValue({ credentials: [] }),
+  deleteWebAuthnCredential: vi.fn().mockResolvedValue(undefined),
 }))
 
 // Mock IndexedDB

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -59,6 +59,15 @@ resource "aws_cognito_user_pool" "main" {
   # MFA configuration (optional)
   mfa_configuration = "OFF"
 
+  # Feature plan tier. ESSENTIALS 以上で WebAuthn (パスキー) 設定が有効になる。
+  user_pool_tier = "ESSENTIALS"
+
+  # パスキー (WebAuthn) 設定。relying_party_id は env ごとのドメインに合わせる。
+  web_authn_configuration {
+    relying_party_id  = local.current_env.domain_name
+    user_verification = "preferred"
+  }
+
   tags = {
     Name = "${var.project_name}-user-pool-${terraform.workspace}"
   }
@@ -100,7 +109,8 @@ resource "aws_cognito_user_pool_client" "main" {
   prevent_user_existence_errors = "ENABLED"
   explicit_auth_flows = [
     "ALLOW_REFRESH_TOKEN_AUTH",
-    "ALLOW_USER_SRP_AUTH"
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_USER_AUTH" # choice-based 認証 (パスキー / WebAuthn) 用
   ]
 
   generate_secret = false

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -68,6 +68,13 @@ resource "aws_cognito_user_pool" "main" {
     user_verification = "preferred"
   }
 
+  # choice-based 認証で許可する第一認証ファクター。
+  # WEB_AUTHN を含めないとプールで WebAuthn が有効にならない (WebAuthnNotEnabledException)。
+  # PASSWORD は必須。既存のパスワードログインを維持しつつパスキーを追加する。
+  sign_in_policy {
+    allowed_first_auth_factors = ["PASSWORD", "WEB_AUTHN"]
+  }
+
   tags = {
     Name = "${var.project_name}-user-pool-${terraform.workspace}"
   }


### PR DESCRIPTION
## 概要

Cognito ネイティブの WebAuthn を利用して、パスワードレスのパスキーログインを追加する。フィッシング耐性のある認証手段をユーザーに提供しつつ、従来のメール+パスワードログインも共存させる。パスキーの登録・管理は認証済みユーザーが設定モーダルから行う。

## 変更内容

### Terraform (`terraform/cognito.tf`)
- User Pool を `user_pool_tier = "ESSENTIALS"` に変更（WebAuthn 有効化に必須。1万MAU 以下なら月額 $0、超過分のみ $0.015/MAU）
- `web_authn_configuration` ブロックを追加（`relying_party_id` は env ごとのドメイン、`user_verification = "preferred"`）
- Client の `explicit_auth_flows` に `ALLOW_USER_AUTH`（choice-based / WebAuthn 用）を追加

### フロントエンド
- `lib/auth-context.tsx`: `signInWithPasskey` / `registerPasskey` / `listPasskeys` / `deletePasskey` を追加（既存の dev-bypass ガード踏襲）
- `app/login/page.tsx`: パスワードレスの「Sign in with a passkey」ボタンを追加。WebAuthn 非対応ブラウザでは非表示
- `components/layout/SettingsDialog.tsx`: パスキー管理セクション（一覧・追加・削除＋削除確認）を追加
- `locales/{en,ja}.ts`: パスキー用 i18n キーを値・型の両方に追加

### テスト
- `vitest.setup.ts` に WebAuthn API（associate/list/delete）モックを追加
- `auth-context.test.tsx` に新メソッドのユニットテスト 4 件を追加

## テスト方法

- [x] `vitest run`（auth-context / SettingsDialog: 12 tests passed）
- [x] `tsc --noEmit`（変更ファイルは型クリーン）／ `eslint` クリーン
- [x] `terraform validate` Success
- [ ] dev 環境 E2E（要 `terraform apply`・実機）:
  1. パスワードでサインイン → 設定モーダルでパスキー登録（ブラウザの WebAuthn プロンプト）
  2. サインアウト → 「Sign in with a passkey」でパスワードレスログイン
  3. 既存のパスワードログインが引き続き動くことを確認

> ⚠️ パスキーは HTTPS + RP ID 一致が必須のため、エンドツーエンド確認は dev 環境（notes.dev.devtools.site）で行う必要がある。

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った