### PR TITLE
feature: パスキーの擬似ワンクリック（メール記憶）

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { useAuth } from "@/lib/auth-context";
 import { FileTextIcon, Loader2Icon, KeyRoundIcon } from "lucide-react";
 import { isDevAuthBypass } from "@/lib/dev-bypass";
+import { getRememberedEmail, rememberEmail } from "@/lib/remembered-email";
 
 /**
  * ログインフォームコンポーネント。送信時に signIn を呼び出し、成功するとルートへリダイレクトする。
@@ -36,10 +37,13 @@ export default function LoginPage() {
   }, [router]);
 
   // WebAuthn 非対応ブラウザではパスキーボタンを表示しない。
+  // あわせて前回ログインのメールをプリフィルし、パスキーの擬似ワンクリックを可能にする。
+  // （localStorage 依存のため初期 state ではなく useEffect で設定しハイドレーション差異を避ける）
   useEffect(() => {
     setPasskeySupported(
       typeof window !== "undefined" && !!window.PublicKeyCredential
     );
+    setEmail((current) => current || getRememberedEmail());
   }, []);
 
   // パスワードログイン。メール・パスワード両方を JS で検証する
@@ -55,6 +59,7 @@ export default function LoginPage() {
 
     try {
       await signIn(email, password);
+      rememberEmail(email);
       router.push("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Sign in failed");
@@ -75,6 +80,7 @@ export default function LoginPage() {
 
     try {
       await signInWithPasskey(email);
+      rememberEmail(email);
       router.push("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Passkey sign in failed");

--- a/frontend/src/lib/remembered-email.test.ts
+++ b/frontend/src/lib/remembered-email.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearRememberedEmail,
+  getRememberedEmail,
+  rememberEmail,
+} from "./remembered-email";
+
+describe("remembered-email", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns an empty string when nothing is stored", () => {
+    expect(getRememberedEmail()).toBe("");
+  });
+
+  it("persists and retrieves the email", () => {
+    rememberEmail("user@example.com");
+    expect(getRememberedEmail()).toBe("user@example.com");
+  });
+
+  it("ignores empty emails", () => {
+    rememberEmail("");
+    expect(getRememberedEmail()).toBe("");
+  });
+
+  it("clears the stored email", () => {
+    rememberEmail("user@example.com");
+    clearRememberedEmail();
+    expect(getRememberedEmail()).toBe("");
+  });
+});

--- a/frontend/src/lib/remembered-email.ts
+++ b/frontend/src/lib/remembered-email.ts
@@ -1,0 +1,41 @@
+/**
+ * 直近にログインしたメールアドレスを localStorage に記憶するモジュール。
+ * パスキーの擬似ワンクリック（再訪ユーザーがメール入力なしでパスキー認証へ進む）に利用する。
+ * メールアドレスは資格情報ではないため平文保存で問題ない。
+ *
+ * 主なエクスポート:
+ * - getRememberedEmail: 記憶済みメールを取得（無ければ空文字）
+ * - rememberEmail: ログイン成功時にメールを保存
+ * - clearRememberedEmail: 記憶を消去
+ */
+const STORAGE_KEY = "notes:last-email";
+
+/** 記憶済みのメールアドレスを返す。SSR / localStorage 不可時は空文字。 */
+export function getRememberedEmail(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** ログイン成功時にメールアドレスを記憶する。空文字は無視する。 */
+export function rememberEmail(email: string): void {
+  if (typeof window === "undefined" || !email) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, email);
+  } catch {
+    /* localStorage が使えなくても致命的ではないので無視 */
+  }
+}
+
+/** 記憶済みのメールアドレスを消去する。 */
+export function clearRememberedEmail(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* 同上 */
+  }
+}


### PR DESCRIPTION
## 概要

ネイティブ Cognito の WebAuthn は SDK 上ユーザー名（メール）が必須で、完全な usernameless（入力なしのワンクリック）は実現できない（[AWS docs](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow-methods.html): "SDK-based applications must prompt for a username"）。その代替として、直近ログインのメールを記憶してプリフィルし、再訪ユーザーが入力なしで「パスキーでログイン」→生体認証に進める擬似ワンクリック体験を提供する。

## 変更内容

- `frontend/src/lib/remembered-email.ts`（新規）: 直近ログインメールの保存/取得/消去。SSR・localStorage 例外をガード。資格情報ではないため平文保存
- `frontend/src/app/login/page.tsx`:
  - マウント時に記憶済みメールを email 欄へプリフィル（ハイドレーション差異回避のため useEffect で設定）
  - パスワード／パスキー両方のログイン成功時に `rememberEmail()` で保存
- `frontend/src/lib/remembered-email.test.ts`（新規）: ユニットテスト4件

## テスト方法

- [x] `vitest run src/lib/remembered-email.test.ts`（4 passed）
- [x] `eslint` / `tsc --noEmit`（変更ファイルクリーン）
- [x] dev 実機確認: localStorage に記憶値を投入し再読込 → email 欄が自動プリフィルされることを確認
- [ ] 実アカウントで「ログイン→次回再訪時にメール記憶→パスキーでワンタップ」を確認

> 注: 本 PR はフロントのみの変更。Cognito/インフラ変更なし。完全な usernameless は別途カスタム認証（aws-samples）の大規模改修が必要なため対象外。

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応を行った（該当する場合）— 既存ログイン画面に準拠し英語ハードコード