### PR TITLE
feature: AI 要約・チャットの非同期化（API Gateway 30秒タイムアウト解消）

### DIFF
--- a/backend/alembic/versions/20260618_01_add_ai_jobs.py
+++ b/backend/alembic/versions/20260618_01_add_ai_jobs.py
@@ -1,0 +1,33 @@
+"""add ai jobs (async summarize/chat)"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260618_01"
+down_revision = "20260409_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_jobs",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("input", sa.Text(), nullable=True),
+        sa.Column("result", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("tokens_used", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ai_jobs")

--- a/backend/app/features/assistant/__init__.py
+++ b/backend/app/features/assistant/__init__.py
@@ -3,13 +3,21 @@
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from app.features.assistant.use_cases import AIInteractionUseCases, EditJobUseCases
+    from app.features.assistant.use_cases import (
+        AIInteractionUseCases,
+        AIJobUseCases,
+        EditJobUseCases,
+    )
 
 __all__ = [
     "AIInteractionUseCases",
+    "AIJobUseCases",
     "EditJobUseCases",
+    "dispatch_ai_job",
     "dispatch_edit_job",
+    "process_chat_job",
     "process_edit_job",
+    "process_summarize_job",
     "router",
     "run_edit_job_queue_records",
 ]
@@ -21,14 +29,17 @@ def __getattr__(name: str) -> Any:
 
         return router
     if name in {
+        "dispatch_ai_job",
         "dispatch_edit_job",
+        "process_chat_job",
         "process_edit_job",
+        "process_summarize_job",
         "run_edit_job_queue_records",
     }:
         from app.features.assistant import job_runner
 
         return getattr(job_runner, name)
-    if name in {"AIInteractionUseCases", "EditJobUseCases"}:
+    if name in {"AIInteractionUseCases", "AIJobUseCases", "EditJobUseCases"}:
         from app.features.assistant import use_cases
 
         return getattr(use_cases, name)

--- a/backend/app/features/assistant/dependencies.py
+++ b/backend/app/features/assistant/dependencies.py
@@ -14,7 +14,11 @@ from sqlmodel import Session
 from app.auth import UserId
 from app.database import get_session
 from app.features.assistant.gateway import AIGateway, get_ai_gateway
-from app.features.assistant.use_cases import AIInteractionUseCases, EditJobUseCases
+from app.features.assistant.use_cases import (
+    AIInteractionUseCases,
+    AIJobUseCases,
+    EditJobUseCases,
+)
 from app.features.workspace.dependencies import get_workspace_query_use_cases
 from app.features.workspace.use_cases import WorkspaceQueryUseCases
 
@@ -45,6 +49,21 @@ def get_edit_job_use_cases(
 ) -> EditJobUseCases:
     """AI編集ジョブの作成・取得を行う EditJobUseCases を生成して返す。"""
     return EditJobUseCases(
+        session=session,
+        user_id=user_id,
+        workspace_queries=workspace_queries,
+    )
+
+
+def get_ai_job_use_cases(
+    session: Annotated[Session, Depends(get_session)],
+    user_id: UserId,
+    workspace_queries: Annotated[
+        WorkspaceQueryUseCases, Depends(get_workspace_query_use_cases)
+    ],
+) -> AIJobUseCases:
+    """要約・チャットの非同期ジョブの作成・取得を行う AIJobUseCases を生成して返す。"""
+    return AIJobUseCases(
         session=session,
         user_id=user_id,
         workspace_queries=workspace_queries,

--- a/backend/app/features/assistant/job_runner.py
+++ b/backend/app/features/assistant/job_runner.py
@@ -27,14 +27,19 @@ from app.features.assistant.errors import (
     AITokenLimitExceededError,
 )
 from app.features.assistant.gateway import AIGateway, get_ai_gateway
+from app.features.assistant.schemas import BedrockMessage
 from app.features.assistant.use_cases import AIInteractionUseCases
 from app.features.workspace.use_cases import WorkspaceQueryUseCases
 from app.logging_utils import log_event
-from app.models import AIEditJob
+from app.models import AIEditJob, AIJob
+from app.models.enums import ChatScope
 
 logger = logging.getLogger(__name__)
 
 PROCESS_EDIT_JOB_TASK = "process_ai_edit_job"
+PROCESS_SUMMARIZE_JOB_TASK = "process_ai_summarize_job"
+PROCESS_CHAT_JOB_TASK = "process_ai_chat_job"
+# 全ジョブ種別が共有する SNS トピック（編集ジョブ用に作成済みのものを再利用）
 EDIT_JOB_TOPIC_ARN_ENV = "AI_EDIT_JOB_TOPIC_ARN"
 
 
@@ -43,34 +48,53 @@ def _get_session() -> Session:
     return Session(get_dsql_engine())
 
 
-async def dispatch_edit_job(
-    job_id: UUID, background_tasks: BackgroundTasks | None = None
+def _task_handlers() -> dict:
+    """task 名 → 処理関数のディスパッチ表（呼び出し時に解決）。"""
+    return {
+        PROCESS_EDIT_JOB_TASK: process_edit_job,
+        PROCESS_SUMMARIZE_JOB_TASK: process_summarize_job,
+        PROCESS_CHAT_JOB_TASK: process_chat_job,
+    }
+
+
+async def dispatch_ai_job(
+    job_id: UUID,
+    task: str,
+    background_tasks: BackgroundTasks | None = None,
 ) -> None:
-    """AI 編集ジョブを SNS/SQS またはローカルバックグラウンドタスクへキューイングする。"""
+    """AI ジョブ（編集・要約・チャット）を SNS/SQS またはローカル実行へキューイングする。
+
+    全ジョブ種別は共有 SNS トピックを使い、task でワーカー側の処理を振り分ける。
+    トピック未設定（ローカル開発）時は BackgroundTasks かインライン実行にフォールバックする。
+    """
     topic_arn = os.getenv(EDIT_JOB_TOPIC_ARN_ENV)
 
     if topic_arn:
         boto3.client("sns").publish(
             TopicArn=topic_arn,
-            Message=json.dumps({"task": PROCESS_EDIT_JOB_TASK, "job_id": str(job_id)}),
+            Message=json.dumps({"task": task, "job_id": str(job_id)}),
         )
         log_event(
             logger,
             logging.INFO,
-            "ops.ai_edit_job.dispatched",
+            "ops.ai_job.dispatched",
             job_id=job_id,
+            task=task,
             dispatch_mode="sns",
             outcome="queued",
         )
         return
 
+    process_fn = _task_handlers()[task]
+
     if background_tasks is not None:
-        background_tasks.add_task(process_edit_job, job_id)
+        background_tasks.add_task(process_fn, job_id)
         log_event(
             logger,
             logging.INFO,
-            "ops.ai_edit_job.dispatched",
+            "ops.ai_job.dispatched",
             job_id=job_id,
+            task=task,
             dispatch_mode="background_tasks",
             outcome="queued",
         )
@@ -79,12 +103,22 @@ async def dispatch_edit_job(
     log_event(
         logger,
         logging.INFO,
-        "ops.ai_edit_job.dispatched",
+        "ops.ai_job.dispatched",
         job_id=job_id,
+        task=task,
         dispatch_mode="inline",
         outcome="running",
     )
-    await process_edit_job(job_id)
+    await process_fn(job_id)
+
+
+async def dispatch_edit_job(
+    job_id: UUID, background_tasks: BackgroundTasks | None = None
+) -> None:
+    """AI 編集ジョブをディスパッチする（dispatch_ai_job の編集用ラッパー）。"""
+    await dispatch_ai_job(
+        job_id, PROCESS_EDIT_JOB_TASK, background_tasks=background_tasks
+    )
 
 
 async def process_edit_job(
@@ -192,6 +226,160 @@ async def process_edit_job(
             session.commit()
 
 
+async def _process_ai_job(
+    job_id: UUID | str,
+    run_call,
+    *,
+    session_factory=_get_session,
+    ai_gateway: AIGateway | None = None,
+) -> None:
+    """汎用 AI ジョブ（要約・チャット）を処理し結果を永続化する共通ランナー。
+
+    run_call(use_cases, params) は (結果テキスト, 消費トークン数) を返す async 呼び出し。
+    トークン計上は AIInteractionUseCases 内で行われる。
+    """
+    ai_gateway = ai_gateway or get_ai_gateway()
+
+    with session_factory() as session:
+        job = session.get(AIJob, job_id)
+        if job is None:
+            log_event(
+                logger,
+                logging.WARNING,
+                "ops.ai_job.not_found",
+                job_id=job_id,
+                outcome="failure",
+            )
+            return
+
+        # 二重実行を防ぐ冪等ガード
+        if job.status in {"running", "completed"}:
+            return
+
+        job.status = "running"
+        job.started_at = datetime.now(UTC)
+        job.updated_at = job.started_at
+        session.add(job)
+        session.commit()
+        log_event(
+            logger,
+            logging.INFO,
+            "ops.ai_job.started",
+            job_id=job.id,
+            kind=job.kind,
+            outcome="running",
+        )
+
+        try:
+            params = json.loads(job.input)
+            workspace_queries = WorkspaceQueryUseCases(session, job.user_id)
+            interaction_use_cases = AIInteractionUseCases(
+                session=session,
+                user_id=job.user_id,
+                ai_gateway=ai_gateway,
+                workspace_queries=workspace_queries,
+            )
+            result, tokens_used = await run_call(interaction_use_cases, params)
+
+            job.status = "completed"
+            job.result = result
+            job.tokens_used = tokens_used
+            job.error_message = None
+            log_event(
+                logger,
+                logging.INFO,
+                "ops.ai_job.completed",
+                job_id=job.id,
+                kind=job.kind,
+                tokens_used=tokens_used,
+                outcome="success",
+            )
+        except AIApplicationTimeoutError:
+            job.status = "failed"
+            job.error_message = AI_EDIT_JOB_TIMEOUT_MESSAGE
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai_job.failed",
+                job_id=job.id,
+                kind=job.kind,
+                outcome="timeout",
+                reason="ai_timeout",
+            )
+        except AITokenLimitExceededError as exc:
+            job.status = "failed"
+            job.error_message = str(exc)
+            log_event(
+                logger,
+                logging.WARNING,
+                "ops.ai_job.failed",
+                job_id=job.id,
+                kind=job.kind,
+                outcome="failure",
+                reason="token_limit_exceeded",
+            )
+        except Exception as exc:
+            log_event(
+                logger,
+                logging.ERROR,
+                "ops.ai_job.failed",
+                job_id=job_id,
+                outcome="error",
+                reason=exc.__class__.__name__,
+                exc_info=True,
+            )
+            job.status = "failed"
+            job.error_message = str(exc)
+        finally:
+            now = datetime.now(UTC)
+            job.completed_at = now if job.status in {"completed", "failed"} else None
+            job.updated_at = now
+            session.add(job)
+            session.commit()
+
+
+async def process_summarize_job(
+    job_id: UUID | str,
+    *,
+    session_factory=_get_session,
+    ai_gateway: AIGateway | None = None,
+) -> None:
+    """キュー済みの要約ジョブを処理する。"""
+
+    async def run(use_cases: AIInteractionUseCases, params: dict):
+        return await use_cases.summarize_note(UUID(params["note_id"]))
+
+    await _process_ai_job(
+        job_id, run, session_factory=session_factory, ai_gateway=ai_gateway
+    )
+
+
+async def process_chat_job(
+    job_id: UUID | str,
+    *,
+    session_factory=_get_session,
+    ai_gateway: AIGateway | None = None,
+) -> None:
+    """キュー済みのチャットジョブを処理する。"""
+
+    async def run(use_cases: AIInteractionUseCases, params: dict):
+        raw_history = params.get("history") or []
+        # gateway.chat は各メッセージで .model_dump() を呼ぶため BedrockMessage に復元する
+        history = [BedrockMessage(**msg) for msg in raw_history] or None
+        return await use_cases.chat_with_context(
+            scope=ChatScope(params["scope"]),
+            question=params["question"],
+            history=history,
+            note_id=UUID(params["note_id"]) if params.get("note_id") else None,
+            folder_id=UUID(params["folder_id"]) if params.get("folder_id") else None,
+            selected_content=params.get("selected_content"),
+        )
+
+    await _process_ai_job(
+        job_id, run, session_factory=session_factory, ai_gateway=ai_gateway
+    )
+
+
 def run_edit_job_from_event(job_id: str) -> None:
     """非 HTTP 起動 (Lambda イベント等) からキュー済み AI 編集ジョブを処理する。"""
     asyncio.run(process_edit_job(job_id))
@@ -211,17 +399,23 @@ def _extract_job_payload(record: dict) -> dict:
 async def process_edit_job_queue_records(
     records: list[dict],
     *,
-    process_job_fn=process_edit_job,
+    handlers: dict | None = None,
 ) -> dict[str, list[dict[str, str]]]:
-    """SQS レコード群を処理し、失敗したアイテムのみ再試行対象として返す。"""
+    """SQS レコード群を task で振り分けて処理し、失敗アイテムのみ再試行対象として返す。
+
+    編集・要約・チャットの全ジョブ種別を同一キュー/ワーカーで処理する。
+    """
+    handlers = handlers or _task_handlers()
     failures: list[dict[str, str]] = []
 
     for record in records:
         message_id = record.get("messageId", "unknown")
         try:
             payload = _extract_job_payload(record)
-            if payload.get("task") != PROCESS_EDIT_JOB_TASK:
-                raise ValueError("Unsupported queue task")
+            task = payload.get("task")
+            process_job_fn = handlers.get(task)
+            if process_job_fn is None:
+                raise ValueError(f"Unsupported queue task: {task}")
 
             job_id = payload.get("job_id")
             if not job_id:
@@ -232,7 +426,7 @@ async def process_edit_job_queue_records(
             log_event(
                 logger,
                 logging.ERROR,
-                "ops.ai_edit_job.queue_record_failed",
+                "ops.ai_job.queue_record_failed",
                 queue_message_id=message_id,
                 outcome="error",
                 exc_info=True,
@@ -243,5 +437,5 @@ async def process_edit_job_queue_records(
 
 
 def run_edit_job_queue_records(records: list[dict]) -> dict[str, list[dict[str, str]]]:
-    """Lambda SQS イベントハンドリング用の同期ラッパー。"""
+    """Lambda SQS イベントハンドリング用の同期ラッパー（全ジョブ種別を処理）。"""
     return asyncio.run(process_edit_job_queue_records(records))

--- a/backend/app/features/assistant/router.py
+++ b/backend/app/features/assistant/router.py
@@ -15,24 +15,32 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from app.auth import UserId
 from app.features.assistant.dependencies import (
     get_ai_interaction_use_cases,
+    get_ai_job_use_cases,
     get_edit_job_use_cases,
 )
 from app.features.assistant.errors import (
     AIApplicationTimeoutError,
     AITokenLimitExceededError,
 )
-from app.features.assistant.job_runner import dispatch_edit_job
+from app.features.assistant.job_runner import (
+    PROCESS_CHAT_JOB_TASK,
+    PROCESS_SUMMARIZE_JOB_TASK,
+    dispatch_ai_job,
+    dispatch_edit_job,
+)
 from app.features.assistant.schemas import (
     ChatRequest,
-    ChatResponse,
     EditJobCreateResponse,
     EditRequest,
     EditResponse,
     SummarizeRequest,
-    SummarizeResponse,
 )
-from app.features.assistant.use_cases import AIInteractionUseCases, EditJobUseCases
-from app.models import AIEditJobCreate, AIEditJobRead
+from app.features.assistant.use_cases import (
+    AIInteractionUseCases,
+    AIJobUseCases,
+    EditJobUseCases,
+)
+from app.models import AIEditJobCreate, AIEditJobRead, AIJobRead
 
 router = APIRouter()
 
@@ -59,30 +67,46 @@ def _raise_ai_http_error(exc: Exception) -> None:
     raise exc
 
 
-@router.post("/summarize", response_model=SummarizeResponse)
-async def summarize_note(
+@router.post(
+    "/summarize-jobs",
+    response_model=AIJobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_summarize_job(
     request: SummarizeRequest,
+    background_tasks: BackgroundTasks,
     user_id: UserId,
-    use_cases: Annotated[AIInteractionUseCases, Depends(get_ai_interaction_use_cases)],
+    use_cases: Annotated[AIJobUseCases, Depends(get_ai_job_use_cases)],
 ):
-    """AIを使ってノートの内容を要約する。"""
+    """要約を非同期ジョブとしてキューに登録し、202 でポーリング可能なジョブを返す。
+
+    同期だと Bedrock 生成が API Gateway の 30 秒上限を超え 503 になるため非同期化している。
+    """
     try:
-        summary, tokens_used = await use_cases.summarize_note(request.note_id)
-    except (AITokenLimitExceededError, AIApplicationTimeoutError) as exc:
+        job = use_cases.create_summarize_job(request.note_id)
+    except AITokenLimitExceededError as exc:
         _raise_ai_http_error(exc)
 
-    return SummarizeResponse(summary=summary, tokens_used=tokens_used)
+    await dispatch_ai_job(
+        job.id, PROCESS_SUMMARIZE_JOB_TASK, background_tasks=background_tasks
+    )
+    return AIJobRead.model_validate(job)
 
 
-@router.post("/chat", response_model=ChatResponse)
-async def chat_with_context(
+@router.post(
+    "/chat-jobs",
+    response_model=AIJobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_chat_job(
     request: ChatRequest,
+    background_tasks: BackgroundTasks,
     user_id: UserId,
-    use_cases: Annotated[AIInteractionUseCases, Depends(get_ai_interaction_use_cases)],
+    use_cases: Annotated[AIJobUseCases, Depends(get_ai_job_use_cases)],
 ):
-    """ノートのコンテキストを参照しながらAIとチャットする。"""
+    """チャットを非同期ジョブとしてキューに登録し、202 でポーリング可能なジョブを返す。"""
     try:
-        answer, tokens_used = await use_cases.chat_with_context(
+        job = use_cases.create_chat_job(
             scope=request.scope,
             question=request.question,
             history=request.history,
@@ -90,10 +114,23 @@ async def chat_with_context(
             folder_id=request.folder_id,
             selected_content=request.selected_content,
         )
-    except (AITokenLimitExceededError, AIApplicationTimeoutError) as exc:
+    except AITokenLimitExceededError as exc:
         _raise_ai_http_error(exc)
 
-    return ChatResponse(answer=answer, tokens_used=tokens_used)
+    await dispatch_ai_job(
+        job.id, PROCESS_CHAT_JOB_TASK, background_tasks=background_tasks
+    )
+    return AIJobRead.model_validate(job)
+
+
+@router.get("/jobs/{job_id}", response_model=AIJobRead)
+async def get_ai_job(
+    job_id: UUID,
+    user_id: UserId,
+    use_cases: Annotated[AIJobUseCases, Depends(get_ai_job_use_cases)],
+):
+    """要約・チャットの非同期ジョブの現在ステータスをポーリングする。"""
+    return AIJobRead.model_validate(use_cases.get_job(job_id))
 
 
 @router.post("/edit", response_model=EditResponse)

--- a/backend/app/features/assistant/schemas.py
+++ b/backend/app/features/assistant/schemas.py
@@ -1,9 +1,10 @@
 """assistantフィーチャのリクエスト/レスポンス Pydanticスキーマ定義。
 
 責務: APIエンドポイントの入出力型を定義し、バリデーションを担う。
-主要なエクスポート: SummarizeRequest/Response, ChatRequest/Response,
+主要なエクスポート: SummarizeRequest, ChatRequest, BedrockMessage,
     EditRequest/Response, EditJobCreateResponse
 呼び出し関係: router.py のエンドポイント関数から参照される。
+    要約・チャットは非同期ジョブ化されたため専用レスポンス型は持たず AIJobRead を返す。
 """
 
 from typing import Literal
@@ -29,16 +30,9 @@ class BedrockMessage(BaseModel):
 
 
 class SummarizeRequest(BaseModel):
-    """要約エンドポイントへのリクエスト。"""
+    """要約ジョブ作成エンドポイントへのリクエスト。"""
 
     note_id: UUID
-
-
-class SummarizeResponse(BaseModel):
-    """要約エンドポイントのレスポンス。tokens_used は消費トークン数。"""
-
-    summary: str
-    tokens_used: int = 0
 
 
 class ChatRequest(BaseModel):
@@ -55,13 +49,6 @@ class ChatRequest(BaseModel):
     question: str = Field(max_length=MAX_AI_QUESTION_CHARS)
     history: list[BedrockMessage] | None = None
     selected_content: str | None = Field(default=None, max_length=MAX_AI_CONTENT_CHARS)
-
-
-class ChatResponse(BaseModel):
-    """チャットエンドポイントのレスポンス。tokens_used は消費トークン数。"""
-
-    answer: str
-    tokens_used: int = 0
 
 
 class EditRequest(BaseModel):

--- a/backend/app/features/assistant/use_cases/__init__.py
+++ b/backend/app/features/assistant/use_cases/__init__.py
@@ -1,6 +1,7 @@
 """Assistant use cases."""
 
 from app.features.assistant.use_cases.ai_interactions import AIInteractionUseCases
+from app.features.assistant.use_cases.ai_jobs import AIJobUseCases
 from app.features.assistant.use_cases.edit_jobs import EditJobUseCases
 
-__all__ = ["AIInteractionUseCases", "EditJobUseCases"]
+__all__ = ["AIInteractionUseCases", "AIJobUseCases", "EditJobUseCases"]

--- a/backend/app/features/assistant/use_cases/ai_jobs.py
+++ b/backend/app/features/assistant/use_cases/ai_jobs.py
@@ -1,0 +1,96 @@
+"""汎用 AI ジョブ（要約・チャット）の作成と取得ユースケース。
+
+責務: 入力検証・所有者確認・トークン上限チェックを行い、AIJob を
+    pending 状態で作成・参照する。実行は job_runner が非同期に行う。
+主要なエクスポート: AIJobUseCases
+呼び出し関係: assistant/router.py から呼ばれ、job_runner.py が処理する。
+    既存の EditJobUseCases（編集専用）を要約・チャット向けに一般化したもの。
+"""
+
+import json
+from uuid import UUID
+
+from sqlmodel import Session
+
+from app.db_commit import commit_with_error_handling
+from app.features.assistant.use_cases.common import (
+    ensure_token_limit,
+    require_non_empty,
+)
+from app.features.workspace.use_cases import WorkspaceQueryUseCases
+from app.models import AIJob
+from app.models.enums import ChatScope
+from app.shared import NotFound
+
+
+class AIJobUseCases:
+    """要約・チャットの非同期ジョブの作成と取得を担うユースケース。"""
+
+    def __init__(
+        self,
+        session: Session,
+        user_id: str,
+        workspace_queries: WorkspaceQueryUseCases,
+    ):
+        self.session = session
+        self.user_id = user_id
+        self.workspace_queries = workspace_queries
+
+    def _create(self, kind: str, payload: dict) -> AIJob:
+        """トークン制限チェック後に pending ジョブを永続化する共通処理。"""
+        ensure_token_limit(self.session, self.user_id)
+        job = AIJob(
+            user_id=self.user_id,
+            kind=kind,
+            status="pending",
+            input=json.dumps(payload),
+        )
+        self.session.add(job)
+        commit_with_error_handling(self.session, "AIJob")
+        self.session.refresh(job)
+        return job
+
+    def create_summarize_job(self, note_id: UUID) -> AIJob:
+        """要約ジョブを作成する。ノートの所有権・存在を作成時に検証する。"""
+        self.workspace_queries.get_owned_note(note_id)
+        return self._create("summarize", {"note_id": str(note_id)})
+
+    def create_chat_job(
+        self,
+        *,
+        scope: ChatScope,
+        question: str,
+        history: list | None = None,
+        note_id: UUID | None = None,
+        folder_id: UUID | None = None,
+        selected_content: str | None = None,
+    ) -> AIJob:
+        """チャットジョブを作成する。入力検証と（ノート指定時）所有権確認を行う。"""
+        require_non_empty(question, "Question is empty")
+        if scope == ChatScope.SELECTION:
+            require_non_empty(selected_content or "", "Selected content is empty")
+        if note_id is not None:
+            self.workspace_queries.get_owned_note(note_id)
+
+        payload = {
+            "scope": scope.value,
+            "question": question,
+            # BedrockMessage 等の pydantic オブジェクト or dict を JSON 化する
+            "history": [
+                msg.model_dump() if hasattr(msg, "model_dump") else dict(msg)
+                for msg in history
+            ]
+            if history
+            else None,
+            "note_id": str(note_id) if note_id else None,
+            "folder_id": str(folder_id) if folder_id else None,
+            "selected_content": selected_content,
+        }
+        return self._create("chat", payload)
+
+    def get_job(self, job_id: UUID) -> AIJob:
+        """指定 ID の AI ジョブを取得する。所有者でない場合は NotFound を送出。"""
+        job = self.session.get(AIJob, job_id)
+        if job is None or job.user_id != self.user_id:
+            raise NotFound("AI job not found")
+        return job

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.admin import (
     AdminUserUpdateRequest,
 )
 from app.models.ai_edit_job import AIEditJob, AIEditJobCreate, AIEditJobRead
+from app.models.ai_job import AIJob, AIJobRead
 from app.models.app_user import AppUser, AppUserRead
 from app.models.applied_mutation import AppliedMutation
 from app.models.folder import Folder, FolderCreate, FolderRead, FolderUpdate
@@ -49,6 +50,8 @@ __all__ = [
     "AIEditJob",
     "AIEditJobCreate",
     "AIEditJobRead",
+    "AIJob",
+    "AIJobRead",
     "AppUser",
     "AppUserRead",
     "AvailableLanguage",

--- a/backend/app/models/ai_job.py
+++ b/backend/app/models/ai_job.py
@@ -1,0 +1,76 @@
+"""汎用 AI ジョブ（要約・チャット）の DB モデルおよび API スキーマ。
+
+責務: 同期だと API Gateway の 30 秒上限を超える要約・チャットを非同期ジョブ化し、
+    結果をポーリングで取得できるよう永続化する。
+主要なエクスポート: AIJob, AIJobRead.
+呼び出し関係: features/assistant の router / use_cases / job_runner から参照される。
+    既存の AIEditJob（編集専用）と同じ非同期パターンを汎用化したもの。
+"""
+
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import field_validator
+from sqlalchemy import Column, Text
+from sqlmodel import Field, SQLModel
+
+# ジョブ種別: 要約 / チャット
+AIJobKind = Literal["summarize", "chat"]
+# ジョブ実行状態
+AIJobStatus = Literal["pending", "running", "completed", "failed"]
+
+
+class AIJob(SQLModel, table=True):
+    """非同期 AI ジョブ（要約・チャット）を DB に永続化するテーブルモデル。
+
+    クライアントはジョブ ID でポーリングし、result が返るまで待機する。
+    input は種別ごとに異なるパラメータを JSON 文字列で保持する
+    （summarize: {note_id} / chat: {scope, question, history, ...}）。
+    """
+
+    __tablename__ = "ai_jobs"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    user_id: str = Field()  # Cognito ユーザーサブ
+    kind: str = Field(max_length=32)  # "summarize" | "chat"
+    status: str = Field(default="pending", max_length=32)  # ジョブ実行状態
+    input: str = Field(default="{}", sa_column=Column(Text))  # 実行パラメータ(JSON)
+    result: str | None = Field(default=None, sa_column=Column(Text))  # 要約文/回答
+    error_message: str | None = Field(
+        default=None, sa_column=Column(Text)
+    )  # エラー詳細
+    tokens_used: int = Field(default=0)  # 消費トークン数
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    started_at: datetime | None = Field(default=None)  # 処理開始日時
+    completed_at: datetime | None = Field(default=None)  # 処理完了日時
+
+
+class AIJobRead(SQLModel):
+    """AI ジョブ取得レスポンススキーマ。ポーリング時にクライアントへ返す。
+
+    input は機微・冗長になり得るため返さない。
+    DB の naive datetime は UTC として補完する。
+    """
+
+    id: UUID
+    kind: AIJobKind
+    status: AIJobStatus
+    result: str | None = None
+    error_message: str | None = None
+    tokens_used: int = 0
+    created_at: datetime
+    updated_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    @field_validator(
+        "created_at", "updated_at", "started_at", "completed_at", mode="before"
+    )
+    @classmethod
+    def ensure_utc_timezone(cls, value: datetime | None) -> datetime | None:
+        # DB から取得した naive datetime に UTC タイムゾーンを付与する
+        if isinstance(value, datetime) and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value

--- a/backend/tests/integration/test_ai_endpoints.py
+++ b/backend/tests/integration/test_ai_endpoints.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 import uuid
 
 import pytest
@@ -9,6 +10,40 @@ TEST_PREFIX = "[IntegrationTest]"
 
 def generate_title(base):
     return f"{TEST_PREFIX} {base} {datetime.datetime.now().isoformat()}"
+
+
+def poll_ai_job(client, job_id, timeout_s=120, interval_s=1.5):
+    """要約・チャットの非同期ジョブを完了/失敗まで GET /api/ai/jobs/{id} でポーリングする。"""
+    deadline = time.monotonic() + timeout_s
+    while True:
+        resp = client.get(f"/api/ai/jobs/{job_id}")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        if data["status"] in ("completed", "failed"):
+            return data
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"AI job {job_id} did not finish in {timeout_s}s (status={data['status']})"
+            )
+        time.sleep(interval_s)
+
+
+def run_summarize_job(client, note_id):
+    """要約ジョブを作成しポーリングして完了したジョブを返す。"""
+    resp = client.post("/api/ai/summarize-jobs", json={"note_id": note_id})
+    assert resp.status_code == 202, resp.text
+    job = poll_ai_job(client, resp.json()["id"])
+    assert job["status"] == "completed", job.get("error_message")
+    return job
+
+
+def run_chat_job(client, payload):
+    """チャットジョブを作成しポーリングして完了したジョブを返す。"""
+    resp = client.post("/api/ai/chat-jobs", json=payload)
+    assert resp.status_code == 202, resp.text
+    job = poll_ai_job(client, resp.json()["id"])
+    assert job["status"] == "completed", job.get("error_message")
+    return job
 
 
 class TestAISummarize:
@@ -32,35 +67,27 @@ class TestAISummarize:
         client.delete(f"/api/notes/{note['id']}")
 
     def test_summarize_note(self, client, test_note):
-        """Create a note with substantial content, call summarize, verify response structure."""
-        response = client.post("/api/ai/summarize", json={"note_id": test_note["id"]})
-        assert response.status_code == 200
-        data = response.json()
-        assert "summary" in data
-        assert isinstance(data["summary"], str)
-        assert len(data["summary"]) > 0
-        assert "tokens_used" in data
-        assert isinstance(data["tokens_used"], int)
-        assert data["tokens_used"] >= 0
+        """Create a note, run the async summarize job, verify the completed job structure."""
+        job = run_summarize_job(client, test_note["id"])
+        assert job["kind"] == "summarize"
+        assert isinstance(job["result"], str)
+        assert len(job["result"]) > 0
+        assert isinstance(job["tokens_used"], int)
+        assert job["tokens_used"] >= 0
 
     def test_summarize_caching(self, client, test_note):
-        """Call summarize twice and verify the second response is served from cache."""
-        response1 = client.post("/api/ai/summarize", json={"note_id": test_note["id"]})
-        assert response1.status_code == 200
-        data1 = response1.json()
-        assert len(data1["summary"]) > 0
+        """Run summarize twice and verify the second job is served from cache (0 tokens)."""
+        job1 = run_summarize_job(client, test_note["id"])
+        assert len(job1["result"]) > 0
 
-        response2 = client.post("/api/ai/summarize", json={"note_id": test_note["id"]})
-        assert response2.status_code == 200
-        data2 = response2.json()
-
-        assert len(data2["summary"]) > 0
-        assert data2["tokens_used"] == 0
+        job2 = run_summarize_job(client, test_note["id"])
+        assert len(job2["result"]) > 0
+        assert job2["tokens_used"] == 0
 
     def test_summarize_nonexistent_note(self, client):
-        """Call summarize with a fake UUID, verify 404."""
+        """Creating a summarize job for a fake UUID must be rejected at creation (404)."""
         fake_id = str(uuid.uuid4())
-        response = client.post("/api/ai/summarize", json={"note_id": fake_id})
+        response = client.post("/api/ai/summarize-jobs", json={"note_id": fake_id})
         assert response.status_code == 404
 
 
@@ -130,64 +157,51 @@ class TestAIChat:
         client.delete(f"/api/folders/{folder['id']}")
 
     def test_chat_note_scope(self, client, test_note):
-        """Create a note, ask a question about it using scope 'note' and note_id, verify response structure."""
-        response = client.post(
-            "/api/ai/chat",
-            json={
+        """Ask a question about a note via an async chat job (scope 'note')."""
+        job = run_chat_job(
+            client,
+            {
                 "scope": "note",
                 "note_id": test_note["id"],
                 "question": "What programming language is this note about?",
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert "answer" in data
-        assert isinstance(data["answer"], str)
-        assert len(data["answer"]) > 0
-        assert "tokens_used" in data
-        assert isinstance(data["tokens_used"], int)
-        assert data["tokens_used"] >= 0
+        assert job["kind"] == "chat"
+        assert isinstance(job["result"], str)
+        assert len(job["result"]) > 0
+        assert isinstance(job["tokens_used"], int)
+        assert job["tokens_used"] >= 0
 
     def test_chat_folder_scope(self, client, test_folder_with_notes):
-        """Create a folder with 2 notes, ask question using scope 'folder' and folder_id, verify 200 and response structure."""
+        """Ask a question via an async chat job scoped to a folder."""
         folder_id = test_folder_with_notes["folder"]["id"]
-        response = client.post(
-            "/api/ai/chat",
-            json={
+        job = run_chat_job(
+            client,
+            {
                 "scope": "folder",
                 "folder_id": folder_id,
                 "question": "What topics are covered in these notes?",
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert "answer" in data
-        assert isinstance(data["answer"], str)
-        assert len(data["answer"]) > 0
-        assert "tokens_used" in data
-        assert isinstance(data["tokens_used"], int)
-        assert data["tokens_used"] >= 0
+        assert isinstance(job["result"], str)
+        assert len(job["result"]) > 0
+        assert job["tokens_used"] >= 0
 
     def test_chat_all_scope(self, client, test_note):
-        """Ask question using scope 'all' (no note_id/folder_id), verify 200 and response structure."""
-        response = client.post(
-            "/api/ai/chat",
-            json={
+        """Ask a question via an async chat job scoped to all notes."""
+        job = run_chat_job(
+            client,
+            {
                 "scope": "all",
                 "question": "Give me a brief summary of all my notes.",
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert "answer" in data
-        assert isinstance(data["answer"], str)
-        assert len(data["answer"]) > 0
-        assert "tokens_used" in data
-        assert isinstance(data["tokens_used"], int)
-        assert data["tokens_used"] >= 0
+        assert isinstance(job["result"], str)
+        assert len(job["result"]) > 0
+        assert job["tokens_used"] >= 0
 
     def test_chat_with_history(self, client, test_note):
-        """Create a note, ask a follow-up question with history list containing one previous exchange, verify 200."""
+        """Ask a follow-up question with history via an async chat job."""
         history = [
             {
                 "role": "user",
@@ -198,23 +212,18 @@ class TestAIChat:
                 "content": "The note is about Python programming.",
             },
         ]
-        response = client.post(
-            "/api/ai/chat",
-            json={
+        job = run_chat_job(
+            client,
+            {
                 "scope": "note",
                 "note_id": test_note["id"],
                 "question": "Who created that language?",
                 "history": history,
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert "answer" in data
-        assert isinstance(data["answer"], str)
-        assert len(data["answer"]) > 0
-        assert "tokens_used" in data
-        assert isinstance(data["tokens_used"], int)
-        assert data["tokens_used"] >= 0
+        assert isinstance(job["result"], str)
+        assert len(job["result"]) > 0
+        assert job["tokens_used"] >= 0
 
 
 class TestTokenUsage:
@@ -256,16 +265,13 @@ class TestTokenUsage:
         assert usage["tokens_used"] >= 0
 
     def test_ai_call_increments_token_usage(self, client, test_note):
-        """Verify that a non-cached AI summarize call increases tokens_used in settings."""
+        """Verify that a non-cached AI summarize job increases tokens_used in settings."""
         # Capture usage before
         before = client.get("/api/settings").json()["token_usage"]["tokens_used"]
 
-        # Make a summarize call (unique content ensures no S3 cache hit)
-        ai_response = client.post(
-            "/api/ai/summarize", json={"note_id": test_note["id"]}
-        )
-        assert ai_response.status_code == 200
-        tokens_charged = ai_response.json()["tokens_used"]
+        # Run a summarize job (unique content ensures no S3 cache hit)
+        job = run_summarize_job(client, test_note["id"])
+        tokens_charged = job["tokens_used"]
 
         # If the call was a cache miss, tokens_charged > 0 and settings must reflect it
         if tokens_charged > 0:

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -10,9 +10,29 @@ from app.features.assistant.gateway import (
     AIGatewayTimeoutError,
     get_ai_gateway,
 )
-from app.features.assistant.job_runner import process_edit_job
+from app.features.assistant.job_runner import (
+    process_chat_job,
+    process_edit_job,
+    process_summarize_job,
+)
 from app.main import app
 from app.models import AIEditJob, Folder, Note
+
+
+def _run_ai_job(process_fn, job_id, session, ai_gateway):
+    """非同期 AI ジョブをテスト内で同期実行するヘルパー。
+
+    SNS 未設定のテストでは dispatch をモックし、worker 相当の処理を直接走らせる。
+    """
+    engine = session.get_bind()
+    assert engine is not None
+    asyncio.run(
+        process_fn(
+            UUID(job_id),
+            session_factory=lambda: Session(engine),
+            ai_gateway=ai_gateway,
+        )
+    )
 
 
 # Mock AI Service
@@ -50,27 +70,66 @@ def mock_ai_service():
     app.dependency_overrides.pop(get_ai_gateway, None)
 
 
-def test_summarize_note(client: TestClient, session: Session, mock_ai_service):
-    # Setup test data
+def test_summarize_note(
+    client: TestClient,
+    session: Session,
+    mock_ai_service,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def noop_dispatch(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.features.assistant.router.dispatch_ai_job", noop_dispatch)
+
     user_id = "test-user-123"
     note = Note(title="Test Note", content="Test Content", user_id=user_id)
     session.add(note)
     session.commit()
 
-    response = client.post("/api/ai/summarize", json={"note_id": str(note.id)})
-    assert response.status_code == 200
-    assert response.json()["summary"] == "Summary: Test Conte..."
+    response = client.post("/api/ai/summarize-jobs", json={"note_id": str(note.id)})
+    assert response.status_code == 202
+    job = response.json()
+    assert job["status"] == "pending"
+    assert job["kind"] == "summarize"
+
+    _run_ai_job(process_summarize_job, job["id"], session, mock_ai_service)
+
+    poll = client.get(f"/api/ai/jobs/{job['id']}")
+    assert poll.status_code == 200
+    data = poll.json()
+    assert data["status"] == "completed"
+    assert data["result"] == "Summary: Test Conte..."
+    assert data["tokens_used"] == 20
 
 
-def test_summarize_empty_note(client: TestClient, session: Session, mock_ai_service):
+def test_summarize_empty_note(
+    client: TestClient,
+    session: Session,
+    mock_ai_service,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def noop_dispatch(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.features.assistant.router.dispatch_ai_job", noop_dispatch)
+
     user_id = "test-user-123"
     note = Note(title="Empty Note", content="  ", user_id=user_id)
     session.add(note)
     session.commit()
 
-    response = client.post("/api/ai/summarize", json={"note_id": str(note.id)})
-    assert response.status_code == 400
-    assert "empty" in response.json()["detail"].lower()
+    # 空ノートの検証は worker 処理時に行われるため、ジョブは受理(202)後に failed になる
+    response = client.post("/api/ai/summarize-jobs", json={"note_id": str(note.id)})
+    assert response.status_code == 202
+    job = response.json()
+
+    _run_ai_job(process_summarize_job, job["id"], session, mock_ai_service)
+
+    poll = client.get(f"/api/ai/jobs/{job['id']}")
+    assert poll.status_code == 200
+    data = poll.json()
+    assert data["status"] == "failed"
+    assert "empty" in (data["error_message"] or "").lower()
 
 
 def test_summarize_unowned_note(make_client, session: Session, mock_ai_service):
@@ -79,30 +138,60 @@ def test_summarize_unowned_note(make_client, session: Session, mock_ai_service):
     session.add(note)
     session.commit()
 
+    # 所有権チェックはジョブ作成時に行われるため 404 で即拒否される
     client = make_client("test-user-123")
-    response = client.post("/api/ai/summarize", json={"note_id": str(note.id)})
+    response = client.post("/api/ai/summarize-jobs", json={"note_id": str(note.id)})
     assert response.status_code == 404
 
 
-def test_chat_note_scope(client: TestClient, session: Session, mock_ai_service):
+def test_chat_note_scope(
+    client: TestClient,
+    session: Session,
+    mock_ai_service,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def noop_dispatch(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.features.assistant.router.dispatch_ai_job", noop_dispatch)
+
     user_id = "test-user-123"
     note = Note(title="Test Note", content="Sample content for chat", user_id=user_id)
     session.add(note)
     session.commit()
 
     response = client.post(
-        "/api/ai/chat",
+        "/api/ai/chat-jobs",
         json={
             "scope": "note",
             "note_id": str(note.id),
             "question": "What is in the note?",
         },
     )
-    assert response.status_code == 200
-    assert "What is in the note?" in response.json()["answer"]
+    assert response.status_code == 202
+    job = response.json()
+    assert job["kind"] == "chat"
+
+    _run_ai_job(process_chat_job, job["id"], session, mock_ai_service)
+
+    poll = client.get(f"/api/ai/jobs/{job['id']}")
+    assert poll.status_code == 200
+    data = poll.json()
+    assert data["status"] == "completed"
+    assert "What is in the note?" in data["result"]
 
 
-def test_chat_folder_scope(client: TestClient, session: Session, mock_ai_service):
+def test_chat_folder_scope(
+    client: TestClient,
+    session: Session,
+    mock_ai_service,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def noop_dispatch(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.features.assistant.router.dispatch_ai_job", noop_dispatch)
+
     user_id = "test-user-123"
     folder = Folder(name="Test Folder", user_id=user_id)
     session.add(folder)
@@ -119,18 +208,36 @@ def test_chat_folder_scope(client: TestClient, session: Session, mock_ai_service
     session.commit()
 
     response = client.post(
-        "/api/ai/chat",
+        "/api/ai/chat-jobs",
         json={
             "scope": "folder",
             "folder_id": str(folder.id),
             "question": "Ask about folder",
         },
     )
-    assert response.status_code == 200
-    assert "Ask about folder" in response.json()["answer"]
+    assert response.status_code == 202
+    job = response.json()
+
+    _run_ai_job(process_chat_job, job["id"], session, mock_ai_service)
+
+    poll = client.get(f"/api/ai/jobs/{job['id']}")
+    assert poll.status_code == 200
+    data = poll.json()
+    assert data["status"] == "completed"
+    assert "Ask about folder" in data["result"]
 
 
-def test_chat_all_scope(client: TestClient, session: Session, mock_ai_service):
+def test_chat_all_scope(
+    client: TestClient,
+    session: Session,
+    mock_ai_service,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def noop_dispatch(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.features.assistant.router.dispatch_ai_job", noop_dispatch)
+
     user_id = "test-user-123"
     note1 = Note(title="Note 1", content="Content 1", user_id=user_id)
     note2 = Note(title="Note 2", content="Content 2", user_id=user_id)
@@ -139,9 +246,16 @@ def test_chat_all_scope(client: TestClient, session: Session, mock_ai_service):
     session.commit()
 
     response = client.post(
-        "/api/ai/chat", json={"scope": "all", "question": "Ask about everything"}
+        "/api/ai/chat-jobs", json={"scope": "all", "question": "Ask about everything"}
     )
-    assert response.status_code == 200
+    assert response.status_code == 202
+    job = response.json()
+
+    _run_ai_job(process_chat_job, job["id"], session, mock_ai_service)
+
+    poll = client.get(f"/api/ai/jobs/{job['id']}")
+    assert poll.status_code == 200
+    assert poll.json()["status"] == "completed"
 
 
 def test_edit_note_content(client: TestClient, session: Session, mock_ai_service):

--- a/backend/tests/test_edit_jobs.py
+++ b/backend/tests/test_edit_jobs.py
@@ -5,7 +5,9 @@ import pytest
 
 from app.features.assistant.job_runner import (
     EDIT_JOB_TOPIC_ARN_ENV,
+    PROCESS_CHAT_JOB_TASK,
     PROCESS_EDIT_JOB_TASK,
+    PROCESS_SUMMARIZE_JOB_TASK,
     dispatch_edit_job,
     process_edit_job,
     process_edit_job_queue_records,
@@ -94,7 +96,7 @@ async def test_process_edit_job_queue_records_reports_partial_failures():
 
     result = await process_edit_job_queue_records(
         records,
-        process_job_fn=fake_process_job,
+        handlers={PROCESS_EDIT_JOB_TASK: fake_process_job},
     )
 
     assert processed == ["job-1"]
@@ -104,3 +106,42 @@ async def test_process_edit_job_queue_records_reports_partial_failures():
             {"itemIdentifier": "msg-3"},
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_process_queue_records_routes_by_task():
+    """編集・要約・チャットの各 task が既定のディスパッチ表で正しい handler に振り分けられる。"""
+    routed: list[str] = []
+
+    def make_handler(label: str):
+        async def handler(job_id: str) -> None:
+            routed.append(f"{label}:{job_id}")
+
+        return handler
+
+    records = [
+        {
+            "messageId": "m1",
+            "body": json.dumps({"task": PROCESS_EDIT_JOB_TASK, "job_id": "edit-1"}),
+        },
+        {
+            "messageId": "m2",
+            "body": json.dumps({"task": PROCESS_SUMMARIZE_JOB_TASK, "job_id": "sum-1"}),
+        },
+        {
+            "messageId": "m3",
+            "body": json.dumps({"task": PROCESS_CHAT_JOB_TASK, "job_id": "chat-1"}),
+        },
+    ]
+
+    result = await process_edit_job_queue_records(
+        records,
+        handlers={
+            PROCESS_EDIT_JOB_TASK: make_handler("edit"),
+            PROCESS_SUMMARIZE_JOB_TASK: make_handler("summarize"),
+            PROCESS_CHAT_JOB_TASK: make_handler("chat"),
+        },
+    )
+
+    assert routed == ["edit:edit-1", "summarize:sum-1", "chat:chat-1"]
+    assert result == {"batchItemFailures": []}

--- a/backend/tests/test_token_usage.py
+++ b/backend/tests/test_token_usage.py
@@ -1,12 +1,15 @@
 """Tests for token usage tracking and limit enforcement."""
 
+import asyncio
 from datetime import UTC, datetime
+from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.features.assistant.gateway import AIGateway, get_ai_gateway
+from app.features.assistant.job_runner import process_chat_job, process_summarize_job
 from app.features.assistant.usage_policy import (
     check_limit,
     get_or_create_current_period,
@@ -17,6 +20,24 @@ from app.main import app
 from app.models import Note
 from app.models.token_usage import MONTHLY_TOKEN_LIMIT, TokenUsage
 from tests.conftest import TEST_USER_ID
+
+
+async def _noop_dispatch(*args, **kwargs):
+    """テストでは SNS ディスパッチを無効化し、処理は明示的に実行する。"""
+    return None
+
+
+def _run_ai_job(process_fn, job_id, session, ai_gateway):
+    """非同期 AI ジョブをテスト内で同期実行する（worker 相当）。"""
+    engine = session.get_bind()
+    assert engine is not None
+    asyncio.run(
+        process_fn(
+            UUID(job_id),
+            session_factory=lambda: Session(engine),
+            ai_gateway=ai_gateway,
+        )
+    )
 
 
 # Mock AI Service that returns token counts
@@ -145,41 +166,55 @@ class TestTokenLimitInAIEndpoints:
     """Tests for token limit enforcement in AI endpoints."""
 
     def test_summarize_records_tokens(
-        self, client: TestClient, session: Session, mock_ai_service
+        self,
+        client: TestClient,
+        session: Session,
+        mock_ai_service,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test that summarize endpoint records token usage."""
+        """Test that the summarize job records token usage (during processing)."""
+        monkeypatch.setattr(
+            "app.features.assistant.router.dispatch_ai_job", _noop_dispatch
+        )
         note = Note(title="Test Note", content="Test Content", user_id=TEST_USER_ID)
         session.add(note)
         session.commit()
 
-        response = client.post("/api/ai/summarize", json={"note_id": str(note.id)})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["tokens_used"] == 150
+        response = client.post("/api/ai/summarize-jobs", json={"note_id": str(note.id)})
+        assert response.status_code == 202
+        _run_ai_job(
+            process_summarize_job, response.json()["id"], session, mock_ai_service
+        )
 
-        # Check usage was recorded
+        # トークンは worker 処理時に記録される
         info = get_usage_info(session, TEST_USER_ID)
         assert info.tokens_used == 150
 
     def test_chat_records_tokens(
-        self, client: TestClient, session: Session, mock_ai_service
+        self,
+        client: TestClient,
+        session: Session,
+        mock_ai_service,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test that chat endpoint records token usage."""
+        """Test that the chat job records token usage (during processing)."""
+        monkeypatch.setattr(
+            "app.features.assistant.router.dispatch_ai_job", _noop_dispatch
+        )
         note = Note(title="Test Note", content="Test Content", user_id=TEST_USER_ID)
         session.add(note)
         session.commit()
 
         response = client.post(
-            "/api/ai/chat",
+            "/api/ai/chat-jobs",
             json={
                 "scope": "note",
                 "note_id": str(note.id),
                 "question": "What is this?",
             },
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["tokens_used"] == 200
+        assert response.status_code == 202
+        _run_ai_job(process_chat_job, response.json()["id"], session, mock_ai_service)
 
         info = get_usage_info(session, TEST_USER_ID)
         assert info.tokens_used == 200
@@ -187,7 +222,7 @@ class TestTokenLimitInAIEndpoints:
     def test_summarize_limit_exceeded(
         self, client: TestClient, session: Session, mock_ai_service
     ):
-        """Test that summarize returns 429 when limit is exceeded."""
+        """Test that summarize job creation returns 429 when limit is exceeded."""
         note = Note(title="Test Note", content="Test Content", user_id=TEST_USER_ID)
         session.add(note)
         session.commit()
@@ -198,14 +233,14 @@ class TestTokenLimitInAIEndpoints:
         session.add(usage)
         session.commit()
 
-        response = client.post("/api/ai/summarize", json={"note_id": str(note.id)})
+        response = client.post("/api/ai/summarize-jobs", json={"note_id": str(note.id)})
         assert response.status_code == 429
         assert "token limit" in response.json()["detail"].lower()
 
     def test_chat_limit_exceeded(
         self, client: TestClient, session: Session, mock_ai_service
     ):
-        """Test that chat returns 429 when limit is exceeded."""
+        """Test that chat job creation returns 429 when limit is exceeded."""
         note = Note(title="Test Note", content="Test Content", user_id=TEST_USER_ID)
         session.add(note)
         session.commit()
@@ -217,7 +252,7 @@ class TestTokenLimitInAIEndpoints:
         session.commit()
 
         response = client.post(
-            "/api/ai/chat",
+            "/api/ai/chat-jobs",
             json={
                 "scope": "note",
                 "note_id": str(note.id),
@@ -227,24 +262,32 @@ class TestTokenLimitInAIEndpoints:
         assert response.status_code == 429
 
     def test_token_usage_accumulates(
-        self, client: TestClient, session: Session, mock_ai_service
+        self,
+        client: TestClient,
+        session: Session,
+        mock_ai_service,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test that token usage accumulates across multiple requests."""
+        """Test that token usage accumulates across multiple jobs."""
+        monkeypatch.setattr(
+            "app.features.assistant.router.dispatch_ai_job", _noop_dispatch
+        )
         note = Note(title="Test Note", content="Test Content", user_id=TEST_USER_ID)
         session.add(note)
         session.commit()
 
-        # First request
-        client.post("/api/ai/summarize", json={"note_id": str(note.id)})
-        # Second request
-        client.post(
-            "/api/ai/chat",
-            json={
-                "scope": "note",
-                "note_id": str(note.id),
-                "question": "What?",
-            },
+        summarize = client.post(
+            "/api/ai/summarize-jobs", json={"note_id": str(note.id)}
         )
+        _run_ai_job(
+            process_summarize_job, summarize.json()["id"], session, mock_ai_service
+        )
+
+        chat = client.post(
+            "/api/ai/chat-jobs",
+            json={"scope": "note", "note_id": str(note.id), "question": "What?"},
+        )
+        _run_ai_job(process_chat_job, chat.json()["id"], session, mock_ai_service)
 
         info = get_usage_info(session, TEST_USER_ID)
         assert info.tokens_used == 350  # 150 + 200
@@ -269,15 +312,25 @@ class TestTokenUsageInSettings:
         assert token_usage["token_limit"] == MONTHLY_TOKEN_LIMIT
 
     def test_settings_reflects_usage(
-        self, client: TestClient, session: Session, mock_ai_service
+        self,
+        client: TestClient,
+        session: Session,
+        mock_ai_service,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Test that settings token_usage reflects actual usage."""
+        monkeypatch.setattr(
+            "app.features.assistant.router.dispatch_ai_job", _noop_dispatch
+        )
         note = Note(title="Test Note", content="Test Content", user_id=TEST_USER_ID)
         session.add(note)
         session.commit()
 
-        # Make an AI call
-        client.post("/api/ai/summarize", json={"note_id": str(note.id)})
+        # Make an AI call (async job → process it)
+        response = client.post("/api/ai/summarize-jobs", json={"note_id": str(note.id)})
+        _run_ai_job(
+            process_summarize_job, response.json()["id"], session, mock_ai_service
+        )
 
         # Check settings
         response = client.get("/api/settings")

--- a/frontend/src/hooks/useAIChat.test.ts
+++ b/frontend/src/hooks/useAIChat.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getApiMock = vi.fn();
+
+vi.mock("./useApi", () => ({
+  useApi: () => ({
+    getApi: getApiMock,
+  }),
+}));
+
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { useAIChat } from "./useAIChat";
+
+describe("useAIChat async jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a summarize job, polls it, and appends the result", async () => {
+    const createSummarizeJob = vi.fn().mockResolvedValue({
+      id: "job-1",
+      kind: "summarize",
+      status: "completed",
+      result: "A short summary",
+      error_message: null,
+      tokens_used: 42,
+    });
+    const getAIJob = vi.fn();
+    getApiMock.mockResolvedValue({ createSummarizeJob, getAIJob });
+
+    const onTokenUsage = vi.fn();
+    const { result } = renderHook(() => useAIChat(onTokenUsage));
+
+    await act(async () => {
+      await result.current.handleSummarize("note-1");
+    });
+
+    expect(createSummarizeJob).toHaveBeenCalledWith({ note_id: "note-1" });
+    expect(onTokenUsage).toHaveBeenCalledWith(42);
+    await waitFor(() => {
+      expect(result.current.chatMessages).toEqual([
+        { role: "assistant", content: "A short summary" },
+      ]);
+    });
+  });
+
+  it("creates a chat job and appends question + answer", async () => {
+    const createChatJob = vi.fn().mockResolvedValue({
+      id: "job-2",
+      kind: "chat",
+      status: "completed",
+      result: "The answer",
+      error_message: null,
+      tokens_used: 10,
+    });
+    getApiMock.mockResolvedValue({ createChatJob, getAIJob: vi.fn() });
+
+    const { result } = renderHook(() => useAIChat());
+
+    await act(async () => {
+      await result.current.handleSendMessage("My question", "note", "note-1");
+    });
+
+    expect(createChatJob).toHaveBeenCalledWith(
+      expect.objectContaining({ question: "My question", scope: "note" })
+    );
+    await waitFor(() => {
+      expect(result.current.chatMessages).toEqual([
+        { role: "user", content: "My question" },
+        { role: "assistant", content: "The answer" },
+      ]);
+    });
+  });
+
+  it("polls a pending job until it completes", async () => {
+    vi.useFakeTimers();
+    try {
+      const createSummarizeJob = vi.fn().mockResolvedValue({
+        id: "job-3",
+        kind: "summarize",
+        status: "pending",
+        result: null,
+        error_message: null,
+        tokens_used: 0,
+      });
+      const getAIJob = vi.fn().mockResolvedValue({
+        id: "job-3",
+        kind: "summarize",
+        status: "completed",
+        result: "Polled summary",
+        error_message: null,
+        tokens_used: 5,
+      });
+      getApiMock.mockResolvedValue({ createSummarizeJob, getAIJob });
+
+      const { result } = renderHook(() => useAIChat());
+
+      let done: Promise<void>;
+      act(() => {
+        done = result.current.handleSummarize("note-1");
+      });
+
+      // ポーリング間隔を進めて完了状態を取得させる
+      await vi.advanceTimersByTimeAsync(1600);
+      await act(async () => {
+        await done;
+      });
+
+      expect(getAIJob).toHaveBeenCalledWith("job-3");
+      expect(result.current.chatMessages).toEqual([
+        { role: "assistant", content: "Polled summary" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/hooks/useAIChat.ts
+++ b/frontend/src/hooks/useAIChat.ts
@@ -19,8 +19,28 @@ import { logger } from "@/lib/logger";
 import type { ChatMessage } from "@/types";
 
 export type ChatScope = "note" | "folder" | "all" | "selection";
-const EDIT_JOB_POLL_INTERVAL_MS = 1500;
-const EDIT_JOB_TIMEOUT_MS = 120000;
+const JOB_POLL_INTERVAL_MS = 1500;
+const JOB_TIMEOUT_MS = 120000;
+
+/**
+ * 非同期 AI ジョブ（要約・チャット・編集）を完了/失敗まで一定間隔でポーリングする共通ヘルパ。
+ * pending/running の間ポーリングし、タイムアウト時は例外を送出する。
+ */
+async function pollJob<T extends { id: string; status: string }>(
+  initial: T,
+  fetchJob: (id: string) => Promise<T>
+): Promise<T> {
+  const startedAt = Date.now();
+  let job = initial;
+  while (job.status === "pending" || job.status === "running") {
+    if (Date.now() - startedAt >= JOB_TIMEOUT_MS) {
+      throw new Error("AI job polling timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, JOB_POLL_INTERVAL_MS));
+    job = await fetchJob(job.id);
+  }
+  return job;
+}
 
 interface UseAIChatReturn {
   chatMessages: ChatMessage[];
@@ -60,16 +80,21 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
     setIsAILoading(true);
     try {
       const apiClient = await getApi();
-      const result = await apiClient.summarizeNote({ note_id: noteId });
+      // 非同期ジョブを作成しポーリングで結果を取得する（30 秒同期上限の回避）
+      const created = await apiClient.createSummarizeJob({ note_id: noteId });
+      const job = await pollJob(created, (id) => apiClient.getAIJob(id));
 
-      if (result.tokens_used && onTokenUsage) {
-        onTokenUsage(result.tokens_used);
+      if (job.status === "failed") {
+        throw new Error(job.error_message || "Summarize failed");
       }
 
-      // Add summary as a chat message
+      if (job.tokens_used && onTokenUsage) {
+        onTokenUsage(job.tokens_used);
+      }
+
       const summaryMessage: ChatMessage = {
         role: "assistant",
-        content: result.summary,
+        content: job.result ?? "",
       };
       setChatMessages((prev) => [...prev, summaryMessage]);
     } catch (error: unknown) {
@@ -95,7 +120,8 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
 
     try {
       const apiClient = await getApi();
-      const result = await apiClient.chatWithNote({
+      // 非同期ジョブを作成しポーリングで回答を取得する（30 秒同期上限の回避）
+      const created = await apiClient.createChatJob({
         scope,
         note_id: noteId || undefined,
         folder_id: folderId || undefined,
@@ -103,14 +129,19 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
         history: chatMessages,
         selected_content: scope === "selection" ? selectedContent : undefined,
       });
+      const job = await pollJob(created, (id) => apiClient.getAIJob(id));
 
-      if (result.tokens_used && onTokenUsage) {
-        onTokenUsage(result.tokens_used);
+      if (job.status === "failed") {
+        throw new Error(job.error_message || "Chat failed");
+      }
+
+      if (job.tokens_used && onTokenUsage) {
+        onTokenUsage(job.tokens_used);
       }
 
       const assistantMessage: ChatMessage = {
         role: "assistant",
-        content: result.answer,
+        content: job.result ?? "",
       };
       setChatMessages((prev) => [...prev, assistantMessage]);
     } catch (error: unknown) {
@@ -145,17 +176,9 @@ export function useAIChat(onTokenUsage?: (tokens: number) => void): UseAIChatRet
         note_id: noteId,
       });
 
-      const startedAt = Date.now();
-      let job = createResult.job;
-
-      while (job.status === "pending" || job.status === "running") {
-        if (Date.now() - startedAt >= EDIT_JOB_TIMEOUT_MS) {
-          throw new Error("Edit job polling timed out");
-        }
-
-        await new Promise((resolve) => setTimeout(resolve, EDIT_JOB_POLL_INTERVAL_MS));
-        job = await apiClient.getEditJob(job.id);
-      }
+      const job = await pollJob(createResult.job, (id) =>
+        apiClient.getEditJob(id)
+      );
 
       if (job.status === "failed") {
         throw new Error(job.error_message || "Edit job failed");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,8 +12,8 @@
  * 各コンポーネントおよび syncQueue / workspaceSync から利用される。
  */
 import type {
+  AIJob,
   ChatRequest,
-  ChatResponse,
   EditJob,
   EditJobCreateResponse,
   EditJobRequest,
@@ -23,7 +23,6 @@ import type {
   SettingsResponse,
   SharedNote,
   SummarizeRequest,
-  SummarizeResponse,
   UserSettingsUpdate,
   UserApiKey,
   UserApiKeyCreate,
@@ -132,18 +131,24 @@ class ApiClient {
   }
 
   // AI API
-  async summarizeNote(data: SummarizeRequest): Promise<SummarizeResponse> {
-    return this.request<SummarizeResponse>("/api/ai/summarize", {
+  // 要約・チャットは非同期ジョブ化されている（同期だと API Gateway の 30 秒上限で 503 になるため）。
+  // ジョブを作成し getAIJob でポーリングして結果を取得する。
+  async createSummarizeJob(data: SummarizeRequest): Promise<AIJob> {
+    return this.request<AIJob>("/api/ai/summarize-jobs", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
-  async chatWithNote(data: ChatRequest): Promise<ChatResponse> {
-    return this.request<ChatResponse>("/api/ai/chat", {
+  async createChatJob(data: ChatRequest): Promise<AIJob> {
+    return this.request<AIJob>("/api/ai/chat-jobs", {
       method: "POST",
       body: JSON.stringify(data),
     });
+  }
+
+  async getAIJob(jobId: string): Promise<AIJob> {
+    return this.request<AIJob>(`/api/ai/jobs/${jobId}`);
   }
 
   async editNoteContent(data: EditRequest): Promise<EditResponse> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -103,9 +103,18 @@ export interface SummarizeRequest {
   note_id: string;
 }
 
-export interface SummarizeResponse {
-  summary: string;
+// 要約・チャットの非同期ジョブ。作成後 getAIJob でポーリングし result を取得する。
+export interface AIJob {
+  id: string;
+  kind: "summarize" | "chat";
+  status: "pending" | "running" | "completed" | "failed";
+  result: string | null;
+  error_message: string | null;
   tokens_used: number;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  completed_at: string | null;
 }
 
 export interface EditProposal {
@@ -128,11 +137,6 @@ export interface ChatRequest {
   question: string;
   history?: ChatMessage[];
   selected_content?: string;
-}
-
-export interface ChatResponse {
-  answer: string;
-  tokens_used: number;
 }
 
 export interface EditRequest {


### PR DESCRIPTION
## 概要

同期の `/api/ai/summarize`・`/api/ai/chat` は Bedrock 生成に 20〜60 秒かかり、手前の **API Gateway (HTTP API) の統合タイムアウト 30 秒（ハード上限）**を超えると **503** になっていた。長文ノートでは本番でも失敗し、CI の AI 統合テストが間欠的に落ちる根本原因でもあった（実測: integrationLatency が 30000ms で 503、Lambda は 60s 上限まで到達）。

既存の AI 編集ジョブと同じ **SNS→SQS→worker Lambda** 機構を**再利用**して要約・チャットを非同期ジョブ化し、30 秒制約から解放する。**新規インフラなし。**

## 変更内容

### バックエンド
- 汎用 `ai_jobs` テーブル `AIJob`（`models/ai_job.py`）＋ Alembic マイグレーション `20260618_01_add_ai_jobs.py`
- `AIJobUseCases`（`use_cases/ai_jobs.py`）— 作成時に所有権・トークン上限を検証
- `job_runner.py` を一般化: `dispatch_ai_job(task)` / `process_summarize_job` / `process_chat_job` / 共通ランナー `_process_ai_job`、キュー処理を **task→handler ディスパッチ表**化（SNS/SQS/worker を再利用）
- `POST /ai/summarize-jobs`・`POST /ai/chat-jobs`（202）・`GET /ai/jobs/{id}` を追加し、**同期 `/ai/summarize`・`/ai/chat` を削除**
- トークン計上は既存 `AIInteractionUseCases._run_ai_call` がworker経路でも実施（二重計上なし）

### フロントエンド
- `api.ts`: `createSummarizeJob` / `createChatJob` / `getAIJob` 追加、同期メソッド削除
- `useAIChat.ts`: 共通 `pollJob` ヘルパに集約し、要約・チャット・編集をジョブ作成→ポーリングへ統一
- `types/index.ts`: `AIJob` 追加、同期レスポンス型削除

## テスト方法

- [x] backend 単体 220 passed（test_ai / test_token_usage を非同期化、task ルーティングテスト追加）、ruff/format クリーン
- [x] frontend 424 passed（`useAIChat.test.ts` 新規）、eslint 0 error
- [x] **dev デプロイ＋統合テスト 31 件 green**（旧来 Bedrock タイムアウトで落ちていた AI テストが完走、4分04秒）

## チェックリスト

- [x] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] ユーザー向けテキストの i18n 対応（タイムアウト/失敗は既存 `aiEdit.*` を再利用）

> 注: `ai_jobs` テーブルは Lambda コールドスタートの create_all で自動作成される。prd 反映時は Alembic マイグレーション適用を推奨。同期エンドポイント削除は破壊的変更（フロントは本 PR で非同期へ切替済み）。