### PR TITLE
fix(ai): restore AI summarize and chat (production outage)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,8 +18,8 @@ COGNITO_USER_POOL_ID=
 COGNITO_APP_CLIENT_ID=
 
 # Bedrock settings
-BEDROCK_REGION=us-east-1
-BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20241022-v2:0
+BEDROCK_REGION=ap-northeast-1
+BEDROCK_MODEL_ID=jp.anthropic.claude-sonnet-4-6
 
 # S3 settings (空のままでも起動するがイメージアップロードは動作しない)
 CACHE_BUCKET_NAME=notes-app-cache-local

--- a/backend/README.md
+++ b/backend/README.md
@@ -87,8 +87,8 @@ Once running:
 | `COGNITO_REGION` | AWS Cognito region | `ap-northeast-1` |
 | `COGNITO_USER_POOL_ID` | Cognito User Pool ID | - |
 | `COGNITO_APP_CLIENT_ID` | Cognito App Client ID | - |
-| `BEDROCK_REGION` | AWS Bedrock region | `us-east-1` |
-| `BEDROCK_MODEL_ID` | Bedrock model ID | `anthropic.claude-3-5-sonnet-20241022-v2:0` |
+| `BEDROCK_REGION` | AWS Bedrock region | `ap-northeast-1` |
+| `BEDROCK_MODEL_ID` | Bedrock model ID | `jp.anthropic.claude-sonnet-4-6` |
 | `SENTRY_DSN` | Local-only Sentry DSN loaded from `.env` | - |
 | `SENTRY_DSN_PARAMETER_NAME` | Backend AWS SSM SecureString parameter name used outside local development | - |
 | `SENTRY_TRACES_SAMPLE_RATE` | Optional trace sample rate override | `1.0` in `local`/`dev`, `0.1` otherwise |

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,8 +45,12 @@ class Settings(BaseSettings):
     integration_test_bypass_token_2: str = ""
 
     # Amazon Bedrock (AI) 設定
-    bedrock_region: str = "us-east-1"
-    bedrock_model_id: str = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    # モデル ID は ap-northeast-1 の推論プロファイルを指す。`jp.` 接頭辞は推論を
+    # 日本国内に閉じるため、個人のノート本文を送る本アプリではこれを維持すること。
+    # `jp.` プロファイルは ap-northeast-1 にしか存在しないので、リージョンとモデル
+    # ID は必ず一組で変更する。
+    bedrock_region: str = "ap-northeast-1"
+    bedrock_model_id: str = "jp.anthropic.claude-sonnet-4-6"
 
     # CORS 設定
     cors_origins: list[str] = ["http://localhost:3000"]

--- a/backend/app/features/assistant/use_cases/common.py
+++ b/backend/app/features/assistant/use_cases/common.py
@@ -12,7 +12,7 @@ from app.features.assistant.errors import (
     AITokenLimitExceededError,
 )
 from app.features.assistant.usage_policy import check_limit
-from app.models import AVAILABLE_MODELS, DEFAULT_LLM_MODEL_ID, UserSettings
+from app.models import DEFAULT_LLM_MODEL_ID, UserSettings, resolve_model_id
 from app.shared import ValidationFailed
 
 
@@ -32,17 +32,5 @@ def get_user_settings(session: Session, user_id: str) -> tuple[str, str]:
     """ユーザー設定から (llm_model_id, language) を返す。未設定の場合はデフォルト値を返す。"""
     settings = session.get(UserSettings, user_id)
     if settings:
-        return _usable_model_id(settings.llm_model_id), settings.language
+        return resolve_model_id(settings.llm_model_id), settings.language
     return DEFAULT_LLM_MODEL_ID, "auto"
-
-
-def _usable_model_id(stored_model_id: str) -> str:
-    """保存済みモデル ID が現在も選択可能なら採用し、そうでなければ既定値に戻す。
-
-    AVAILABLE_MODELS からモデルを外す（退役・リージョン移行など）と、その ID を
-    保存済みのユーザーは InvokeModel で失敗し続ける。設定画面を開き直すまで AI
-    機能が動かないことになるため、ここで既定値へ寄せる。
-    """
-    if any(model["id"] == stored_model_id for model in AVAILABLE_MODELS):
-        return stored_model_id
-    return DEFAULT_LLM_MODEL_ID

--- a/backend/app/features/assistant/use_cases/common.py
+++ b/backend/app/features/assistant/use_cases/common.py
@@ -12,7 +12,7 @@ from app.features.assistant.errors import (
     AITokenLimitExceededError,
 )
 from app.features.assistant.usage_policy import check_limit
-from app.models import DEFAULT_LLM_MODEL_ID, UserSettings
+from app.models import AVAILABLE_MODELS, DEFAULT_LLM_MODEL_ID, UserSettings
 from app.shared import ValidationFailed
 
 
@@ -32,5 +32,17 @@ def get_user_settings(session: Session, user_id: str) -> tuple[str, str]:
     """ユーザー設定から (llm_model_id, language) を返す。未設定の場合はデフォルト値を返す。"""
     settings = session.get(UserSettings, user_id)
     if settings:
-        return settings.llm_model_id, settings.language
+        return _usable_model_id(settings.llm_model_id), settings.language
     return DEFAULT_LLM_MODEL_ID, "auto"
+
+
+def _usable_model_id(stored_model_id: str) -> str:
+    """保存済みモデル ID が現在も選択可能なら採用し、そうでなければ既定値に戻す。
+
+    AVAILABLE_MODELS からモデルを外す（退役・リージョン移行など）と、その ID を
+    保存済みのユーザーは InvokeModel で失敗し続ける。設定画面を開き直すまで AI
+    機能が動かないことになるため、ここで既定値へ寄せる。
+    """
+    if any(model["id"] == stored_model_id for model in AVAILABLE_MODELS):
+        return stored_model_id
+    return DEFAULT_LLM_MODEL_ID

--- a/backend/app/features/settings/use_cases.py
+++ b/backend/app/features/settings/use_cases.py
@@ -29,6 +29,7 @@ from app.models import (
     UserSettings,
     UserSettingsRead,
     UserSettingsUpdate,
+    resolve_model_id,
 )
 from app.shared import ValidationFailed
 
@@ -124,7 +125,10 @@ class SettingsUseCases:
         """UserSettings を UserSettingsRead に変換して返す。"""
         return UserSettingsRead(
             user_id=settings.user_id,
-            llm_model_id=settings.llm_model_id,
+            # 選択可能でなくなったモデルを保存しているユーザーには既定値を見せる。
+            # 生の値を返すと、この API 自身が受け付けない ID を返すことになり、
+            # 読み出した値をそのまま書き戻すと 400 になってしまう。
+            llm_model_id=resolve_model_id(settings.llm_model_id),
             language=settings.language,
             token_limit=settings.token_limit,
             created_at=settings.created_at,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -37,6 +37,7 @@ from app.models.user_settings import (
     UserSettings,
     UserSettingsRead,
     UserSettingsUpdate,
+    resolve_model_id,
 )
 
 __all__ = [
@@ -58,6 +59,7 @@ __all__ = [
     "AvailableModel",
     "DEFAULT_LANGUAGE",
     "DEFAULT_LLM_MODEL_ID",
+    "resolve_model_id",
     "Folder",
     "FolderCreate",
     "FolderRead",

--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -12,30 +12,29 @@ from sqlmodel import Field, SQLModel
 
 from app.models.token_usage import MONTHLY_TOKEN_LIMIT
 
-# デフォルトLLMモデルID（クロスリージョン推論プロファイル経由のClaude 3.5 Haiku）
-DEFAULT_LLM_MODEL_ID = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+# デフォルトLLMモデルID。
+#
+# ここは実際に InvokeModel へ渡る値であり、`BEDROCK_MODEL_ID` 環境変数ではない。
+# 環境変数のほうはフォールバック用の既定値にすぎない点に注意すること。
+#
+# `jp.` は日本国内に閉じた推論プロファイル。ユーザーのノート本文を送信するため
+# これを採用している。`jp.` プロファイルは ap-northeast-1 にしか存在しないので、
+# BEDROCK_REGION（terraform/lambda.tf・config.py）と必ず一組で変更する。
+DEFAULT_LLM_MODEL_ID = "jp.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 # ユーザーが選択可能なモデル一覧
-# "us." プレフィックス付きモデルはUSリージョンのクロスリージョン推論プロファイルを使用
-# プレフィックスなしは旧モデル向けのオンデマンド呼び出し
 #
-# 注意: 現時点ではコスト効率を優先してHaikuモデルのみ提供。
+# 注意: コスト効率を優先してHaikuモデルのみ提供する方針は維持している。
 # Sonnetモデルは将来のプレミアムプランで追加予定。
+#
+# 履歴: 以前ここに並んでいた `us.anthropic.claude-3-5-haiku-20241022-v1:0` と
+# `anthropic.claude-3-haiku-20240307-v1:0` は退役・退役予定で、前者は既定値だった
+# ため AI 機能が全面停止していた。退役日を書き添えて交換すること。
 AVAILABLE_MODELS = [
     {
-        "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
         "name": "Claude Haiku 4.5",
-        "description": "最新・高性能・低コスト",
-    },
-    {
-        "id": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-        "name": "Claude 3.5 Haiku",
         "description": "高速・低コスト（推奨）",
-    },
-    {
-        "id": "anthropic.claude-3-haiku-20240307-v1:0",
-        "name": "Claude 3 Haiku",
-        "description": "高速・最低コスト",
     },
 ]
 

--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -38,6 +38,20 @@ AVAILABLE_MODELS = [
     },
 ]
 
+
+def resolve_model_id(stored_model_id: str | None) -> str:
+    """保存済みモデル ID が現在も選択可能ならそれを、そうでなければ既定値を返す。
+
+    AVAILABLE_MODELS からモデルを外す（退役・リージョン移行など）と、その ID を
+    保存していたユーザーは InvokeModel が失敗し続ける。設定 API が「自分では
+    受け付けない ID」を返してしまう問題も同じ原因なので、読み出し側と AI 呼び出し
+    側の両方でここを通す。
+    """
+    if any(model["id"] == stored_model_id for model in AVAILABLE_MODELS):
+        return stored_model_id  # type: ignore[return-value]
+    return DEFAULT_LLM_MODEL_ID
+
+
 # Default language setting (auto-detect from browser)
 DEFAULT_LANGUAGE = "auto"
 

--- a/backend/tests/test_ai_application_service.py
+++ b/backend/tests/test_ai_application_service.py
@@ -6,7 +6,13 @@ from app.features.assistant.gateway import AIGateway
 from app.features.assistant.usage_policy import get_usage_info, record_usage
 from app.features.assistant.use_cases import AIInteractionUseCases, EditJobUseCases
 from app.features.workspace.use_cases import WorkspaceQueryUseCases
-from app.models import AIEditJob, Note, UserSettings
+from app.models import (
+    AVAILABLE_MODELS,
+    DEFAULT_LLM_MODEL_ID,
+    AIEditJob,
+    Note,
+    UserSettings,
+)
 from app.models.enums import ChatScope
 from app.shared import NotFound, ValidationFailed
 from tests.conftest import OTHER_USER_ID, TEST_USER_ID
@@ -72,7 +78,7 @@ async def test_summarize_note_uses_user_settings_and_records_usage(session: Sess
     session.add(
         UserSettings(
             user_id=TEST_USER_ID,
-            llm_model_id="custom-model",
+            llm_model_id=AVAILABLE_MODELS[0]["id"],
             language="ja",
         )
     )
@@ -94,11 +100,43 @@ async def test_summarize_note_uses_user_settings_and_records_usage(session: Sess
         {
             "operation": "summarize",
             "content": "Hello world",
-            "model_id": "custom-model",
+            "model_id": AVAILABLE_MODELS[0]["id"],
             "language": "ja",
         }
     ]
     assert get_usage_info(session, TEST_USER_ID).tokens_used == 12
+
+
+@pytest.mark.asyncio
+async def test_summarize_note_falls_back_when_stored_model_is_retired(session: Session):
+    """選択可能でなくなったモデル ID を保存済みのユーザーが既定値に寄せられること。
+
+    退役やリージョン移行で AVAILABLE_MODELS からモデルを外すと、その ID を保存して
+    いたユーザーは InvokeModel で失敗し続ける。実際にこれで AI 機能が全面停止したため
+    回帰テストとして固定する。
+    """
+    note = Note(title="Test", content="Hello world", user_id=TEST_USER_ID)
+    session.add(note)
+    session.add(
+        UserSettings(
+            user_id=TEST_USER_ID,
+            llm_model_id="us.anthropic.claude-3-5-haiku-20241022-v1:0",  # 2026-02-19 退役
+            language="ja",
+        )
+    )
+    session.commit()
+
+    ai_gateway = CapturingAIGateway()
+    use_cases = AIInteractionUseCases(
+        session,
+        TEST_USER_ID,
+        ai_gateway,
+        WorkspaceQueryUseCases(session, TEST_USER_ID),
+    )
+
+    await use_cases.summarize_note(note.id)
+
+    assert ai_gateway.calls[0]["model_id"] == DEFAULT_LLM_MODEL_ID
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_bedrock.py
+++ b/backend/tests/test_bedrock.py
@@ -228,3 +228,56 @@ async def test_edit_large_content_uses_chunking(mock_boto_client, mock_settings)
     assert len(calls) > 1
     assert edited == content.replace("teh", "the")
     assert total_tokens == 11 * len(calls)
+
+
+# 退役済み Bedrock モデル ID の一覧。
+# 2026-08-09 時点で、この2つは実際に InvokeModel が
+# ResourceNotFoundException("This model version has reached the end of its life")
+# を返す。以前これが本番に入り込み、AI 要約・チャットが停止した。
+RETIRED_BEDROCK_MODEL_IDS = frozenset(
+    {
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+    }
+)
+
+
+def _declared_default(field_name: str) -> str:
+    """Settings クラスが宣言している既定値を返す。
+
+    `get_settings()` ではなくクラスの既定値を見るのは意図的。前者はローカルの
+    `backend/.env` に上書きされるため、開発者の手元の設定次第で結果が変わって
+    しまう。ここで検証したいのは「リポジトリが出荷する値」なので、環境に依存
+    しないクラス既定値を対象にする。
+    """
+    from app.config import Settings
+
+    return Settings.model_fields[field_name].default
+
+
+def test_default_bedrock_model_is_not_retired():
+    """既定のモデル ID が退役済みモデルに逆戻りしていないことを検査する。
+
+    ここが通らない場合、AI 機能はデプロイした瞬間に沈黙する。
+    """
+    model_id = _declared_default("bedrock_model_id")
+    assert model_id not in RETIRED_BEDROCK_MODEL_IDS, (
+        f"BEDROCK_MODEL_ID={model_id!r} は退役済みで InvokeModel が失敗する。"
+        " 現行世代の推論プロファイルに更新すること。"
+    )
+
+
+def test_jp_inference_profile_is_paired_with_its_region():
+    """`jp.` 推論プロファイルは ap-northeast-1 にしか存在しない。
+
+    リージョンとモデル ID は必ず一組で設定する必要があり、
+    片方だけ変えると実行時に落ちる。
+    """
+    model_id = _declared_default("bedrock_model_id")
+    region = _declared_default("bedrock_region")
+    if model_id.startswith("jp."):
+        assert region == "ap-northeast-1", (
+            f"jp. プロファイル {model_id!r} には ap-northeast-1 が必要だが"
+            f" bedrock_region={region!r} になっている。"
+        )

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -88,7 +88,8 @@ class TestUpdateSettings:
     def test_update_settings_change_model(self, client: TestClient):
         """Test updating the LLM model selection."""
         # Get valid model ID from available models
-        valid_model_id = AVAILABLE_MODELS[1]["id"]  # Pick second model
+        # 末尾を選ぶ。候補が1件でも動き、2件以上に戻れば [0] とは別のモデルになる。
+        valid_model_id = AVAILABLE_MODELS[-1]["id"]
 
         response = client.put(
             "/api/settings",
@@ -198,7 +199,7 @@ class TestUpdateLanguageSettings:
 
     def test_update_model_and_language_together(self, client: TestClient):
         """Test updating both model and language at once."""
-        valid_model_id = AVAILABLE_MODELS[1]["id"]
+        valid_model_id = AVAILABLE_MODELS[-1]["id"]
 
         response = client.put(
             "/api/settings",

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -40,7 +40,12 @@ resource "aws_iam_role_policy" "bedrock_access" {
         Resource = [
           # Foundation models (on-demand)
           "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
-          # Cross-region inference profiles
+          # Cross-region inference profiles.
+          # `jp.` is the one actually in use (see BEDROCK_MODEL_ID in lambda.tf):
+          # it keeps inference inside Japan, which matters because we send users'
+          # personal note content. Without this entry the invoke fails with
+          # AccessDenied even though the model itself is available.
+          "arn:aws:bedrock:*:*:inference-profile/jp.anthropic.claude-*",
           "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-*",
           "arn:aws:bedrock:*:*:inference-profile/eu.anthropic.claude-*"
         ]

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -19,8 +19,10 @@ locals {
       COGNITO_USER_POOL_ID  = aws_cognito_user_pool.main.id
       COGNITO_APP_CLIENT_ID = aws_cognito_user_pool_client.main.id
       COGNITO_REGION        = var.aws_region
-      BEDROCK_REGION        = "us-east-1"
-      BEDROCK_MODEL_ID      = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+      # `jp.` 推論プロファイルは ap-northeast-1 にしか存在しない。リージョンと
+      # モデル ID は必ず一組で変更すること。接頭辞 `jp.` は推論を日本国内に閉じる。
+      BEDROCK_REGION        = "ap-northeast-1"
+      BEDROCK_MODEL_ID      = "jp.anthropic.claude-sonnet-4-6"
       DSQL_CLUSTER_ENDPOINT = aws_dsql_cluster.main.identifier
       CORS_ORIGINS = jsonencode([
         "https://${local.current_env.domain_name}",


### PR DESCRIPTION
## What was wrong

AI summarize and chat were **failing in production**. Every call returned:

```
ResourceNotFoundException: This model version has reached the end of its life.
```

This also blocked the whole repo: `lefthook` `pre-push` runs the dev integration tests, and the 7 AI tests failed there — so **no one could push anything** until this was fixed.

## Root cause (not where it first appeared to be)

The first suspect was `BEDROCK_MODEL_ID` in `terraform/lambda.tf`. That was stale, but it is only a fallback — it is **not** what these endpoints send. The real path:

```
ai_interactions._run_ai_call
  -> get_user_settings()
    -> UserSettings.llm_model_id, else DEFAULT_LLM_MODEL_ID
```

`DEFAULT_LLM_MODEL_ID` was `us.anthropic.claude-3-5-haiku-20241022-v1:0` — Claude 3.5 Haiku, **retired 2026-02-19**. Every entry in `AVAILABLE_MODELS` was dead or dying:

| id | state |
|---|---|
| `us.anthropic.claude-haiku-4-5-20251001-v1:0` | alive, but a `us.` profile |
| `us.anthropic.claude-3-5-haiku-20241022-v1:0` | **retired 2026-02-19**, and the default |
| `anthropic.claude-3-haiku-20240307-v1:0` | retires 2026-04-19 |

## Changes

- **Model list** → the one `jp.` Haiku that exists in ap-northeast-1. Haiku-only is unchanged policy (the file already reserves Sonnet for a future premium plan), so no tier is added here.
- **Region + IAM** → `ap-northeast-1`, because `jp.` profiles exist only there. **The IAM policy was the trap**: it allowed inference profiles matching only `us.` and `eu.`. Swapping the model id alone would have deployed cleanly and still failed at runtime with AccessDenied, looking like the fix simply didn't work.
- **Fallback** → a stored `llm_model_id` no longer in `AVAILABLE_MODELS` resolves to the default. Without this, existing users keep failing even after the default is fixed, because their own row still names the retired model.
- **Settings read path** → `GET /api/settings` was returning a model id that `PUT /api/settings` validates against the same list and rejects, so reading your settings and writing them straight back was a 400. Found by the dev integration test.
- `jp.` keeps inference inside Japan, which matters because we send users' personal note content.

The request shape is untouched — the existing boto3 `invoke_model` path works as-is against this model, verified with a real invoke before any code was written. `docs/repo-review-2026-07-02.md` suggested migrating to the Anthropic SDK's Bedrock client; declined, as it adds a runtime dependency and buys nothing here.

## Verification

- `make test-backend` → **223 passed** (3 new regression tests: EOL-model guard, `jp.`/region pairing, fallback)
- Deployed to dev and ran `make test-integration ENV=dev` → **31 passed, 0 failed** (was 24 passed / 7 failed)
- `terraform validate` + `fmt -check` clean

## Note for the reviewer

`make tf-plan ENV=dev` also showed **unrelated pre-existing drift**: `aws_cloudtrail.main` would be **created** (trail + S3 bucket, ongoing cost) and the cost report would go weekly → daily. I deliberately used a targeted apply so those were not created unattended. **A plain `make deploy ENV=dev` will apply them** — worth a conscious decision before anyone does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)