### PR TITLE
ci: add unit test, lint, and Terraform static-check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend unit tests and lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: 0.11.17
+          python-version: 3.12.3
+
+      - name: Install backend dependencies
+        run: cd backend && uv sync --extra dev
+
+      - name: Run backend unit tests
+        run: make test-backend
+
+      - name: Lint backend
+        run: make lint-backend
+
+      - name: Check backend formatting
+        run: make format-check-backend
+
+  frontend:
+    name: Frontend unit tests, lint, and typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.14.0
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Run frontend unit tests
+        run: make test-frontend
+
+      - name: Lint frontend
+        run: make lint-frontend
+
+      # Non-blocking for now: `tsc --noEmit` currently reports 7 pre-existing
+      # errors, all in test files and all predating this workflow --
+      #   src/hooks/useFolders.test.ts        TS2783 (duplicate `folders` key,
+      #                                       silently overwritten by the spread)
+      #   src/instrumentation-client.test.ts  TS2540 \
+      #   src/lib/logger.test.ts              TS2540  } `process.env.NODE_ENV` is
+      #   src/lib/sentry.test.ts              TS2540 /  read-only; use vi.stubEnv
+      # Fixing them is out of scope for "add a CI gate", but shipping a workflow
+      # that is red on day one would train everyone to ignore it. So the step
+      # runs and stays visible in the logs without blocking the merge.
+      # TODO: fix the 7 errors, then delete this continue-on-error line.
+      - name: Typecheck frontend
+        continue-on-error: true
+        run: cd frontend && npx tsc --noEmit
+
+  terraform:
+    name: Terraform static checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: 1.15.5
+
+      # make tf-init enters tf-switch, which selects a remote backend and requires a configured profile.
+      - name: Initialize Terraform without a backend
+        run: terraform -chdir=terraform init -backend=false
+
+      - name: Validate Terraform
+        run: terraform -chdir=terraform validate
+
+      - name: Check Terraform formatting
+        run: terraform fmt -check -recursive terraform/
+
+      - name: Install conftest
+        env:
+          CONFTEST_VERSION: 0.68.2
+        run: |
+          curl --fail --silent --show-error --location \
+            "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
+            --output "${RUNNER_TEMP}/conftest.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/conftest.tar.gz" -C "${RUNNER_TEMP}" conftest
+          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
+
+      - name: Verify Conftest policies
+        run: make conftest-verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,19 +64,7 @@ jobs:
       - name: Lint frontend
         run: make lint-frontend
 
-      # Non-blocking for now: `tsc --noEmit` currently reports 7 pre-existing
-      # errors, all in test files and all predating this workflow --
-      #   src/hooks/useFolders.test.ts        TS2783 (duplicate `folders` key,
-      #                                       silently overwritten by the spread)
-      #   src/instrumentation-client.test.ts  TS2540 \
-      #   src/lib/logger.test.ts              TS2540  } `process.env.NODE_ENV` is
-      #   src/lib/sentry.test.ts              TS2540 /  read-only; use vi.stubEnv
-      # Fixing them is out of scope for "add a CI gate", but shipping a workflow
-      # that is red on day one would train everyone to ignore it. So the step
-      # runs and stays visible in the logs without blocking the merge.
-      # TODO: fix the 7 errors, then delete this continue-on-error line.
       - name: Typecheck frontend
-        continue-on-error: true
         run: cd frontend && npx tsc --noEmit
 
   terraform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,14 @@ jobs:
       - name: Initialize Terraform without a backend
         run: terraform -chdir=terraform init -backend=false
 
+      # `init -backend=false` leaves the workspace as "default", but
+      # variables.tf does `local.env_config[terraform.workspace]` and that map
+      # only has dev/prd keys -- so validate fails with "Invalid index" unless a
+      # real workspace name is set. TF_WORKSPACE supplies one without needing a
+      # state backend, and avoids bending production config to suit CI.
       - name: Validate Terraform
+        env:
+          TF_WORKSPACE: dev
         run: terraform -chdir=terraform validate
 
       - name: Check Terraform formatting

--- a/backend/tests/test_bedrock.py
+++ b/backend/tests/test_bedrock.py
@@ -16,6 +16,22 @@ def mock_settings():
 
 
 @pytest.fixture
+def mock_summary_cache():
+    """summarize() が実 S3 を触らないようにサマリキャッシュを差し替える。
+
+    `summary_cache.py` はモジュール読み込み時にシングルトンを生成し、その中で
+    `boto3.client("s3")` を作る。つまりテストのフィクスチャが `boto3.client` に
+    パッチを当てるより前にクライアントが出来上がっており、パッチをすり抜ける。
+    結果、これらのテストは AWS 認証情報のあるマシンでのみ通り、CI では
+    NoCredentialsError で落ちていた。ここを塞いでユニットテストを密閉する。
+    """
+    cache = Mock()
+    cache.get_cached_summary.return_value = None
+    with patch("app.features.assistant.gateway.get_summary_cache", return_value=cache):
+        yield cache
+
+
+@pytest.fixture
 def mock_boto_client():
     with patch("boto3.client") as mock_client:
         client_instance = Mock()
@@ -24,7 +40,7 @@ def mock_boto_client():
 
 
 @pytest.mark.asyncio
-async def test_summarize_success(mock_boto_client, mock_settings):
+async def test_summarize_success(mock_boto_client, mock_settings, mock_summary_cache):
     service = BedrockGateway()
 
     # Mock response from Bedrock
@@ -164,7 +180,7 @@ def test_extract_edited_content():
 
 
 @pytest.mark.asyncio
-async def test_bedrock_error(mock_boto_client, mock_settings):
+async def test_bedrock_error(mock_boto_client, mock_settings, mock_summary_cache):
     service = BedrockGateway()
 
     mock_boto_client.invoke_model.side_effect = ClientError(

--- a/frontend/src/hooks/useFolders.test.ts
+++ b/frontend/src/hooks/useFolders.test.ts
@@ -68,7 +68,7 @@ function useFoldersHarness(
   const [selectedFolderId, setSelectedFolderId] = useState(initialSelectedFolderId);
 
   return {
-    folders,
+    // `folders` は下の spread が返す値で上書きされるため、ここには置かない。
     selectedFolderId,
     ...useFolders(folders, setFolders, selectedFolderId, setSelectedFolderId, {
       onSnapshotSynced: onSnapshotSyncedMock,

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -8,7 +8,7 @@ describe("instrumentation-client", () => {
     process.env.NEXT_PUBLIC_API_URL = "https://api.example.com";
     process.env.NEXT_PUBLIC_SENTRY_DSN = "https://public@example.ingest.sentry.io/123";
     process.env.NEXT_PUBLIC_ENVIRONMENT = "dev";
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
   });
 
   it("initializes the browser SDK and exports router tracing", async () => {

--- a/frontend/src/lib/logger.test.ts
+++ b/frontend/src/lib/logger.test.ts
@@ -9,7 +9,7 @@ describe("logger", () => {
   });
 
   it("suppresses info logs in production console output", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
 
     logger.info("Informational message");
@@ -19,7 +19,7 @@ describe("logger", () => {
   });
 
   it("sends warnings to console and Sentry", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     logger.warn("Sync warning", { failedCount: 2 });
@@ -35,7 +35,7 @@ describe("logger", () => {
   });
 
   it("captures exceptions for error logs", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const error = new Error("boom");
 

--- a/frontend/src/lib/sentry.test.ts
+++ b/frontend/src/lib/sentry.test.ts
@@ -9,7 +9,7 @@ describe("Sentry browser config", () => {
     process.env.NEXT_PUBLIC_API_URL = "https://api.example.com";
     process.env.NEXT_PUBLIC_SENTRY_DSN = "https://public@example.ingest.sentry.io/123";
     process.env.NEXT_PUBLIC_ENVIRONMENT = "dev";
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
   });
 
   it("adds the backend API to trace propagation targets", () => {
@@ -44,7 +44,7 @@ describe("Sentry browser config", () => {
   });
 
   it("uses lower production sample rates", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
 
     const config = getSentryBrowserConfig();
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'happy-dom',
+    // vi.stubEnv() の値をテストごとに自動で戻す。
+    // 以前は process.env.NODE_ENV を直接代入しており、値がテスト間に漏れていた。
+    unstubEnvs: true,
     globals: true,
     setupFiles: './vitest.setup.ts',
     alias: {


### PR DESCRIPTION
The repository had only `e2e.yml`, so backend and frontend unit tests and linters ran nowhere except local `lefthook` hooks — which `git push --no-verify`, or a push from any other machine, skips entirely. This adds the missing gate.

## Three jobs, no AWS credentials and no OIDC anywhere

| job | steps |
|---|---|
| **backend** | `uv sync`, pytest (integration tests excluded — they need a deployed environment), `ruff check`, `ruff format --check` |
| **frontend** | `npm ci`, vitest, eslint, `tsc --noEmit` |
| **terraform** | `init -backend=false`, `validate`, `fmt -check`, `conftest verify` |

Tool versions are pinned to the values already in `mise.toml`. Every third-party action is pinned to a commit SHA — **each one verified against the GitHub API rather than copied from memory**.

## The typecheck story

`tsc --noEmit` failed on `main` with 7 pre-existing errors, all in test files. Shipping a workflow that is red on day one just trains everyone to ignore it, so the second commit fixes them and the step is a real blocking gate here.

Six were **TS2540** — `process.env.NODE_ENV` is read-only under current `@types/node`. Replaced with `vi.stubEnv()` plus `unstubEnvs: true` in the vitest config. That is also a behavioural fix, not just a type fix: the old assignments were never restored, so `NODE_ENV` leaked from one test file into whatever ran next.

The seventh was **TS2783** in `useFolders.test.ts` — `folders` was listed explicitly in an object literal and then overwritten by the spread directly below it. Dropping the explicit key preserves runtime behaviour exactly, since the spread already won.

## Verification

- `make test-backend` → 223 passed
- frontend: 428 tests pass, `tsc --noEmit` exits 0, eslint clean (25 pre-existing warnings, 0 errors)
- `terraform validate` / `fmt -check` / `conftest verify` all run locally and pass
- backend job confirmed to need no AWS credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)